### PR TITLE
feat: Adjust animation-duration for TableDetail toggle to 165ms

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
@@ -63,6 +63,11 @@
   bottom: 0;
 }
 
+.content[data-vaul-drawer] {
+  transition-duration: 165ms;
+  animation-duration: 165ms;
+}
+
 .handle {
   top: auto;
 }


### PR DESCRIPTION
I adjusted the animation-duration for showing and hiding the TableDetail to 165ms.