### PR TITLE
Map ActiveRecord column types to PostgreSQL equivalents

### DIFF
--- a/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
+++ b/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
@@ -115,7 +115,7 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
           "name": "age",
           "notNull": false,
           "primary": false,
-          "type": "string",
+          "type": "varchar",
           "unique": false,
         },
         "company_id": {
@@ -135,7 +135,7 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
           "name": "created_at",
           "notNull": true,
           "primary": false,
-          "type": "datetime",
+          "type": "timestamp",
           "unique": false,
         },
         "id": {
@@ -155,7 +155,7 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
           "name": "is_deleted",
           "notNull": false,
           "primary": false,
-          "type": "string",
+          "type": "varchar",
           "unique": false,
         },
         "name": {
@@ -165,7 +165,7 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
           "name": "name",
           "notNull": false,
           "primary": false,
-          "type": "string",
+          "type": "varchar",
           "unique": false,
         },
         "user_name": {
@@ -175,7 +175,7 @@ exports[`parse > should parse schema.rb to JSON correctly 1`] = `
           "name": "user_name",
           "notNull": true,
           "primary": false,
-          "type": "string",
+          "type": "varchar",
           "unique": false,
         },
       },

--- a/frontend/packages/db-structure/src/parser/schemarb/convertColumnType.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/convertColumnType.ts
@@ -1,0 +1,51 @@
+// https://github.com/rails/rails/blob/v8.0.0/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L134-L179
+const mapping: Record<string, string> = {
+  // primary_key: // should be handled separately
+  string: 'varchar',
+  text: 'text',
+  integer: 'integer',
+  bigint: 'bigint',
+  float: 'float',
+  decimal: 'decimal',
+  datetime: 'timestamp', // set dynamically based on datetime_type, and default is 'timestamp' https://github.com/rails/rails/pull/41084
+  timestamp: 'timestamp',
+  timestamptz: 'timestamptz',
+  time: 'time',
+  date: 'date',
+  daterange: 'daterange',
+  numrange: 'numrange',
+  tsrange: 'tsrange',
+  tstzrange: 'tstzrange',
+  int4range: 'int4range',
+  int8range: 'int8range',
+  binary: 'bytea',
+  boolean: 'boolean',
+  xml: 'xml',
+  tsvector: 'tsvector',
+  hstore: 'hstore',
+  inet: 'inet',
+  cidr: 'cidr',
+  macaddr: 'macaddr',
+  uuid: 'uuid',
+  json: 'json',
+  jsonb: 'jsonb',
+  ltree: 'ltree',
+  citext: 'citext',
+  point: 'point',
+  line: 'line',
+  lseg: 'lseg',
+  box: 'box',
+  path: 'path',
+  polygon: 'polygon',
+  circle: 'circle',
+  bit: 'bit',
+  bit_varying: 'bit varying',
+  money: 'money',
+  interval: 'interval',
+  oid: 'oid',
+  // enum: // special type. should be handled separately
+}
+
+export function convertColumnType(schemarbType: string): string {
+  return mapping[schemarbType] || schemarbType
+}

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -56,8 +56,7 @@ describe(processor, () => {
         columns: {
           name: aColumn({
             name: 'name',
-            // TODO: `t.string` should be converted to varchar for PostgreSQL
-            type: 'string',
+            type: 'varchar',
             notNull: true,
           }),
         },
@@ -191,7 +190,7 @@ describe(processor, () => {
         columns: {
           name: aColumn({
             name: 'name',
-            type: 'string',
+            type: 'varchar',
             comment: 'this is name',
           }),
         },

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -28,6 +28,7 @@ import type {
 import { aColumn, aRelationship, aTable, anIndex } from '../../schema/index.js'
 import type { Processor } from '../types.js'
 import { handleOneToOneRelationships } from '../utils/index.js'
+import { convertColumnType } from './convertColumnType.js'
 
 function extractTableName(argNodes: Node[]): string {
   const nameNode = argNodes.find((node) => node instanceof StringNode)
@@ -122,7 +123,7 @@ function extractTableDetails(blockNodes: Node[]): [Column[], Index[]] {
 function extractColumnDetails(node: CallNode): Column {
   const column = aColumn({
     name: '',
-    type: node.name,
+    type: convertColumnType(node.name),
   })
 
   const argNodes = node.arguments_?.compactChildNodes() || []


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

- Updated snapshots and test cases to reflect the converted column types, e.g., `string` -> `varchar`, `datetime` -> `timestamp`.


<img width="300" alt="2024-12-06 22 00 10" src="https://github.com/user-attachments/assets/45848a1b-2396-49c6-8ece-a66555f47bff">


- Added `convertColumnType` function to map Rails schema.rb types to PostgreSQL column types, aligning with ActiveRecord::ConnectionAdapters implementation.


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
