### PR TITLE
Use the same token for checkout and push steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           sparse-checkout: |
             .github
             ${{ env.working-directory }}


### PR DESCRIPTION
## Summary


This change ensures that the same token is used in both the `checkout` and `push` steps, aligning with the implementation in [this workflow](https://github.com/liam-hq/liam/blob/97e100449095c6b4720c31bbfae9ddf88cc4ffbf/.github/workflows/license-frontend.yml#L45).

By doing so, the workflow is expected to run even after a push to a pull request.

