### PR TITLE
feat: parse one to one relationships for schema.rb

### DIFF
--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -220,5 +220,28 @@ describe(processor, () => {
 
       expect(result.relationships).toEqual(expected)
     })
+
+    it('unique foreign key', async () => {
+      const result = await processor(/* Ruby */ `
+        create_table "posts" do |t|
+          t.bigint "user_id", unique: true
+        end
+
+        add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id"
+      `)
+
+      const rel = aRelationship({
+        name: 'fk_posts_user_id',
+        primaryTableName: 'users',
+        primaryColumnName: 'id',
+        foreignTableName: 'posts',
+        foreignColumnName: 'user_id',
+        cardinality: 'ONE_TO_ONE',
+      })
+
+      const expected = { fk_posts_user_id: rel }
+
+      expect(result.relationships).toEqual(expected)
+    })
   })
 })

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -22,27 +22,12 @@ import type {
   Index,
   Indices,
   Relationship,
-  Relationships,
   Table,
   Tables,
 } from '../../schema/index.js'
 import { aColumn, aRelationship, aTable, anIndex } from '../../schema/index.js'
 import type { Processor } from '../types.js'
-
-// If there is a unique index for a column in relationships, make it `ONE_TO_ONE` cardinality.
-const handleOneToOneRelationships = (
-  tables: Tables,
-  relationships: Relationships,
-) => {
-  for (const relationship of Object.values(relationships)) {
-    const foreignTable = tables[relationship.foreignTableName]
-    const foreignColumn = foreignTable?.columns[relationship.foreignColumnName]
-
-    if (foreignColumn?.unique) {
-      relationship.cardinality = 'ONE_TO_ONE'
-    }
-  }
-}
+import { handleOneToOneRelationships } from '../utils/index.js'
 
 function extractTableName(argNodes: Node[]): string {
   const nameNode = argNodes.find((node) => node instanceof StringNode)

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -22,11 +22,27 @@ import type {
   Index,
   Indices,
   Relationship,
+  Relationships,
   Table,
   Tables,
 } from '../../schema/index.js'
 import { aColumn, aRelationship, aTable, anIndex } from '../../schema/index.js'
 import type { Processor } from '../types.js'
+
+// If there is a unique index for a column in relationships, make it `ONE_TO_ONE` cardinality.
+const handleOneToOneRelationships = (
+  tables: Tables,
+  relationships: Relationships,
+) => {
+  for (const relationship of Object.values(relationships)) {
+    const foreignTable = tables[relationship.foreignTableName]
+    const foreignColumn = foreignTable?.columns[relationship.foreignColumnName]
+
+    if (foreignColumn?.unique) {
+      relationship.cardinality = 'ONE_TO_ONE'
+    }
+  }
+}
 
 function extractTableName(argNodes: Node[]): string {
   const nameNode = argNodes.find((node) => node instanceof StringNode)
@@ -313,6 +329,7 @@ class DBStructureFinder extends Visitor {
         {} as Record<string, Relationship>,
       ),
     }
+    handleOneToOneRelationships(dbStructure.tables, dbStructure.relationships)
     return dbStructure
   }
 

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
@@ -12,26 +12,10 @@ import type {
   DBStructure,
   ForeignKeyConstraint,
   Relationship,
-  Relationships,
   Table,
-  Tables,
 } from '../../../schema/index.js'
+import { handleOneToOneRelationships } from '../../utils/index.js'
 import type { RawStmtWrapper } from './parser.js'
-
-// If there is a unique index for a column in relationships, make it `ONE_TO_ONE` cardinality.
-const handleOneToOneRelationships = (
-  tables: Tables,
-  relationships: Relationships,
-) => {
-  for (const relationship of Object.values(relationships)) {
-    const foreignTable = tables[relationship.foreignTableName]
-    const foreignColumn = foreignTable?.columns[relationship.foreignColumnName]
-
-    if (foreignColumn?.unique) {
-      relationship.cardinality = 'ONE_TO_ONE'
-    }
-  }
-}
 
 // Transform function for AST to DBStructure
 export const convertToDBStructure = (ast: RawStmtWrapper[]): DBStructure => {

--- a/frontend/packages/db-structure/src/parser/utils/handleOneToOneRelationships.ts
+++ b/frontend/packages/db-structure/src/parser/utils/handleOneToOneRelationships.ts
@@ -1,0 +1,16 @@
+import type { Relationships, Tables } from '../../schema/index.js'
+
+// If there is a unique index for a column in relationships, make it `ONE_TO_ONE` cardinality.
+export const handleOneToOneRelationships = (
+  tables: Tables,
+  relationships: Relationships,
+) => {
+  for (const relationship of Object.values(relationships)) {
+    const foreignTable = tables[relationship.foreignTableName]
+    const foreignColumn = foreignTable?.columns[relationship.foreignColumnName]
+
+    if (foreignColumn?.unique) {
+      relationship.cardinality = 'ONE_TO_ONE'
+    }
+  }
+}

--- a/frontend/packages/db-structure/src/parser/utils/index.ts
+++ b/frontend/packages/db-structure/src/parser/utils/index.ts
@@ -1,0 +1,1 @@
+export { handleOneToOneRelationships } from './handleOneToOneRelationships.js'


### PR DESCRIPTION
## Summary

Support `ONE_TO_ONE` cardinality for schema.rb parser.

If foreign key is unique, it must be one to one relationship.

```ruby
create_table "posts" do |t|
  t.bigint "user_id", unique: true
end

add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id"
```

## Related Issue

* https://github.com/liam-hq/liam/pull/166

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
