### PR TITLE
fix: fix layout for text overflow

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableHeader/TableHeader.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableHeader/TableHeader.module.css
@@ -12,3 +12,9 @@
   font-weight: 500;
   line-height: normal;
 }
+
+.name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableHeader/TableHeader.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableHeader/TableHeader.tsx
@@ -10,7 +10,7 @@ export const TableHeader: FC<Props> = ({ name }) => {
   return (
     <div className={styles.wrapper}>
       <Table2 width={16} />
-      <span>{name}</span>
+      <span className={styles.name}>{name}</span>
     </div>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
@@ -31,9 +31,15 @@
   color: var(--overlay-70);
 }
 
-.columnName {
+.columnNameWrapper {
   display: inline-flex;
   justify-content: space-between;
+}
+
+.columnName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .columnType {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -60,8 +60,8 @@ export const TableNode: FC<Props> = ({ data: { table } }) => {
                       />
                     ))}
 
-                  <span className={styles.columnName}>
-                    <span>{column.name}</span>
+                  <span className={styles.columnNameWrapper}>
+                    <span className={styles.columnName}>{column.name}</span>
                     <span className={styles.columnType}>{column.type}</span>
                   </span>
                 </li>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -1,0 +1,5 @@
+.tableName {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -12,6 +12,7 @@ import {
 } from '@liam-hq/ui'
 import { Table2 } from '@liam-hq/ui'
 import { useDBStructureStore } from '../../../stores'
+import styles from './LeftPane.module.css'
 import { TableCounter } from './TableCounter'
 
 export const LeftPane = () => {
@@ -28,7 +29,7 @@ export const LeftPane = () => {
                 <SidebarMenuItem key={table.name}>
                   <SidebarMenuButton>
                     <Table2 width="10px" />
-                    <span>{table.name}</span>
+                    <span className={styles.tableName}>{table.name}</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -56,6 +56,7 @@
 
 .sidebarContent {
   flex: 1 1 0%;
+  overflow-y: auto;
 }
 
 .sidebarMenuButton {


### PR DESCRIPTION
|before|after|
| --- | --- |
| <img width="1397" alt="スクリーンショット_2024-12-05_17_04_49" src="https://github.com/user-attachments/assets/c58bf772-8d00-4664-92c2-2987679cd548"> | <img width="1397" alt="スクリーンショット_2024-12-05_17_03_56" src="https://github.com/user-attachments/assets/8ee4484c-976f-486e-8f7b-24fe4685d9a0"> |



