### PR TITLE
Extract column comments for schemarb parser

### DIFF
--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -189,5 +189,25 @@ describe(processor, () => {
 
       expect(result).toEqual(expected)
     })
+
+    it('column commnet', async () => {
+      const result = await processor(/* Ruby */ `
+        create_table "users" do |t|
+          t.string "name", comment: 'this is name'
+        end
+      `)
+
+      const expected = userTable({
+        columns: {
+          name: aColumn({
+            name: 'name',
+            type: 'string',
+            comment: 'this is name',
+          }),
+        },
+      })
+
+      expect(result).toEqual(expected)
+    })
   })
 })

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -157,6 +157,10 @@ function extractColumnOptions(hashNode: KeywordHashNode, column: Column): void {
       case 'unique':
         column.unique = value instanceof TrueNode
         break
+      case 'comment':
+        // @ts-expect-error: unescaped is defined as string but it is actually object
+        column.comment = value.unescaped.value
+        break
     }
   }
 }


### PR DESCRIPTION
## Summary

Add implementation to extract column comments for schemarb parser.
Support for postgres parser will be separate pr for avoiding conflicts.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
