### PR TITLE
maintenance: enhance parser test cases 3

### DIFF
--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -110,4 +110,18 @@ export const parserTestCases = {
       }),
     },
   }),
+  'index (unique: true)': userTable({
+    columns: {
+      email: aColumn({
+        name: 'email',
+      }),
+    },
+    indices: {
+      index_users_on_email: anIndex({
+        name: 'index_users_on_email',
+        unique: true,
+        columns: ['email'],
+      }),
+    },
+  }),
 }

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -32,6 +32,15 @@ export const parserTestCases = {
   'table comment': userTable({
     comment: 'store our users.',
   }),
+  'column comment': userTable({
+    columns: {
+      description: aColumn({
+        name: 'description',
+        type: 'text',
+        comment: 'this is description',
+      }),
+    },
+  }),
   'not null': userTable({
     columns: {
       name: aColumn({

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -3,6 +3,7 @@ import {
   aColumn,
   aDBStructure,
   aTable,
+  anIndex,
 } from '../../schema/index.js'
 
 const userTable = (override?: Partial<Table>) =>
@@ -92,6 +93,20 @@ export const parserTestCases = {
         name: 'mention',
         type: 'text',
         unique: true,
+      }),
+    },
+  }),
+  'index (unique: false)': userTable({
+    columns: {
+      email: aColumn({
+        name: 'email',
+      }),
+    },
+    indices: {
+      index_users_on_id_and_email: anIndex({
+        name: 'index_users_on_id_and_email',
+        unique: false,
+        columns: ['id', 'email'],
       }),
     },
   }),

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -45,6 +45,16 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases['table comment'])
     })
 
+    it('column comment', async () => {
+      const result = await processor(/* Ruby */ `
+        create_table "users" do |t|
+          t.text "description", comment: 'this is description'
+        end
+      `)
+
+      expect(result).toEqual(parserTestCases['column comment'])
+    })
+
     it('not null', async () => {
       const result = await processor(/* Ruby */ `
         create_table "users" do |t|
@@ -172,26 +182,6 @@ describe(processor, () => {
             name: 'index_users_on_id_and_email',
             unique: true,
             columns: ['id', 'email'],
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
-    })
-
-    it('column comment', async () => {
-      const result = await processor(/* Ruby */ `
-        create_table "users" do |t|
-          t.string "name", comment: 'this is name'
-        end
-      `)
-
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'varchar',
-            comment: 'this is name',
           }),
         },
       })

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -180,6 +180,17 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases['index (unique: false)'])
     })
 
+    it('index (unique: true)', async () => {
+      const result = await processor(/* Ruby */ `
+        create_table "users" do |t|
+          t.string "email"
+          t.index ["email"], name: "index_users_on_email", unique: true
+        end
+      `)
+
+      expect(result).toEqual(parserTestCases['index (unique: true)'])
+    })
+
     it('foreign key', async () => {
       const result = await processor(/* Ruby */ `
         add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -5,7 +5,6 @@ import {
   aDBStructure,
   aRelationship,
   aTable,
-  anIndex,
 } from '../../schema/index.js'
 import { processor } from './index.js'
 

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -169,24 +169,15 @@ describe(processor, () => {
       expect(result).toEqual(expected)
     })
 
-    it('index', async () => {
+    it('index (unique: false)', async () => {
       const result = await processor(/* Ruby */ `
         create_table "users" do |t|
-          t.index [ "id", "email" ], name: "index_users_on_id_and_email", unique: true
+          t.string "email"
+          t.index [ "id", "email" ], name: "index_users_on_id_and_email"
         end
       `)
 
-      const expected = userTable({
-        indices: {
-          index_users_on_id_and_email: anIndex({
-            name: 'index_users_on_id_and_email',
-            unique: true,
-            columns: ['id', 'email'],
-          }),
-        },
-      })
-
-      expect(result).toEqual(expected)
+      expect(result).toEqual(parserTestCases['index (unique: false)'])
     })
 
     it('foreign key', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -1,39 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import type { Table } from '../../../schema/index.js'
-import { aColumn, aDBStructure, aTable } from '../../../schema/index.js'
 import { parserTestCases } from '../../__tests__/index.js'
 import { processor } from './index.js'
 
 describe(processor, () => {
   describe('should parse create_table correctly', () => {
-    const userTable = (override?: Partial<Table>) =>
-      aDBStructure({
-        tables: {
-          users: aTable({
-            name: 'users',
-            columns: {
-              id: aColumn({
-                name: 'id',
-                type: 'bigserial',
-                notNull: true,
-                primary: true,
-                unique: true,
-              }),
-              name: aColumn({
-                name: 'name',
-                type: 'varchar',
-                notNull: false,
-              }),
-              ...override?.columns,
-            },
-            indices: {
-              ...override?.indices,
-            },
-            comment: override?.comment ?? null,
-          }),
-        },
-      })
-
     it('table comment', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -123,6 +123,19 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases.unique)
     })
 
+    it('index (unique: false)', async () => {
+      const result = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          email VARCHAR(255)
+        );
+
+        CREATE INDEX index_users_on_id_and_email ON public.users USING btree (id, email);
+      `)
+
+      expect(result).toEqual(parserTestCases['index (unique: false)'])
+    })
+
     it('foreign keys by create table', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE posts (
@@ -250,29 +263,6 @@ describe(processor, () => {
       }
 
       expect(result.relationships).toEqual(expectedRelationships)
-    })
-
-    it('index', async () => {
-      const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255)
-        );
-
-        CREATE INDEX index_users_on_id_and_name ON public.users USING btree (id, name);
-      `)
-
-      const expected = userTable({
-        indices: {
-          index_users_on_id_and_name: {
-            name: 'index_users_on_id_and_name',
-            unique: false,
-            columns: ['id', 'name'],
-          },
-        },
-      })
-
-      expect(result).toEqual(expected)
     })
 
     it('unique index', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -136,6 +136,19 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases['index (unique: false)'])
     })
 
+    it('index (unique: true)', async () => {
+      const result = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          email VARCHAR(255)
+        );
+
+        CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+      `)
+
+      expect(result).toEqual(parserTestCases['index (unique: true)'])
+    })
+
     it('foreign keys by create table', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE posts (
@@ -263,29 +276,6 @@ describe(processor, () => {
       }
 
       expect(result.relationships).toEqual(expectedRelationships)
-    })
-
-    it('unique index', async () => {
-      const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255)
-        );
-
-        CREATE UNIQUE INDEX index_users_on_id_and_name ON public.users USING btree (id, name);
-      `)
-
-      const expected = userTable({
-        indices: {
-          index_users_on_id_and_name: {
-            name: 'index_users_on_id_and_name',
-            unique: true,
-            columns: ['id', 'name'],
-          },
-        },
-      })
-
-      expect(result).toEqual(expected)
     })
   })
 })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -45,6 +45,18 @@ describe(processor, () => {
       expect(result).toEqual(parserTestCases['table comment'])
     })
 
+    it('column commnet', async () => {
+      const result = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          description TEXT
+        );
+        COMMENT ON COLUMN users.description IS 'this is description';
+      `)
+
+      expect(result).toEqual(parserTestCases['column comment'])
+    })
+
     it('not null', async () => {
       const result = await processor(/* sql */ `
         CREATE TABLE users (
@@ -280,28 +292,6 @@ describe(processor, () => {
             unique: true,
             columns: ['id', 'name'],
           },
-        },
-      })
-
-      expect(result).toEqual(expected)
-    })
-
-    it('column commnet', async () => {
-      const result = await processor(/* sql */ `
-        CREATE TABLE users (
-          id BIGSERIAL PRIMARY KEY,
-          name VARCHAR(255)
-        );
-        COMMENT ON COLUMN users.name IS 'this is name';
-      `)
-
-      const expected = userTable({
-        columns: {
-          name: aColumn({
-            name: 'name',
-            type: 'varchar',
-            comment: 'this is name',
-          }),
         },
       })
 


### PR DESCRIPTION
The commonisation of test cases implemented at https://github.com/liam-hq/liam/pull/169, https://github.com/liam-hq/liam/pull/181 are reflected in some of the tests
This is still a work in progress and has not been reflected in all test cases.


- **test: Add test case for 'column comment' in parser tests**
- **test: Add test case for 'index (unique: false)' in parser tests**
- **test: Add test case for 'index (unique: true)' in parser tests**
- **test: Remove unused userTable setup in PostgreSQL index tests**
