### PR TITLE
Permit Eclipse 2.0 License

### DIFF
--- a/frontend/config/dependency_decisions.yml
+++ b/frontend/config/dependency_decisions.yml
@@ -95,3 +95,9 @@
     :why: Compatible with Apache-2.0 license. See https://opensource.org/license/mpl-2-0
     :versions: []
     :when: 2024-11-29 09:12:22.146432000 Z
+- - :permit
+  - Eclipse 2.0
+  - :who: OSPO @masutaka
+    :why: Compatible with Apache-2.0 license. See https://opensource.org/license/epl-2-0
+    :versions: []
+    :when: 2024-12-09 09:29:53.604007000 Z

--- a/frontend/docs/packages-license.md
+++ b/frontend/docs/packages-license.md
@@ -1,6 +1,6 @@
 # frontend
 
-As of December  9, 2024  7:46am. 1019 total
+As of December  9, 2024  9:37am. 1020 total
 
 ## Summary
 * 887 MIT
@@ -18,6 +18,7 @@ As of December  9, 2024  7:46am. 1019 total
 * 1 (BSD-2-Clause OR MIT OR Apache-2.0)
 * 1 CC0 1.0 Universal
 * 1 Public Domain
+* 1 Eclipse 2.0
 * 1 CC-BY-4.0
 * 1 Mozilla Public License 2.0
 * 1 Python-2.0
@@ -4263,6 +4264,17 @@ CC-BY-4.0 permitted
 * /home/runner/work/liam/liam/frontend
 
 <a href="http://en.wikipedia.org/wiki/ISC_license">ISC</a> permitted
+
+
+
+<a name="elkjs"></a>
+### elkjs v0.9.3
+#### 
+
+##### Paths
+* /home/runner/work/liam/liam/frontend
+
+<a href="https://www.eclipse.org/legal/epl-v20.html">Eclipse 2.0</a> permitted
 
 
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

💡 This is a pull request to the https://github.com/liam-hq/liam/pull/179.

By introducing Eclipse 2.0 licensed packages with Apache-2.0 licensed OSS, It seems not to be any license conflicts.

## Other Information
<!-- Add any other relevant information for the reviewer. -->
* https://opensource.org/license/apache-2-0
* https://opensource.org/license/epl-2-0

When developing an open-source project under the Apache-2.0 license and considering the use of a package under the Eclipse Public License 2.0 (EPL-2.0), potential license conflicts need to be carefully evaluated. Here’s an analysis based on the license definitions:

1. Redistribution Conditions of EPL-2.0

If you are incorporating a package under the EPL-2.0 license, the entire software does not need to adopt the EPL-2.0 license. However, if you modify and redistribute code governed by EPL-2.0, those modifications must remain under EPL-2.0.
* EPL-2.0 is a Weak Copyleft license, meaning its effects apply only to the modified portions of the code.
* If EPL-2.0 code is used as an “independent module,” it does not impose its licensing terms on other parts of the project.

2. Redistribution Conditions of Apache-2.0

The Apache-2.0 license imposes certain conditions, but these are not as restrictive as EPL-2.0. When incorporating Apache-2.0 code, the following requirements must be met:
* Include a copy of the license file.
* As long as the Apache-2.0 requirements are satisfied, combining it with code under other licenses is permitted.

3. Compatibility Between EPL-2.0 and Apache-2.0

Section 7(c) of EPL-2.0 explicitly permits the inclusion of Apache-2.0 licensed code in an EPL-2.0 project. Therefore, there are no issues when using Apache-2.0 code in an EPL-2.0 project.

However, the reverse—including EPL-2.0 code in an Apache-2.0 project—requires more attention.

4. Specific Points of Concern
* Modularity: If EPL-2.0 code is treated as an “independent module,” it can generally be used in an Apache-2.0 project without significant issues.
* Handling Modifications: If EPL-2.0 code is modified and redistributed, the modified portions must remain under the EPL-2.0 license. This may cause inconsistencies in licensing within an Apache-2.0 project.

5. Final Assessment

When including EPL-2.0 licensed code in an Apache-2.0 project, consider the following:
* Ensure that EPL-2.0 code is handled as a separate library or module.
* Clearly state the licensing conditions during redistribution.

While there is no direct conflict between the two licenses, care must be taken regarding redistribution and usage conditions.

If you have specific use cases or details about the dependencies involved, I can provide further advice tailored to your situation.
