### PR TITLE
maintenance: Fix test comments to valid syntax highlight

### DIFF
--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -33,7 +33,7 @@ describe(processor, () => {
       })
 
     it('not null', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255) NOT NULL
@@ -54,7 +54,7 @@ describe(processor, () => {
     })
 
     it('nullable', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255)
@@ -67,7 +67,7 @@ describe(processor, () => {
     })
 
     it('unique', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255) UNIQUE
@@ -88,7 +88,7 @@ describe(processor, () => {
     })
 
     it('default value as varchar', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255) DEFAULT 'new user'
@@ -109,7 +109,7 @@ describe(processor, () => {
     })
 
     it('default value as integer', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255),
@@ -131,7 +131,7 @@ describe(processor, () => {
     })
 
     it('default value as boolean', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255),
@@ -153,7 +153,7 @@ describe(processor, () => {
     })
 
     it('should parse foreign keys to relationships', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255)
@@ -182,7 +182,7 @@ describe(processor, () => {
     })
 
     it('index', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255)
@@ -205,7 +205,7 @@ describe(processor, () => {
     })
 
     it('unique index', async () => {
-      const result = await processor(/* PostgreSQL */ `
+      const result = await processor(/* sql */ `
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
           name VARCHAR(255)


### PR DESCRIPTION
I've fixed the syntax highlighting in the PostgreSQL test because it wasn't enabled.

|before|after|
| --- | --- |
| <img width="852" alt="スクリーンショット 2024-12-04 19 00 53" src="https://github.com/user-attachments/assets/9c8a954c-0d76-45d9-8d69-243d0bb624e2"> | <img width="852" alt="スクリーンショット 2024-12-04 19 01 05" src="https://github.com/user-attachments/assets/9faf504e-4010-414e-98a0-69be7016c8a0"> |

FYI: This syntax highlighting will be enabled if you include the following extensions:

https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates