### PR TITLE
feat: Make ToC sticky navigation and implement responsive layout

### DIFF
--- a/frontend/apps/service-site/src/features/posts/components/PostDetailPage/PostDetailPage.module.css
+++ b/frontend/apps/service-site/src/features/posts/components/PostDetailPage/PostDetailPage.module.css
@@ -1,3 +1,21 @@
+.container {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: var(--spacing-10, 40px);
+  margin-top: var(--spacing-10, 40px);
+  padding: 0 var(--spacing-5, 20px);
+}
+
+.center {
+  padding: var(--spacing-6, 24px);
+}
+
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-10, 40px);
+}
+
 .navPostWrapper {
   display: grid;
   grid-template-rows: auto auto;
@@ -28,28 +46,17 @@
   }
 }
 
-.container {
-  padding: 0 var(--spacing-20, 80px);
-  display: flex;
-  justify-content: space-between;
-  margin-top: var(--spacing-10, 40px);
-  gap: var(--spacing-10, 40px);
-}
+@media screen and (min-width: 1024px) {
+  .container {
+    display: grid;
+    grid-template-columns: 274px auto 274px;
+    gap: var(--spacing-10, 40px);
+    padding: 0 var(--spacing-20, 80px);
+  }
 
-.left {
-  width: 274px;
-  position: sticky;
-  top: 0;
-}
-
-.center {
-  width: 880px;
-  padding: var(--spacing-6, 24px);
-}
-
-.right {
-  width: 274px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-10, 40px);
+  .left {
+    position: sticky;
+    top: calc(var(--default-header-height) + var(--spacing-8));
+    align-self: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I have made the Table of Contents (ToC) sticky when scrolling for screen widths of 1028px and above.
Additionally, I have implemented responsive layout adjustments for the ToC and category list, ensuring their positions are appropriately placed based on the window width.

https://github.com/user-attachments/assets/f08f537b-6198-45f6-ba4d-1d480f75d643

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
