### PR TITLE
Support FalseNode for id args

### DIFF
--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -168,6 +168,30 @@ describe(processor, () => {
       expect(result).toEqual(expected)
     })
 
+    it('no primary key', async () => {
+      const result = await processor(/* Ruby */ `
+        create_table "users", id: false do |t|
+          t.string "name"
+        end
+      `)
+
+      const expected = aDBStructure({
+        tables: {
+          users: aTable({
+            name: 'users',
+            columns: {
+              name: aColumn({
+                name: 'name',
+                type: 'varchar',
+              }),
+            },
+          }),
+        },
+      })
+
+      expect(result).toEqual(expected)
+    })
+
     it('index (unique: false)', async () => {
       const result = await processor(/* Ruby */ `
         create_table "users" do |t|

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -80,8 +80,14 @@ function extractIdColumn(argNodes: Node[]): Column | null {
     )
 
     if (idAssoc && idAssoc instanceof AssocNode) {
-      // @ts-expect-error: unescaped is defined as string but it is actually object
-      idColumn.type = idAssoc.value.unescaped.value
+      if (idAssoc.value instanceof FalseNode) return null
+      if (
+        idAssoc.value instanceof StringNode ||
+        idAssoc.value instanceof SymbolNode
+      )
+        // @ts-expect-error: unescaped is defined as string but it is actually object
+        idColumn.type = idAssoc.value.unescaped.value
+
       return idColumn
     }
   }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Support `FalseNode` for `create_table` `id` args.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Why we only support `FalseNode`:
<!-- Add any other relevant information for the reviewer. -->

`id: true` is not supported in Rails 8.0.0, so there's no need to support it.

schema.rb:

```ruby
create_table "users", id: true do |t|
  t.string "name"
end
```

Error occur:

```ruby
[ERROR] undefined method `to_sym' for true
```

Reason:

```ruby
def column(name, type, index: nil, **options)
  name = name.to_s
  type = type.to_sym if type # <-- This is the cause
end
```

https://github.com/rails/rails/blob/v8.0.0/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L490