### PR TITLE
chore: Configure Biome for CSS formatting in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,10 +18,7 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[css]": {
-    "editor.formatOnSave": false,
-    "editor.codeActionsOnSave": {
-      "source.fixAll.stylelint": "always"
-    }
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[mdx]": {
     "editor.formatOnSave": false,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I adjusted the CSS file formatting when saving in VSCode, as it wasn't working properly before.
I changed it to format using Biome as the base.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f088ae49-2f0a-449f-b94d-a7cb9f1992d5" /> | <video src="https://github.com/user-attachments/assets/e301ecae-d903-4843-80a6-27373c281f1a" /> | 


