### PR TITLE
fix: Remove unused favicon link from index.html

### DIFF
--- a/frontend/packages/cli/index.html
+++ b/frontend/packages/cli/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>


### PR DESCRIPTION
of the generated static assets had unnecessary 404 errors.

```
$ node packages/cli/dist-cli/bin/cli.js erd build --input ./packages/db-structure/src/parser/sql/input/postgresql_schema1.in.sql                           

$ npx http-server ./dist                                                                                                        
Starting up http-server, serving ./dist

http-server version: 14.1.1

http-server settings: 
CORS: disabled
Cache: 3600 seconds
Connection Timeout: 120 seconds
Directory Listings: visible
AutoIndex: visible
Serve GZIP Files: false
Serve Brotli Files: false
Default File Extension: none

Available on:
  http://127.0.0.1:8080
  http://192.168.0.103:8080
Hit CTRL-C to stop the server

[Mon Dec 02 2024 11:46:20 GMT+0900 (日本標準時)]  "GET /" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
(node:7811) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
(Use `node --trace-deprecation ...` to show where the warning was created)
[Mon Dec 02 2024 11:46:20 GMT+0900 (日本標準時)]  "GET /assets/index-B3DBtjYh.js" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
[Mon Dec 02 2024 11:46:20 GMT+0900 (日本標準時)]  "GET /assets/index-DKO-UkUe.css" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
[Mon Dec 02 2024 11:46:20 GMT+0900 (日本標準時)]  "GET /schema.json" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
[Mon Dec 02 2024 11:46:20 GMT+0900 (日本標準時)]  "GET /vite.svg" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
[Mon Dec 02 2024 11:46:20 GMT+0900 (日本標準時)]  "GET /vite.svg" Error (404): "Not found"
```
