### PR TITLE
feat: add mobile styles for the Heading component

### DIFF
--- a/frontend/apps/service-site/src/features/posts/components/Heading/Heading.module.css
+++ b/frontend/apps/service-site/src/features/posts/components/Heading/Heading.module.css
@@ -21,3 +21,21 @@
 .h5 {
   font-size: var(--font-size-6, 1rem);
 }
+
+@media screen and (max-width: 768px) {
+  .h2 {
+    font-size: var(--font-size-8, 1.25rem);
+  }
+
+  .h3 {
+    font-size: var(--font-size-7, 1.125rem);
+  }
+
+  .h4 {
+    font-size: var(--font-size-6, 1rem);
+  }
+
+  .h5 {
+    font-size: var(--font-size-5, 0.875rem);
+  }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Heading component already implemented by https://github.com/route06inc/liam/pull/32/files .
Cause, this PR's scope is styling for mobile only.

<img width="398" alt="スクリーンショット 2024-10-16 19 29 38" src="https://github.com/user-attachments/assets/220ed1de-4cb5-4b3f-b998-80d4623b7f24">

<img width="399" alt="スクリーンショット 2024-10-16 19 30 11" src="https://github.com/user-attachments/assets/403d02aa-8ef6-4e70-8990-1128e14f5911">

<img width="398" alt="スクリーンショット 2024-10-16 19 30 18" src="https://github.com/user-attachments/assets/53ac35fc-64f5-45ea-beeb-0f547246c855">


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

- Add mobile styles for the Heading component.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
