### PR TITLE
feat: Add label in ShowModeMenu

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Toolbar/ShowModeMenu/ShowModeMenu.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Toolbar/ShowModeMenu/ShowModeMenu.module.css
@@ -1,6 +1,17 @@
 .wrapper {
   display: grid;
   grid-auto-flow: column;
+  gap: var(--spacing-1);
+  align-items: center;
+}
+
+.label {
+  color: var(--overlay-60);
+  font-family: var(--main-font);
+  font-size: var(--font-size-3);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
 }
 
 .content {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Toolbar/ShowModeMenu/ShowModeMenu.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Toolbar/ShowModeMenu/ShowModeMenu.tsx
@@ -34,6 +34,7 @@ export const ShowModeMenu: FC = () => {
 
   return (
     <div className={styles.wrapper}>
+      <span className={styles.label}>show</span>
       <DropdownMenuRoot>
         <DropdownMenuTrigger>
           <Button
@@ -47,7 +48,7 @@ export const ShowModeMenu: FC = () => {
         <DropdownMenuPortal>
           <DropdownMenuContent
             className={styles.content}
-            align="end"
+            align="start"
             side="bottom"
             sideOffset={12}
           >


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I fixed an oversight in ShowModeMenu by adding the display of label text. 🙏 

| Before | After |
|--------|--------|
|<img width="1113" alt="スクリーンショット 2024-12-06 15 10 55" src="https://github.com/user-attachments/assets/759b6893-d919-4a1e-bfee-e31c150ee369"> |<img width="1114" alt="スクリーンショット 2024-12-06 15 09 04" src="https://github.com/user-attachments/assets/c4008888-b29f-4d1d-af24-cc70b61dd9e9"> | 
