### PR TITLE
fix(postgres-parser): Implement chunked SQL processing and merge DB structures

### DIFF
--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
@@ -1,8 +1,19 @@
+import type { DBStructure } from '../../../schema/index.js'
 import type { Processor } from '../../types.js'
 import { convertToDBStructure } from './converter.js'
+import { mergeDBStructures } from './mergeDBStructures.js'
 import { parse } from './parser.js'
+import { processSQLInChunks } from './processSQLInChunks.js'
 
 export const processor: Processor = async (str: string) => {
-  const parsed = await parse(str)
-  return convertToDBStructure(parsed)
+  const dbStructure: DBStructure = { tables: {}, relationships: {} }
+  const CHUNK_SIZE = 1000
+
+  await processSQLInChunks(str, CHUNK_SIZE, async (chunk) => {
+    const parsed = await parse(chunk)
+    const partial = convertToDBStructure(parsed)
+    mergeDBStructures(dbStructure, partial)
+  })
+
+  return dbStructure
 }

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/mergeDBStructures.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/mergeDBStructures.ts
@@ -1,0 +1,24 @@
+import type { DBStructure } from '../../../schema/index.js'
+
+export const mergeDBStructures = (target: DBStructure, source: DBStructure) => {
+  for (const [tableName, table] of Object.entries(source.tables)) {
+    target.tables[tableName] = {
+      ...target.tables[tableName],
+      ...table,
+      columns: {
+        ...target.tables[tableName]?.columns,
+        ...table.columns,
+      },
+      indices: {
+        ...target.tables[tableName]?.indices,
+        ...table.indices,
+      },
+    }
+  }
+
+  for (const [relationshipName, relationship] of Object.entries(
+    source.relationships,
+  )) {
+    target.relationships[relationshipName] = relationship
+  }
+}

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { processSQLInChunks } from './processSQLInChunks.js'
+
+describe(processSQLInChunks, () => {
+  describe('processSQLInChunks', () => {
+    it('should split input by newline and process each chunk', async () => {
+      const input = 'SELECT 1;\nSELECT 2;\nSELECT 3;'
+      const chunkSize = 2
+      const callback = vi.fn()
+
+      await processSQLInChunks(input, chunkSize, callback)
+
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(callback).toHaveBeenCalledWith('SELECT 1;\nSELECT 2;')
+      expect(callback).toHaveBeenCalledWith('SELECT 3;')
+    })
+
+    it('should handle chunks correctly to avoid invalid SQL syntax', async () => {
+      const input = 'SELECT 1;\nSELECT 2;\nSELECT 3;\nSELECT 4;'
+      const chunkSize = 3
+      const callback = vi.fn()
+
+      await processSQLInChunks(input, chunkSize, callback)
+
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(callback).toHaveBeenCalledWith('SELECT 1;\nSELECT 2;\nSELECT 3;')
+      expect(callback).toHaveBeenCalledWith('SELECT 4;')
+    })
+
+    it('should handle input with no newlines correctly', async () => {
+      const input = 'SELECT 1; SELECT 2; SELECT 3;'
+      const chunkSize = 1
+      const callback = vi.fn()
+
+      await processSQLInChunks(input, chunkSize, callback)
+
+      expect(callback).toHaveBeenCalledTimes(1)
+      expect(callback).toHaveBeenCalledWith('SELECT 1; SELECT 2; SELECT 3;')
+    })
+
+    it('should handle empty input correctly', async () => {
+      const input = ''
+      const chunkSize = 1
+      const callback = vi.fn()
+
+      await processSQLInChunks(input, chunkSize, callback)
+
+      expect(callback).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
@@ -1,0 +1,35 @@
+/**
+ * Processes a large SQL input string in chunks, ensuring that each chunk ends with a complete SQL statement.
+ *
+ * @param input - The large SQL input string to be processed.
+ * @param chunkSize - The number of lines to include in each chunk.
+ * @param callback - An asynchronous callback function to process each chunk of SQL statements.
+ */
+export const processSQLInChunks = async (
+  input: string,
+  chunkSize: number,
+  callback: (chunk: string) => Promise<void>,
+): Promise<void> => {
+  const lines = input.split('\n')
+  let partialStmt = ''
+
+  for (let i = 0; i < lines.length; i += chunkSize) {
+    const chunk = lines.slice(i, i + chunkSize).join('\n')
+    const combined = partialStmt + chunk
+
+    const lastSemicolonIndex = combined.lastIndexOf(';')
+    if (lastSemicolonIndex === -1) {
+      partialStmt = combined
+      continue
+    }
+
+    const parseablePart = combined.slice(0, lastSemicolonIndex + 1)
+    partialStmt = combined.slice(lastSemicolonIndex + 1)
+    await callback(parseablePart)
+  }
+
+  // Process the last remaining statement.
+  if (partialStmt.trim()) {
+    await callback(partialStmt)
+  }
+}


### PR DESCRIPTION
## Description

In the PostgreSQL parser, the SQL string is now split into chunks of 1000 lines each time it is processed.

## Background

Several errors were occurring when entering huge SQL strings.

### The top 2000 lines can be parsed and tables can be retrieved.

https://github.com/liam-hq/liam/pull/155/commits/1a4246e5e48c14ba4262e95b83330a5628ae34bf
https://github.com/liam-hq/liam/actions/runs/12157819490/job/33904440226#step:4:39

### The top 2500 lines can be executable, but the tables and relationships cannot be returned.

https://github.com/liam-hq/liam/pull/155/commits/9a37df9ed49fa1f7209882eaf0fe5ad1588be369
https://github.com/liam-hq/liam/actions/runs/12158068823/job/33905205933#step:4:39

### The top 2500 lines cannot be executable.

```
TypeError: Ma[F[(F[((c + 12) >> 2)] >> 2)]] is not a function
 ❯ tb ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:18:10370
 ❯ ef ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:16:596970
 ❯ od ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:14:143
 ❯ invoke_iii ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:27:96707
 ❯ ne ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:16:569069
 ❯ Array.xj ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:16:[53](https://github.com/liam-hq/liam/actions/runs/12158189449/job/33905579058#step:4:55)4612
 ❯ xg ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:17:23569
 ❯ Object.raw_parse ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:27:28356
 ❯ Object.parse ../../node_modules/.pnpm/pg-query-emscripten@5.1.0/node_modules/pg-query-emscripten/pg_query.js:9:602
```

https://github.com/liam-hq/liam/pull/155/commits/c36ed7e93c581100fb73ff22062fa5386ecafb84
https://github.com/liam-hq/liam/actions/runs/12158189449/job/33905579058#step:4:41

## Testing

```
node packages/cli/dist-cli/bin/cli.js erd build --input structure.sql --format postgres    
```

