### PR TITLE
feat: show warning errors when table name is not string

### DIFF
--- a/frontend/docs/packages-license.md
+++ b/frontend/docs/packages-license.md
@@ -1,9 +1,9 @@
 # frontend
 
-As of December 10, 2024  3:16am. 1020 total
+As of December  9, 2024 12:25pm. 1020 total
 
 ## Summary
-* 887 MIT
+* 888 MIT
 * 59 ISC
 * 30 Apache 2.0
 * 14 Simplified BSD
@@ -7846,6 +7846,17 @@ Public Domain manually approved
 
 
 
+<a name="neverthrow"></a>
+### neverthrow v8.1.1
+#### 
+
+##### Paths
+* /home/runner/work/liam/liam/frontend
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
 <a name="next"></a>
 ### next v15.0.3
 #### 
@@ -11257,5 +11268,3 @@ Unknown manually approved
 * /home/runner/work/liam/liam/frontend
 
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-

--- a/frontend/packages/cli/src/cli/runPreprocess.ts
+++ b/frontend/packages/cli/src/cli/runPreprocess.ts
@@ -26,7 +26,13 @@ export async function runPreprocess(
 
   let json = null
   try {
-    json = await parse(input, format)
+    const { value, errors } = await parse(input, format)
+    json = value
+    if (errors.length > 0) {
+      for (const error of errors) {
+        console.error(error)
+      }
+    }
   } catch (error) {
     throw new Error(
       `Failed to parse ${format} file: ${error instanceof Error ? error.message : String(error)}`,

--- a/frontend/packages/db-structure/package.json
+++ b/frontend/packages/db-structure/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@ruby/prism": "1.2.0",
+    "neverthrow": "8.1.1",
     "pg-query-emscripten": "5.1.0",
     "valibot": "^1.0.0-beta.5"
   },

--- a/frontend/packages/db-structure/src/parser/errors.ts
+++ b/frontend/packages/db-structure/src/parser/errors.ts
@@ -1,0 +1,13 @@
+export class ProcessError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ParseError'
+  }
+}
+
+export class WarningError extends ProcessError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WarningError'
+  }
+}

--- a/frontend/packages/db-structure/src/parser/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/index.test.ts
@@ -12,8 +12,8 @@ describe(parse, () => {
       'utf-8',
     )
 
-    const result = await parse(schemaText, 'schemarb')
-    expect(result).toMatchSnapshot()
+    const { value } = await parse(schemaText, 'schemarb')
+    expect(value).toMatchSnapshot()
   })
 
   it('should parse postgresql to JSON correctly', async () => {
@@ -22,7 +22,7 @@ describe(parse, () => {
       'utf-8',
     )
 
-    const result = await parse(schemaText, 'postgres')
-    expect(result).toMatchSnapshot()
+    const { value } = await parse(schemaText, 'postgres')
+    expect(value).toMatchSnapshot()
   })
 })

--- a/frontend/packages/db-structure/src/parser/index.ts
+++ b/frontend/packages/db-structure/src/parser/index.ts
@@ -1,7 +1,7 @@
 import * as v from 'valibot'
-import type { DBStructure } from '../schema/index.js'
 import { processor as schemarbProcessor } from './schemarb/index.js'
 import { processor as postgresqlProcessor } from './sql/index.js'
+import type { ProcessResult } from './types.js'
 
 export const supportedFormatSchema = v.union([
   v.literal('schemarb'),
@@ -14,7 +14,7 @@ export type SupportedFormat = v.InferOutput<typeof supportedFormatSchema>
 export const parse = (
   str: string,
   format: SupportedFormat,
-): Promise<DBStructure> | DBStructure => {
+): Promise<ProcessResult> => {
   switch (format) {
     case 'schemarb':
       return schemarbProcessor(str)

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -36,26 +36,26 @@ describe(processor, () => {
       })
 
     it('table comment', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users", comment: "store our users." do |t|
         end
       `)
 
-      expect(result).toEqual(parserTestCases['table comment'])
+      expect(value).toEqual(parserTestCases['table comment'])
     })
 
     it('column comment', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.text "description", comment: 'this is description'
         end
       `)
 
-      expect(result).toEqual(parserTestCases['column comment'])
+      expect(value).toEqual(parserTestCases['column comment'])
     })
 
     it('not null', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.string "name", null: false
         end
@@ -71,31 +71,31 @@ describe(processor, () => {
         },
       })
 
-      expect(result).toEqual(expected)
+      expect(value).toEqual(expected)
     })
 
     it('nullable', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.text "description", null: true
         end
       `)
 
-      expect(result).toEqual(parserTestCases.nullable)
+      expect(value).toEqual(parserTestCases.nullable)
     })
 
     it('default value as string', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.text "description", default: "user's description", null: true
         end
       `)
 
-      expect(result).toEqual(parserTestCases['default value as string'])
+      expect(value).toEqual(parserTestCases['default value as string'])
     })
 
     it('default value as integer', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.integer "age", default: 30, null: true
         end
@@ -113,11 +113,11 @@ describe(processor, () => {
         },
       })
 
-      expect(result).toEqual(expected)
+      expect(value).toEqual(expected)
     })
 
     it('default value as boolean', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.boolean "active", default: true, null: true
         end
@@ -135,21 +135,21 @@ describe(processor, () => {
         },
       })
 
-      expect(result).toEqual(expected)
+      expect(value).toEqual(expected)
     })
 
     it('unique', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.text "mention", unique: true
         end
       `)
 
-      expect(result).toEqual(parserTestCases.unique)
+      expect(value).toEqual(parserTestCases.unique)
     })
 
     it('primary key as args', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users", id: :bigint
       `)
 
@@ -165,7 +165,7 @@ describe(processor, () => {
         },
       })
 
-      expect(result).toEqual(expected)
+      expect(value).toEqual(expected)
     })
 
     it('no primary key', async () => {
@@ -193,29 +193,29 @@ describe(processor, () => {
     })
 
     it('index (unique: false)', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.string "email"
           t.index [ "id", "email" ], name: "index_users_on_id_and_email"
         end
       `)
 
-      expect(result).toEqual(parserTestCases['index (unique: false)'])
+      expect(value).toEqual(parserTestCases['index (unique: false)'])
     })
 
     it('index (unique: true)', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.string "email"
           t.index ["email"], name: "index_users_on_email", unique: true
         end
       `)
 
-      expect(result).toEqual(parserTestCases['index (unique: true)'])
+      expect(value).toEqual(parserTestCases['index (unique: true)'])
     })
 
     it('foreign key', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
       `)
 
@@ -232,11 +232,11 @@ describe(processor, () => {
 
       const expected = { fk_posts_user_id: rel }
 
-      expect(result.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(expected)
     })
 
     it('unique foreign key', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "posts" do |t|
           t.bigint "user_id", unique: true
         end
@@ -255,7 +255,7 @@ describe(processor, () => {
 
       const expected = { fk_posts_user_id: rel }
 
-      expect(result.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(expected)
     })
   })
 })

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -6,7 +6,7 @@ import {
   aRelationship,
   aTable,
 } from '../../schema/index.js'
-import { TableNameNotFound, processor } from './index.js'
+import { UnsupportedTokenError, processor } from './index.js'
 
 import { parserTestCases } from '../__tests__/index.js'
 
@@ -271,7 +271,11 @@ describe(processor, () => {
       `)
 
       const value = userTable()
-      const errors = [new TableNameNotFound('Table name not found')]
+      const errors = [
+        new UnsupportedTokenError(
+          'Expected a string for the table name, but received different data',
+        ),
+      ]
 
       expect(result).toEqual({ value, errors })
     })

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -169,7 +169,7 @@ describe(processor, () => {
     })
 
     it('no primary key', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         create_table "users", id: false do |t|
           t.string "name"
         end
@@ -189,7 +189,7 @@ describe(processor, () => {
         },
       })
 
-      expect(result).toEqual(expected)
+      expect(value).toEqual(expected)
     })
 
     it('index (unique: false)', async () => {

--- a/frontend/packages/db-structure/src/parser/schemarb/index.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.ts
@@ -1,1 +1,1 @@
-export { processor } from './parser.js'
+export { processor, TableNameNotFound } from './parser.js'

--- a/frontend/packages/db-structure/src/parser/schemarb/index.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.ts
@@ -1,1 +1,4 @@
-export { processor, TableNameNotFound } from './parser.js'
+export {
+  processor,
+  UnsupportedTokenError,
+} from './parser.js'

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -32,17 +32,23 @@ import type { ProcessResult, Processor } from '../types.js'
 import { handleOneToOneRelationships } from '../utils/index.js'
 import { convertColumnType } from './convertColumnType.js'
 
-export class TableNameNotFound extends WarningError {
+export class UnsupportedTokenError extends WarningError {
   constructor(message: string) {
     super(message)
-    this.name = 'WarningError'
+    this.name = 'UnsupportedTokenError'
   }
 }
 
-function extractTableName(argNodes: Node[]): Result<string, TableNameNotFound> {
+function extractTableName(
+  argNodes: Node[],
+): Result<string, UnsupportedTokenError> {
   const nameNode = argNodes.find((node) => node instanceof StringNode)
   if (!nameNode) {
-    return err(new TableNameNotFound('Table name not found'))
+    return err(
+      new UnsupportedTokenError(
+        'Expected a string for the table name, but received different data',
+      ),
+    )
   }
 
   // @ts-expect-error: unescaped is defined as string but it is actually object

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -26,7 +26,7 @@ import type {
   Tables,
 } from '../../schema/index.js'
 import { aColumn, aRelationship, aTable, anIndex } from '../../schema/index.js'
-import type { Processor } from '../types.js'
+import type { ProcessResult, Processor } from '../types.js'
 import { handleOneToOneRelationships } from '../utils/index.js'
 import { convertColumnType } from './convertColumnType.js'
 
@@ -385,14 +385,17 @@ class DBStructureFinder extends Visitor {
   }
 }
 
-async function parseRubySchema(schemaString: string): Promise<DBStructure> {
+async function parseRubySchema(schemaString: string): Promise<ProcessResult> {
   const parse = await loadPrism()
   const tableFinder = new DBStructureFinder()
 
   const parseResult = parse(schemaString)
   parseResult.value.accept(tableFinder)
 
-  return tableFinder.getDBStructure()
+  return {
+    value: tableFinder.getDBStructure(),
+    errors: tableFinder.getErrors(),
+  }
 }
 
 export const processor: Processor = (str) => parseRubySchema(str)

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -14,6 +14,7 @@ import {
   Visitor,
   loadPrism,
 } from '@ruby/prism'
+import { type Result, err, ok } from 'neverthrow'
 import type {
   Column,
   Columns,
@@ -26,17 +27,28 @@ import type {
   Tables,
 } from '../../schema/index.js'
 import { aColumn, aRelationship, aTable, anIndex } from '../../schema/index.js'
+import { type ProcessError, WarningError } from '../errors.js'
 import type { ProcessResult, Processor } from '../types.js'
 import { handleOneToOneRelationships } from '../utils/index.js'
 import { convertColumnType } from './convertColumnType.js'
 
-function extractTableName(argNodes: Node[]): string {
+export class TableNameNotFound extends WarningError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WarningError'
+  }
+}
+
+function extractTableName(argNodes: Node[]): Result<string, TableNameNotFound> {
   const nameNode = argNodes.find((node) => node instanceof StringNode)
   if (!nameNode) {
-    throw new Error('Table name not found')
+    return err(new TableNameNotFound('Table name not found'))
   }
+
   // @ts-expect-error: unescaped is defined as string but it is actually object
-  return nameNode.unescaped.value
+  const value = nameNode.unescaped.value
+
+  return ok(value)
 }
 
 function extractTableComment(argNodes: Node[]): string | null {
@@ -306,6 +318,7 @@ function extractForeignKeyOptions(
 class DBStructureFinder extends Visitor {
   private tables: Table[] = []
   private relationships: Relationship[] = []
+  private errors: ProcessError[] = []
 
   getDBStructure(): DBStructure {
     const dbStructure: DBStructure = {
@@ -325,11 +338,20 @@ class DBStructureFinder extends Visitor {
     return dbStructure
   }
 
+  getErrors(): ProcessError[] {
+    return this.errors
+  }
+
   handleCreateTable(node: CallNode): void {
     const argNodes = node.arguments_?.compactChildNodes() || []
+    const nameResult = extractTableName(argNodes)
+    if (nameResult.isErr()) {
+      this.errors.push(nameResult.error)
+      return
+    }
 
     const table = aTable({
-      name: extractTableName(argNodes),
+      name: nameResult.value,
     })
 
     table.comment = extractTableComment(argNodes)

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -5,18 +5,18 @@ import { processor } from './index.js'
 describe(processor, () => {
   describe('should parse create_table correctly', () => {
     it('table comment', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY
         );
         COMMENT ON TABLE users IS 'store our users.';
       `)
 
-      expect(result).toEqual(parserTestCases['table comment'])
+      expect(value).toEqual(parserTestCases['table comment'])
     })
 
     it('column commnet', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           description TEXT
@@ -24,77 +24,77 @@ describe(processor, () => {
         COMMENT ON COLUMN users.description IS 'this is description';
       `)
 
-      expect(result).toEqual(parserTestCases['column comment'])
+      expect(value).toEqual(parserTestCases['column comment'])
     })
 
     it('not null', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           name VARCHAR(255) NOT NULL
         );
       `)
 
-      expect(result).toEqual(parserTestCases['not null'])
+      expect(value).toEqual(parserTestCases['not null'])
     })
 
     it('nullable', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           description TEXT
         );
       `)
 
-      expect(result).toEqual(parserTestCases.nullable)
+      expect(value).toEqual(parserTestCases.nullable)
     })
 
     it('default value as string', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           description TEXT DEFAULT 'user''s description'
         );
       `)
 
-      expect(result).toEqual(parserTestCases['default value as string'])
+      expect(value).toEqual(parserTestCases['default value as string'])
     })
 
     it('default value as integer', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           age INTEGER DEFAULT 30
         );
       `)
 
-      expect(result).toEqual(parserTestCases['default value as integer'])
+      expect(value).toEqual(parserTestCases['default value as integer'])
     })
 
     it('default value as boolean', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           active BOOLEAN DEFAULT TRUE
         );
       `)
 
-      expect(result).toEqual(parserTestCases['default value as boolean'])
+      expect(value).toEqual(parserTestCases['default value as boolean'])
     })
 
     it('unique', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           mention TEXT UNIQUE
         );
       `)
 
-      expect(result).toEqual(parserTestCases.unique)
+      expect(value).toEqual(parserTestCases.unique)
     })
 
     it('index (unique: false)', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           email VARCHAR(255)
@@ -103,11 +103,11 @@ describe(processor, () => {
         CREATE INDEX index_users_on_id_and_email ON public.users USING btree (id, email);
       `)
 
-      expect(result).toEqual(parserTestCases['index (unique: false)'])
+      expect(value).toEqual(parserTestCases['index (unique: false)'])
     })
 
     it('index (unique: true)', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
           email VARCHAR(255)
@@ -116,11 +116,11 @@ describe(processor, () => {
         CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
       `)
 
-      expect(result).toEqual(parserTestCases['index (unique: true)'])
+      expect(value).toEqual(parserTestCases['index (unique: true)'])
     })
 
     it('foreign keys by create table', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
           id BIGSERIAL PRIMARY KEY,
           user_id INT REFERENCES users(id)
@@ -140,11 +140,11 @@ describe(processor, () => {
         },
       }
 
-      expect(result.relationships).toEqual(expectedRelationships)
+      expect(value.relationships).toEqual(expectedRelationships)
     })
 
     it('unique foreign keys by create table', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
           id BIGSERIAL PRIMARY KEY,
           user_id INT REFERENCES users(id) UNIQUE
@@ -164,11 +164,11 @@ describe(processor, () => {
         },
       }
 
-      expect(result.relationships).toEqual(expectedRelationships)
+      expect(value.relationships).toEqual(expectedRelationships)
     })
 
     it('foreign keys with no action by alter table', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
             id SERIAL PRIMARY KEY,
             user_id INT NOT NULL
@@ -191,11 +191,11 @@ describe(processor, () => {
         },
       }
 
-      expect(result.relationships).toEqual(expectedRelationships)
+      expect(value.relationships).toEqual(expectedRelationships)
     })
 
     it('foreign keys with action by alter table', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
             id SERIAL PRIMARY KEY,
             user_id INT NOT NULL
@@ -218,11 +218,11 @@ describe(processor, () => {
         },
       }
 
-      expect(result.relationships).toEqual(expectedRelationships)
+      expect(value.relationships).toEqual(expectedRelationships)
     })
 
     it('unique foreign keys by alter table', async () => {
-      const result = await processor(/* sql */ `
+      const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
             id SERIAL PRIMARY KEY,
             user_id INT NOT NULL UNIQUE
@@ -245,7 +245,7 @@ describe(processor, () => {
         },
       }
 
-      expect(result.relationships).toEqual(expectedRelationships)
+      expect(value.relationships).toEqual(expectedRelationships)
     })
   })
 })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
@@ -15,5 +15,5 @@ export const processor: Processor = async (str: string) => {
     mergeDBStructures(dbStructure, partial)
   })
 
-  return dbStructure
+  return { value: dbStructure, errors: [] }
 }

--- a/frontend/packages/db-structure/src/parser/types.ts
+++ b/frontend/packages/db-structure/src/parser/types.ts
@@ -1,3 +1,3 @@
 import type { DBStructure } from '../schema/index.js'
 
-export type Processor = (str: string) => DBStructure | Promise<DBStructure>
+export type Processor = (str: string) => Promise<DBStructure>

--- a/frontend/packages/db-structure/src/parser/types.ts
+++ b/frontend/packages/db-structure/src/parser/types.ts
@@ -1,3 +1,9 @@
 import type { DBStructure } from '../schema/index.js'
+import type { ProcessError } from './errors.js'
 
-export type Processor = (str: string) => Promise<DBStructure>
+export type ProcessResult = {
+  value: DBStructure
+  errors: ProcessError[]
+}
+
+export type Processor = (str: string) => Promise<ProcessResult>

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@ruby/prism':
         specifier: 1.2.0
         version: 1.2.0
+      neverthrow:
+        specifier: 8.1.1
+        version: 8.1.1
       pg-query-emscripten:
         specifier: 5.1.0
         version: 5.1.0
@@ -4156,6 +4159,10 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  neverthrow@8.1.1:
+    resolution: {integrity: sha512-DpbZ/UDI0B+TxJB1JysXSfi1++3YK2xLBqQLTlRN0b4zxlZ2MoiB+dKKV8dMRzt1fAFjRKDknXOVJgpl+a4Amw==}
+    engines: {node: '>=18'}
 
   next-themes@0.4.3:
     resolution: {integrity: sha512-nG84VPkTdUHR2YeD89YchvV4I9RbiMAql3GiLEQlPvq1ioaqPaIReK+yMRdg/zgiXws620qS1rU30TiWmmG9lA==}
@@ -10241,6 +10248,10 @@ snapshots:
   neo-async@2.6.2: {}
 
   netmask@2.0.2: {}
+
+  neverthrow@8.1.1:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.27.3
 
   next-themes@0.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Description

Even if there are unsupported syntaxes, only warnings are displayed and the system exits normally.

## Background

Previously, if a name was passed to `create_table` as a variable, an error would occur because it was not a string.

```rb
variable = "posts"
create_table variable do |t|
end
```

This does not happen very often because schema.rb is generally generated code, but it often happens when users write their own table definitions while using ActiveRecord's DSL, such as [Ridgepole](https://github.com/ridgepole/ridgepole).

## Solution

Error information is logged but exits normally.
The output is still dirty, but the formatting of the logs will be tackled in a separate issue.

```
node packages/cli/dist-cli/bin/cli.js erd build --input ../../../test/db/Schemafile --format schemarb
UnsupportedTokenError: Expected a string for the table name, but received different data
    at extractTableName (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:21231:20)
    at DBStructureFinder.handleCreateTable (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:21489:28)
    at DBStructureFinder.visitCallNode (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:21531:18)
    at CallNode.accept (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:4330:13)
    at file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:612:17
    at Array.forEach (<anonymous>)
    at DBStructureFinder.visitChildNodes (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:611:30)
    at DBStructureFinder.visitStatementsNode (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:1897:10)
    at StatementsNode.accept (file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:17967:13)
    at file:///Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/packages/cli/dist-cli/bin/cli.js:612:17
```