### PR TITLE
Add smoke tests for CLI

### DIFF
--- a/frontend/packages/cli/src/cli/smoke.test.ts
+++ b/frontend/packages/cli/src/cli/smoke.test.ts
@@ -14,20 +14,20 @@ describe('CLI Smoke Test', () => {
     try {
       const { stdout, stderr } = await execAsync('npx --no-install . help')
       expect(stderr).toBe('')
-      expect(stdout).toEqual(
-        `Usage: liam [options] [command]
+      expect(stdout).toMatchInlineSnapshot(`
+        "Usage: liam [options] [command]
 
-CLI tool for Liam
+        CLI tool for Liam
 
-Options:
-  -V, --version   output the version number
-  -h, --help      display help for command
+        Options:
+          -V, --version   output the version number
+          -h, --help      display help for command
 
-Commands:
-  erd             ERD commands
-  help [command]  display help for command
-`,
-      )
+        Commands:
+          erd             ERD commands
+          help [command]  display help for command
+        "
+      `)
     } catch (error) {
       // Fail the test if an error occurs
       expect(error).toBeNull()


### PR DESCRIPTION

## Summary
Add smoke tests for CLI
- Introduced `smoke.test.ts` to verify that the CLI tool can run essential commands without errors.
- Includes tests for basic CLI usage and ERD command execution, checking for expected output.

## Related Issue
N/A

## Changes
### Testing:
- Added `smoke.test.ts` under `frontend/packages/cli/src/cli/` to perform end-to-end checks on the CLI.
- The tests ensure that:
  - The `help` command outputs the expected usage information.
  - The `erd build` command runs successfully, generating the required output.

### Test Setup:
- The `beforeAll` hook prepares the environment by cleaning up and building the CLI tool.
- Each test case uses `node:child_process` to execute CLI commands and verifies the output using `vitest`.

## Testing
N/A

## Other Information
N/A
