### PR TITLE
Temporarily remove the `x`, `y`, and `color` fields from DBStructure.

### DIFF
--- a/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
+++ b/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
@@ -5,7 +5,6 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
   "relationships": {},
   "tables": {
     "users": {
-      "color": null,
       "columns": {
         "age": {
           "check": null,
@@ -88,8 +87,6 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
       "comment": null,
       "indices": [],
       "name": "users",
-      "x": 0,
-      "y": 0,
     },
   },
 }

--- a/frontend/packages/db-structure/src/parser/index.ts
+++ b/frontend/packages/db-structure/src/parser/index.ts
@@ -28,9 +28,6 @@ const convertToDBStructure = (data: any): DBStructure => {
         columns,
         indices: [],
         name: table.name,
-        x: 0,
-        y: 0,
-        color: null,
       }
       return acc
     }, {}),

--- a/frontend/packages/db-structure/src/schema/index.ts
+++ b/frontend/packages/db-structure/src/schema/index.ts
@@ -29,12 +29,9 @@ const indexSchema = v.object({
 
 const tableSchema = v.object({
   name: tableNameSchema,
-  x: v.number(),
-  y: v.number(),
   columns: columnsSchema,
   comment: v.nullable(v.string()),
   indices: v.array(indexSchema),
-  color: v.nullable(v.string()),
 })
 
 export type Table = v.InferOutput<typeof tableSchema>


### PR DESCRIPTION

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Temporarily remove the `x`, `y`, and `color` fields from DBStructure.

These fields are not part of PostgreSQL DDL or `schema.rb`, making it challenging to set their values. Additionally, these fields are better considered during the implementation of ERD rendering. Therefore, they should be temporarily removed.


## Related Issue
<!-- Mention the related issue number if applicable. -->
N/A

## Changes
<!-- List the main changes made in this PR. -->

Removed the `x`, `y`, and `color` fields from DBStructure.

## Testing
<!-- Briefly describe the testing steps or results. -->
N/A

## Other Information
<!-- Add any other relevant information for the reviewer. -->
N/A
