### PR TITLE
feat: Add z-index variables

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/AppBar/AppBar.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/AppBar/AppBar.module.css
@@ -6,6 +6,7 @@
   padding: 0 var(--spacing-4);
   background-color: var(--global-muted-background);
   border-bottom: 1px solid var(--pane-border);
+  z-index: var(--z-index-header);
 }
 
 .logo {

--- a/frontend/packages/ui/src/components/Drawer/Drawer.module.css
+++ b/frontend/packages/ui/src/components/Drawer/Drawer.module.css
@@ -1,5 +1,6 @@
 .content {
   position: fixed;
+  z-index: var(--z-index-drawer);
 }
 
 /*

--- a/frontend/packages/ui/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/frontend/packages/ui/src/components/DropdownMenu/DropdownMenu.module.css
@@ -3,7 +3,7 @@
     Needed to set the z-index on the parent element div[data-radix-popper-content-wrapper].
     @see: https://github.com/radix-ui/primitives/issues/1839#issuecomment-1708479747
   */
-  z-index: var(--z-index-popup-button);
+  z-index: var(--z-index-dropdown-menu);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-half);

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -32,7 +32,7 @@
   height: 100%;
   position: absolute;
   inset: 0 auto auto 0;
-  z-index: 10;
+  z-index: var(--z-index-sidebar);
   transition-duration: 200ms;
   animation-timing-function: linear;
   transition-property: left, right, width;

--- a/frontend/packages/ui/src/styles/variables.css
+++ b/frontend/packages/ui/src/styles/variables.css
@@ -2,4 +2,10 @@
   --default-timing-function: ease-out;
   --default-animation-duration: 300ms;
   --default-hover-animation-duration: 100ms;
+
+  --z-index-sidebar: 900;
+  --z-index-drawer: 900;
+  --z-index-header: 1000;
+  --z-index-dropdown-menu: 1100;
+  --z-index-tooltip: 2000;
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Since the Tooltip was getting hidden beneath the Sidebar and the Drawer was overlapping above the header, I added CSS Variables for z-index and adjusted the stacking order of these elements.

| Before | After |
|--------|--------|
|<video src="https://github.com/user-attachments/assets/64de5f38-dbb3-4a23-95b9-c0f1c61684f6" /> |<video src="https://github.com/user-attachments/assets/7640074d-4833-4a93-8eca-820bd99336e5" /> | 








