### PR TITLE
Fix CLI build command and Turbo dependencies for dev task

### DIFF
--- a/frontend/packages/cli/package.json
+++ b/frontend/packages/cli/package.json
@@ -35,7 +35,7 @@
     "build": "pnpm run '/^build:.*/'",
     "build:cli": "rollup -c",
     "build:vite": "vite build --outDir dist-cli/html",
-    "command:build": "pnpm build && node ./dist-cli/bin/cli.js erd build --input fixtures/input.schema.rb",
+    "command:build": "node ./dist-cli/bin/cli.js erd build --input fixtures/input.schema.rb",
     "dev": "pnpm command:build && cp dist/schema.json public/ && pnpm run '/^dev:.*/'",
     "dev:app": "vite",
     "dev:css": "tcm src --watch",

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -9,6 +9,11 @@
       "cache": false,
       "persistent": true
     },
+    "@liam/cli#dev": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "persistent": true
+    },
     "gen": {
       "dependsOn": ["^gen"]
     },


### PR DESCRIPTION

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

This commit simplifies the CLI build process by directly invoking the node script in the `command:build` script of the `package.json`. It removes the unnecessary preceding `pnpm build` command, streamlining the execution path. Additionally, the `cli#dev` task in `turbo.json` is updated to explicitly depend on the `build` task, ensuring that all necessary builds are completed before development tasks commence.

## Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

## Changes
<!-- List the main changes made in this PR. -->

before: `turbo dev`  task dependencies

```mermaid
graph TD
   liam/cli#dev -->  ___ROOT___
   liam/configs#dev -->  ___ROOT___
   liam/db-structure#dev -->  ___ROOT___
   liam/docs#dev -->  ___ROOT___
   liam/erd-core#dev -->  ___ROOT___
   liam/figma-to-css-variables#dev -->  ___ROOT___
   liam/ui#dev -->  ___ROOT___
```


-----


after: `turbo dev`  task dependencies

```mermaid
graph TD
   liam/cli#build -->  liam/db-structure#build
   liam/cli#build -->  liam/erd-core#build
   liam/cli#dev -->  liam/cli#build
   liam/configs#build -->  ___ROOT___
   liam/configs#dev -->  ___ROOT___
   liam/db-structure#build -->  liam/configs#build
   liam/db-structure#dev -->  ___ROOT___
   liam/docs#dev -->  ___ROOT___
   liam/erd-core#build -->  liam/configs#build
   liam/erd-core#build -->  liam/db-structure#build
   liam/erd-core#build -->  liam/ui#build
   liam/erd-core#dev -->  ___ROOT___
   liam/figma-to-css-variables#dev -->  ___ROOT___
   liam/ui#build -->  liam/configs#build
   liam/ui#dev -->  ___ROOT___
```



## Testing
<!-- Briefly describe the testing steps or results. -->

After cloning the repository, running `pnpm i && pnpm dev` now will work right away.

## Other Information
<!-- Add any other relevant information for the reviewer. -->

N/A

