### PR TITLE
Add foreign key parsing for postgres parser

### DIFF
--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -165,13 +165,8 @@ describe(processor, () => {
       expect(result).toEqual(expected)
     })
 
-    it('should parse foreign keys to one-to-many relationships', async () => {
+    it('foreign keys by create table', async () => {
       const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255)
-        );
-
         CREATE TABLE posts (
           id BIGSERIAL PRIMARY KEY,
           user_id INT REFERENCES users(id)
@@ -194,13 +189,8 @@ describe(processor, () => {
       expect(result.relationships).toEqual(expectedRelationships)
     })
 
-    it('should parse foreign keys and unique index to one-to-one relationships', async () => {
+    it('unique foreign keys by create table', async () => {
       const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255)
-        );
-
         CREATE TABLE posts (
           id BIGSERIAL PRIMARY KEY,
           user_id INT REFERENCES users(id) UNIQUE


### PR DESCRIPTION
## Summary

Support foreign key parsing for postgres parser.

Supported format in this pr.

```sql
CREATE TABLE posts (
    id SERIAL PRIMARY KEY,
    user_id INT NOT NULL
);

ALTER TABLE posts
ADD CONSTRAINT fk_posts_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL;
```

## Related Issue

* https://github.com/liam-hq/liam/pull/131
* https://github.com/liam-hq/liam/pull/167


## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
