### PR TITLE
Add foreign key parsing for schemarb parser

### DIFF
--- a/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
+++ b/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
@@ -5,13 +5,13 @@ exports[`parse > should parse postgresql to JSON correctly 1`] = `
   "relationships": {
     "users_id_to_posts_user_id": {
       "cardinality": "ONE_TO_MANY",
-      "deleteConstraint": "NO ACTION",
+      "deleteConstraint": "NO_ACTION",
       "foreignColumnName": "user_id",
       "foreignTableName": "posts",
       "name": "users_id_to_posts_user_id",
       "primaryColumnName": "id",
       "primaryTableName": "users",
-      "updateConstraint": "NO ACTION",
+      "updateConstraint": "NO_ACTION",
     },
   },
   "tables": {

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { Table } from '../../schema/index.js'
-import { aColumn, aDBStructure, aTable, anIndex } from '../../schema/index.js'
+import {
+  aColumn,
+  aDBStructure,
+  aRelationship,
+  aTable,
+  anIndex,
+} from '../../schema/index.js'
 import { processor } from './index.js'
 
 describe(processor, () => {
@@ -222,6 +228,27 @@ describe(processor, () => {
       })
 
       expect(result).toEqual(expected)
+    })
+
+    it('foreign key', async () => {
+      const result = await processor(/* Ruby */ `
+        add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
+      `)
+
+      const rel = aRelationship({
+        name: 'fk_posts_user_id',
+        primaryTableName: 'users',
+        primaryColumnName: 'id',
+        foreignTableName: 'posts',
+        foreignColumnName: 'user_id',
+        cardinality: 'ONE_TO_MANY',
+        updateConstraint: 'RESTRICT',
+        deleteConstraint: 'CASCADE',
+      })
+
+      const expected = { fk_posts_user_id: rel }
+
+      expect(result.relationships).toEqual(expected)
     })
   })
 })

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -242,9 +242,9 @@ function normalizeConstraintName(constraint: string): ForeignKeyConstraint {
     case 'restrict':
       return 'RESTRICT'
     case 'nullify':
-      return 'SET NULL'
+      return 'SET_NULL'
     default:
-      return 'NO ACTION'
+      return 'NO_ACTION'
   }
 }
 

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -20,10 +20,11 @@ import type {
   DBStructure,
   Index,
   Indices,
+  Relationship,
   Table,
   Tables,
 } from '../../schema/index.js'
-import { aColumn, aTable, anIndex } from '../../schema/index.js'
+import { aColumn, aRelationship, aTable, anIndex } from '../../schema/index.js'
 import type { Processor } from '../types.js'
 
 function extractTableName(argNodes: Node[]): string {
@@ -216,8 +217,79 @@ function extractDefaultValue(
   return null
 }
 
+function extractRelationshipTableNames(argNodes: Node[]): [string, string] {
+  argNodes = argNodes.filter((node) => node instanceof StringNode)
+  if (!(argNodes.length === 2)) {
+    throw new Error('Foreign key relationship must have two table names')
+  }
+
+  const [foreignTableName, primaryTableName] = argNodes.map((node) => {
+    // @ts-expect-error: unescaped is defined as string but it is actually object
+    if (node instanceof StringNode) return node.unescaped.value
+    return null
+  })
+
+  return [primaryTableName, foreignTableName]
+}
+
+function normalizeConstraintName(constraint: string): string {
+  // Valid values are :nullify, :cascade, and :restrict
+  // https://github.com/rails/rails/blob/v8.0.0/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L1161-L1164
+  switch (constraint) {
+    case 'cascade':
+      return 'CASCADE'
+    case 'restrict':
+      return 'RESTRICT'
+    case 'nullify':
+      return 'SET NULL'
+    default:
+      return 'NO ACTION'
+  }
+}
+
+function extractForeignKeyOptions(argNodes: Node[], relation: Relationship): void {
+  for (const argNode of argNodes) {
+    if (argNode instanceof KeywordHashNode) {
+      for (const argElement of argNode.elements) {
+        if (!(argElement instanceof AssocNode)) continue
+        // @ts-expect-error: unescaped is defined as string but it is actually object
+        const key = argElement.key.unescaped.value
+        const value = argElement.value
+
+        switch (key) {
+          case 'column':
+            if (value instanceof StringNode || value instanceof SymbolNode) {
+              // @ts-expect-error: unescaped is defined as string but it is actually object
+              relation.foreignColumnName = value.unescaped.value
+            }
+            break
+          case 'name':
+            if (value instanceof StringNode || value instanceof SymbolNode) {
+              // @ts-expect-error: unescaped is defined as string but it is actually object
+              relation.name = value.unescaped.value
+            }
+            break
+          case 'on_update':
+            if (value instanceof SymbolNode) {
+              // @ts-expect-error: unescaped is defined as string but it is actually object
+              relation.updateConstraint = normalizeConstraintName(value.unescaped.value)
+            }
+            break
+          case 'on_delete':
+            if (value instanceof SymbolNode) {
+              // @ts-expect-error: unescaped is defined as string but it is actually object
+              relation.deleteConstraint = normalizeConstraintName(value.unescaped.value)
+            }
+            break
+        }
+      }
+    }
+  }
+}
+
 class DBStructureFinder extends Visitor {
   private tables: Table[] = []
+  private relationships: Relationship[] = []
 
   getDBStructure(): DBStructure {
     const dbStructure: DBStructure = {
@@ -225,45 +297,68 @@ class DBStructureFinder extends Visitor {
         acc[table.name] = table
         return acc
       }, {} as Tables),
-      relationships: {},
+      relationships: this.relationships.reduce((acc, relationship) => {
+        acc[relationship.name] = relationship
+        return acc
+      }, {} as Record<string, Relationship>),
     }
     return dbStructure
   }
 
+  handleCreateTable(node: CallNode): void {
+    const argNodes = node.arguments_?.compactChildNodes() || []
+
+    const table = aTable({
+      name: extractTableName(argNodes),
+    })
+
+    table.comment = extractTableComment(argNodes)
+
+    const columns: Column[] = []
+    const indices: Index[] = []
+
+    const idColumn = extractIdColumn(argNodes)
+    if (idColumn) columns.push(idColumn)
+
+    const blockNodes = node.block?.compactChildNodes() || []
+    const [extractColumns, extractIndices] = extractTableDetails(blockNodes)
+
+    columns.push(...extractColumns)
+    indices.push(...extractIndices)
+
+    table.columns = columns.reduce((acc, column) => {
+      acc[column.name] = column
+      return acc
+    }, {} as Columns)
+
+    table.indices = indices.reduce((acc, index) => {
+      acc[index.name] = index
+      return acc
+    }, {} as Indices)
+
+    this.tables.push(table)
+  }
+
+  handleAddForeignKey(node: CallNode): void {
+    const argNodes = node.arguments_?.compactChildNodes() || []
+
+    const [primaryTableName, foreignTableName] = extractRelationshipTableNames(argNodes)
+
+    const relationship = aRelationship({
+      primaryTableName: primaryTableName,
+      // TODO: This is a guess, we should add a way to specify the primary column name
+      primaryColumnName: 'id',
+      foreignTableName: foreignTableName,
+    })
+
+    extractForeignKeyOptions(argNodes, relationship)
+
+    this.relationships.push(relationship)
+  }
+
   override visitCallNode(node: CallNode): void {
-    if (node.name === 'create_table') {
-      const argNodes = node.arguments_?.compactChildNodes() || []
-
-      const table = aTable({
-        name: extractTableName(argNodes),
-      })
-
-      table.comment = extractTableComment(argNodes)
-
-      const columns: Column[] = []
-      const indices: Index[] = []
-
-      const idColumn = extractIdColumn(argNodes)
-      if (idColumn) columns.push(idColumn)
-
-      const blockNodes = node.block?.compactChildNodes() || []
-      const [extractColumns, extractIndices] = extractTableDetails(blockNodes)
-
-      columns.push(...extractColumns)
-      indices.push(...extractIndices)
-
-      table.columns = columns.reduce((acc, column) => {
-        acc[column.name] = column
-        return acc
-      }, {} as Columns)
-
-      table.indices = indices.reduce((acc, index) => {
-        acc[index.name] = index
-        return acc
-      }, {} as Indices)
-
-      this.tables.push(table)
-    }
+    if (node.name === 'create_table') this.handleCreateTable(node)
+    if (node.name === 'add_foreign_key') this.handleAddForeignKey(node)
 
     super.visitCallNode(node)
   }

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
@@ -10,6 +10,7 @@ import type {
 import type {
   Columns,
   DBStructure,
+  ForeignKeyConstraint,
   Relationship,
   Relationships,
   Table,
@@ -129,7 +130,7 @@ export const convertToDBStructure = (ast: RawStmtWrapper[]): DBStructure => {
 
         // Update or delete constraint for foreign key
         // see: https://github.com/launchql/pgsql-parser/blob/pgsql-parser%4013.16.0/packages/deparser/src/deparser.ts#L3101-L3141
-        const getConstraintAction = (action?: string): string => {
+        const getConstraintAction = (action?: string): ForeignKeyConstraint => {
           switch (action?.toLowerCase()) {
             case 'r':
               return 'RESTRICT'

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
@@ -137,13 +137,13 @@ export const convertToDBStructure = (ast: RawStmtWrapper[]): DBStructure => {
             case 'c':
               return 'CASCADE'
             case 'n':
-              return 'SET NULL'
+              return 'SET_NULL'
             case 'd':
-              return 'SET DEFAULT'
+              return 'SET_DEFAULT'
             case 'a':
-              return 'NO ACTION'
+              return 'NO_ACTION'
             default:
-              return 'NO ACTION' // Default to 'NO ACTION' for unknown or missing values
+              return 'NO_ACTION' // Default to 'NO_ACTION' for unknown or missing values
           }
         }
 

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -190,8 +190,8 @@ describe(processor, () => {
           foreignTableName: 'posts',
           foreignColumnName: 'user_id',
           cardinality: 'ONE_TO_MANY',
-          updateConstraint: 'NO ACTION',
-          deleteConstraint: 'NO ACTION',
+          updateConstraint: 'NO_ACTION',
+          deleteConstraint: 'NO_ACTION',
         },
       }
 
@@ -219,8 +219,8 @@ describe(processor, () => {
           foreignTableName: 'posts',
           foreignColumnName: 'user_id',
           cardinality: 'ONE_TO_ONE',
-          updateConstraint: 'NO ACTION',
-          deleteConstraint: 'NO ACTION',
+          updateConstraint: 'NO_ACTION',
+          deleteConstraint: 'NO_ACTION',
         },
       }
 

--- a/frontend/packages/db-structure/src/schema/dbStructure.ts
+++ b/frontend/packages/db-structure/src/schema/dbStructure.ts
@@ -52,6 +52,10 @@ const foreignKeyConstraintSchema = v.picklist([
   'NO ACTION',
 ])
 
+export type ForeignKeyConstraint = v.InferOutput<
+  typeof foreignKeyConstraintSchema
+>
+
 const relationshipSchema = v.object({
   name: relationshipNameSchema,
   primaryTableName: tableNameSchema,

--- a/frontend/packages/db-structure/src/schema/dbStructure.ts
+++ b/frontend/packages/db-structure/src/schema/dbStructure.ts
@@ -44,6 +44,13 @@ const tableSchema = v.object({
 export type Table = v.InferOutput<typeof tableSchema>
 
 const cardinalitySchema = v.picklist(['ONE_TO_ONE', 'ONE_TO_MANY'])
+const foreignKeyConstraintSchema = v.picklist([
+  'CASCADE',
+  'RESTRICT',
+  'SET NULL',
+  'SET DEFAULT',
+  'NO ACTION',
+])
 
 const relationshipSchema = v.object({
   name: relationshipNameSchema,
@@ -52,8 +59,8 @@ const relationshipSchema = v.object({
   foreignTableName: tableNameSchema,
   foreignColumnName: columnNameSchema,
   cardinality: cardinalitySchema,
-  updateConstraint: v.string(),
-  deleteConstraint: v.string(),
+  updateConstraint: foreignKeyConstraintSchema,
+  deleteConstraint: foreignKeyConstraintSchema,
 })
 export type Relationship = v.InferOutput<typeof relationshipSchema>
 

--- a/frontend/packages/db-structure/src/schema/dbStructure.ts
+++ b/frontend/packages/db-structure/src/schema/dbStructure.ts
@@ -47,9 +47,9 @@ const cardinalitySchema = v.picklist(['ONE_TO_ONE', 'ONE_TO_MANY'])
 const foreignKeyConstraintSchema = v.picklist([
   'CASCADE',
   'RESTRICT',
-  'SET NULL',
-  'SET DEFAULT',
-  'NO ACTION',
+  'SET_NULL',
+  'SET_DEFAULT',
+  'NO_ACTION',
 ])
 
 export type ForeignKeyConstraint = v.InferOutput<

--- a/frontend/packages/db-structure/src/schema/factories.ts
+++ b/frontend/packages/db-structure/src/schema/factories.ts
@@ -2,6 +2,7 @@ import type {
   Column,
   DBStructure,
   Index,
+  Relationship,
   Table,
   Tables,
 } from './dbStructure.js'
@@ -35,6 +36,20 @@ export const anIndex = (override?: Partial<Index>): Index => ({
   name: '',
   unique: false,
   columns: [],
+  ...override,
+})
+
+export const aRelationship = (
+  override?: Partial<Relationship>,
+): Relationship => ({
+  name: '',
+  primaryTableName: '',
+  primaryColumnName: '',
+  foreignTableName: '',
+  foreignColumnName: '',
+  cardinality: 'ONE_TO_MANY',
+  updateConstraint: 'NO ACTION',
+  deleteConstraint: 'NO ACTION',
   ...override,
 })
 

--- a/frontend/packages/db-structure/src/schema/factories.ts
+++ b/frontend/packages/db-structure/src/schema/factories.ts
@@ -48,8 +48,8 @@ export const aRelationship = (
   foreignTableName: '',
   foreignColumnName: '',
   cardinality: 'ONE_TO_MANY',
-  updateConstraint: 'NO ACTION',
-  deleteConstraint: 'NO ACTION',
+  updateConstraint: 'NO_ACTION',
+  deleteConstraint: 'NO_ACTION',
   ...override,
 })
 

--- a/frontend/packages/db-structure/src/schema/index.ts
+++ b/frontend/packages/db-structure/src/schema/index.ts
@@ -9,6 +9,7 @@ export type {
   Relationships,
   Index,
   Indices,
+  ForeignKeyConstraint,
 } from './dbStructure.js'
 export {
   aColumn,

--- a/frontend/packages/db-structure/src/schema/index.ts
+++ b/frontend/packages/db-structure/src/schema/index.ts
@@ -10,4 +10,10 @@ export type {
   Index,
   Indices,
 } from './dbStructure.js'
-export { aColumn, aTable, aDBStructure, anIndex } from './factories.js'
+export {
+  aColumn,
+  aTable,
+  aDBStructure,
+  anIndex,
+  aRelationship,
+} from './factories.js'


### PR DESCRIPTION
## Summary

Add foreign key parsing for schemarb parser.

## Related Issue

For postgres paser:

* https://github.com/liam-hq/liam/pull/131

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information

Two patterns of notation for foreign key constraints in schema.rb

1️⃣: Foreign key constraints at the same time as table creation

```rb
create_table :products do |t|
  t.references :category, foreign_key: true
end
```

2️⃣: Foreign key constraints after table creation

```rb
add_foreign_key :articles, :authors
```

I looked through several Rails projects and they are all written in  2️⃣.

https://github.com/mastodon/mastodon/blob/main/db/schema.rb
https://github.com/autolab/Autolab/blob/master/db/schema.rb
https://github.com/lobsters/lobsters/blob/master/db/schema.rb
https://github.com/astuto/astuto/blob/main/db/schema.rb
https://github.com/chatwoot/chatwoot/blob/develop/db/schema.rb

It would be good to support  2️⃣ first.
If we find a project that uses  1️⃣, we can support that as well.
