### PR TITLE
Rename Actions secret and variable

### DIFF
--- a/.github/workflows/license-frontend.yml
+++ b/.github/workflows/license-frontend.yml
@@ -35,8 +35,8 @@ jobs:
         if: steps.fork-check.outputs.is_fork != 'true'
         id: app-token
         with:
-          app-id: ${{ vars.CI_TRIGGER_APP_ID }}
-          private-key: ${{ secrets.CI_TRIGGER_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.LICENSE_CI_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.LICENSE_CI_TRIGGER_APP_PRIVATE_KEY }}
       - name: Checkout code for non-fork PRs
         if: steps.fork-check.outputs.is_fork != 'true'
         uses: actions/checkout@v4

--- a/frontend/docs/packages-license.md
+++ b/frontend/docs/packages-license.md
@@ -1,6 +1,6 @@
 # frontend
 
-As of December  6, 2024  6:26am. 1019 total
+As of December  9, 2024  7:46am. 1019 total
 
 ## Summary
 * 887 MIT


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
I have chosen a generic name so that it can be used with other CI triggers, but I would like to change it to a specific name because I feel that it mixes up the usage and induces over-authorization.

I have already created `vars.LICENSE_CI_TRIGGER_APP_ID` and `secrets.LICENSE_CI_TRIGGER_APP_PRIVATE_KEY`.

* https://github.com/liam-hq/liam/settings/variables/actions
* https://github.com/liam-hq/liam/settings/secrets/actions

## Related Issue
<!-- Mention the related issue number if applicable. -->
Nothing

## Testing
<!-- Briefly describe the testing steps or results. -->
✅ https://github.com/liam-hq/liam/actions/runs/12231131566

## Other Information
<!-- Add any other relevant information for the reviewer. -->

After this PR is merged, I will remove the variable and secret.

* `vars.CI_TRIGGER_APP_ID`
* `secrets.CI_TRIGGER_APP_PRIVATE_KEY`
