### PR TITLE
Update GitHub App token variables for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CHANGESET_CI_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.CHANGESET_CI_TRIGGER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |
@@ -28,13 +35,6 @@ jobs:
       - uses: ./.github/actions/pnpm-setup
         with:
           working-directory: ${{ env.working-directory }}
-
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.CHANGESET_CI_TRIGGER_APP_ID }}
-          private-key: ${{ secrets.CHANGESET_CI_TRIGGER_APP_PRIVATE_KEY }}
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1.4.9


### PR DESCRIPTION


## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Follow-up to https://github.com/liam-hq/liam/pull/136

Switched to a different GitHub App for `.github/workflows/release.yml` compared to `.github/workflows/license-frontend.yml`.

The new GitHub App ID and private key are registered in the following locations:

- [Secrets](https://github.com/liam-hq/liam/settings/secrets/actions) (private page)  
- [Variables](https://github.com/liam-hq/liam/settings/variables/actions) (private page)

