### PR TITLE
Automatically assign PR author if the PR assignees is empty

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -1,0 +1,11 @@
+name: Add assignee to PR
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-assignee-to-pr:
+    permissions:
+      pull-requests: write
+    uses: route06/actions/.github/workflows/add_assignee_to_pr.yml@v2


### PR DESCRIPTION
Introduce this our reusable workflow:
https://github.com/route06/actions/blob/v2.2.0/.github/workflows/add_assignee_to_pr.yml
