### PR TITLE
maintenance: enhance parser test cases 2

### DIFF
--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -32,4 +32,13 @@ export const parserTestCases = {
   'table comment': userTable({
     comment: 'store our users.',
   }),
+  'not null': userTable({
+    columns: {
+      name: aColumn({
+        name: 'name',
+        type: 'varchar',
+        notNull: true,
+      }),
+    },
+  }),
 }

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -58,5 +58,14 @@ export const parserTestCases = {
         default: "user's description",
       }),
     },
-  })
+  }),
+  'default value as integer': userTable({
+    columns: {
+      age: aColumn({
+        name: 'age',
+        type: 'int4',
+        default: 30,
+      }),
+    },
+  }),
 }

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -68,4 +68,13 @@ export const parserTestCases = {
       }),
     },
   }),
+  'default value as boolean': userTable({
+    columns: {
+      active: aColumn({
+        name: 'active',
+        type: 'bool',
+        default: true,
+      }),
+    },
+  })
 }

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -41,4 +41,16 @@ export const parserTestCases = {
       }),
     },
   }),
+  nullable: userTable({
+    columns: {
+      description: aColumn({
+        name: 'description',
+        type: 'text',
+        notNull: false,
+      }),
+    },
+  }),
+  'default value as string': userTable({
+
+  })
 }

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -76,5 +76,14 @@ export const parserTestCases = {
         default: true,
       }),
     },
-  })
+  }),
+  unique: userTable({
+    columns: {
+      mention: aColumn({
+        name: 'mention',
+        type: 'text',
+        unique: true,
+      }),
+    },
+  }),
 }

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -51,6 +51,12 @@ export const parserTestCases = {
     },
   }),
   'default value as string': userTable({
-
+    columns: {
+      description: aColumn({
+        name: 'description',
+        type: 'text',
+        default: "user's description",
+      }),
+    },
   })
 }

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -56,6 +56,7 @@ describe(processor, () => {
         columns: {
           name: aColumn({
             name: 'name',
+            // TODO: `t.string` should be converted to varchar for PostgreSQL
             type: 'string',
             notNull: true,
           }),

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -97,6 +97,7 @@ describe(processor, () => {
         columns: {
           age: aColumn({
             name: 'age',
+            // TODO: `t.integer` should be converted to int4 for PostgreSQL
             type: 'integer',
             notNull: false,
             default: 30,

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -69,21 +69,11 @@ describe(processor, () => {
     it('nullable', async () => {
       const result = await processor(/* Ruby */ `
         create_table "users" do |t|
-          t.string "name", null: true
+          t.text "description", null: true
         end
       `)
 
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'string',
-            notNull: false,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
+      expect(result).toEqual(parserTestCases.nullable)
     })
 
     it('default value as string', async () => {

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -130,6 +130,16 @@ describe(processor, () => {
       expect(result).toEqual(expected)
     })
 
+    it('unique', async () => {
+      const result = await processor(/* Ruby */ `
+        create_table "users" do |t|
+          t.text "mention", unique: true
+        end
+      `)
+
+      expect(result).toEqual(parserTestCases.unique)
+    })
+
     it('primary key as args', async () => {
       const result = await processor(/* Ruby */ `
         create_table "users", id: :bigint
@@ -142,26 +152,6 @@ describe(processor, () => {
             type: 'bigint',
             notNull: true,
             primary: true,
-            unique: true,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
-    })
-
-    it('unique', async () => {
-      const result = await processor(/* Ruby */ `
-        create_table "users" do |t|
-          t.string "name", unique: true
-        end
-      `)
-
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'string',
             unique: true,
           }),
         },

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -119,6 +119,7 @@ describe(processor, () => {
         columns: {
           active: aColumn({
             name: 'active',
+            // TODO: `t.boolean` should be converted to bool for PostgreSQL
             type: 'boolean',
             notNull: false,
             default: true,

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -79,22 +79,11 @@ describe(processor, () => {
     it('default value as string', async () => {
       const result = await processor(/* Ruby */ `
         create_table "users" do |t|
-          t.string "name", default: "new user", null: true
+          t.text "description", default: "user's description", null: true
         end
       `)
 
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'string',
-            notNull: false,
-            default: 'new user',
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
+      expect(result).toEqual(parserTestCases['default value as string'])
     })
 
     it('default value as integer', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -60,13 +60,11 @@ describe(processor, () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255)
+          description TEXT
         );
       `)
 
-      const expected = userTable()
-
-      expect(result).toEqual(expected)
+      expect(result).toEqual(parserTestCases.nullable)
     })
 
     it('unique', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -104,21 +104,11 @@ describe(processor, () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255) UNIQUE
+          mention TEXT UNIQUE
         );
       `)
 
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'varchar',
-            unique: true,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
+      expect(result).toEqual(parserTestCases.unique)
     })
 
     it('should parse foreign keys to one-to-many relationships', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -89,6 +89,17 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases['default value as integer'])
     })
 
+    it('default value as boolean', async () => {
+      const result = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          active BOOLEAN DEFAULT TRUE
+        );
+      `)
+
+      expect(result).toEqual(parserTestCases['default value as boolean'])
+    })
+
     it('unique', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (
@@ -103,28 +114,6 @@ describe(processor, () => {
             name: 'name',
             type: 'varchar',
             unique: true,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
-    })
-
-    it('default value as boolean', async () => {
-      const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255),
-          active BOOLEAN DEFAULT TRUE
-        );
-      `)
-
-      const expected = userTable({
-        columns: {
-          active: aColumn({
-            name: 'active',
-            type: 'bool',
-            default: true,
           }),
         },
       })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -67,6 +67,17 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases.nullable)
     })
 
+    it('default value as string', async () => {
+      const result = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          description TEXT DEFAULT 'user''s description'
+        );
+      `)
+
+      expect(result).toEqual(parserTestCases['default value as string'])
+    })
+
     it('unique', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (
@@ -81,27 +92,6 @@ describe(processor, () => {
             name: 'name',
             type: 'varchar',
             unique: true,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
-    })
-
-    it('default value as varchar', async () => {
-      const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255) DEFAULT 'new user'
-        );
-      `)
-
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'varchar',
-            default: 'new user',
           }),
         },
       })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -53,17 +53,7 @@ describe(processor, () => {
         );
       `)
 
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'varchar',
-            notNull: true,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
+      expect(result).toEqual(parserTestCases['not null'])
     })
 
     it('nullable', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -78,6 +78,17 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases['default value as string'])
     })
 
+    it('default value as integer', async () => {
+      const result = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          age INTEGER DEFAULT 30
+        );
+      `)
+
+      expect(result).toEqual(parserTestCases['default value as integer'])
+    })
+
     it('unique', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (
@@ -92,28 +103,6 @@ describe(processor, () => {
             name: 'name',
             type: 'varchar',
             unique: true,
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
-    })
-
-    it('default value as integer', async () => {
-      const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255),
-          age INTEGER DEFAULT 30
-        );
-      `)
-
-      const expected = userTable({
-        columns: {
-          age: aColumn({
-            name: 'age',
-            type: 'int4',
-            default: 30,
           }),
         },
       })


### PR DESCRIPTION
The commonisation of test cases implemented at https://github.com/liam-hq/liam/pull/169 is reflected in some of the tests
This is still a work in progress and has not been reflected in all test cases.

- **test: Add test case for 'not null' column in parser tests**
- **test: Add test cases for nullable columns in parser tests**
- **test: Add test cases for default value as string columns in parser tests**
- **test: Add test cases for default value as integer columns in parser tests**
- **test: Add test cases for default value as boolean columns in parser tests**
- **test: Add test cases for unique constraints columns in parser tests**
