### PR TITLE
fix: display selected table name

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.tsx
@@ -17,7 +17,7 @@ export const TableDetail: FC<Props> = ({ table }) => {
     <section className={styles.wrapper}>
       <div className={styles.header}>
         <DrawerTitle asChild>
-          <h1 className={styles.heading}>Table Name</h1>
+          <h1 className={styles.heading}>{table.name}</h1>
         </DrawerTitle>
         <DrawerClose>
           <IconButton icon={<XIcon />} tooltipContent="Close" />


### PR DESCRIPTION
I fixed it so that the table name of the selected TableNode is displayed, as previously all TableNodes showed only 'Table Name' regardless of which one was selected.