### PR TITLE
maintenance: show timestamp to generated files

### DIFF
--- a/frontend/apps/service-site/src/styles/Dark/variables.css
+++ b/frontend/apps/service-site/src/styles/Dark/variables.css
@@ -1,5 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
+ * Generated on Thu, 17 Oct 2024 04:57:00 GMT
  */
 
 :root {

--- a/frontend/apps/service-site/src/styles/Mode 1/variables.css
+++ b/frontend/apps/service-site/src/styles/Mode 1/variables.css
@@ -1,5 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
+ * Generated on Thu, 17 Oct 2024 04:57:00 GMT
  */
 
 :root {

--- a/frontend/packages/figma-to-css-variables/bin/runStyleDictionary.mjs
+++ b/frontend/packages/figma-to-css-variables/bin/runStyleDictionary.mjs
@@ -62,6 +62,9 @@ export async function runStyleDictionary(
       const subDirInput = path.join(inputDir, subDir)
       const subDirOutput = `${path.join(outputPath, subDir)}/`
 
+      /**
+       * @type {import('style-dictionary').Config}
+       */
       const config = {
         source: [source(subDirInput)],
         platforms: {
@@ -87,6 +90,11 @@ export async function runStyleDictionary(
               'color/css',
               'number/px',
             ],
+            options: {
+              formatting: {
+                fileHeaderTimestamp: true,
+              },
+            },
           },
         },
         log: {


### PR DESCRIPTION
- ref: https://github.com/route06inc/liam/pull/40
- ref: https://github.com/route06inc/liam/pull/44

Add a timestamp for the purpose of testing the workflow created above.
Knowing the generation date also has the advantage of showing how old it is!