### PR TITLE
fix: Add support for foreign key without column name

### DIFF
--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -236,7 +236,7 @@ describe(processor, () => {
     })
 
     it('foreign key(omit column name)', async () => {
-      const result = await processor(/* Ruby */ `
+      const { value } = await processor(/* Ruby */ `
         add_foreign_key "posts", "users", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
       `)
 
@@ -253,7 +253,7 @@ describe(processor, () => {
 
       const expected = { fk_posts_user_id: rel }
 
-      expect(result.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(expected)
     })
 
     it('unique foreign key', async () => {

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -235,6 +235,27 @@ describe(processor, () => {
       expect(value.relationships).toEqual(expected)
     })
 
+    it('foreign key(omit column name)', async () => {
+      const result = await processor(/* Ruby */ `
+        add_foreign_key "posts", "users", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
+      `)
+
+      const rel = aRelationship({
+        name: 'fk_posts_user_id',
+        primaryTableName: 'users',
+        primaryColumnName: 'id',
+        foreignTableName: 'posts',
+        foreignColumnName: 'user_id',
+        cardinality: 'ONE_TO_MANY',
+        updateConstraint: 'RESTRICT',
+        deleteConstraint: 'CASCADE',
+      })
+
+      const expected = { fk_posts_user_id: rel }
+
+      expect(result.relationships).toEqual(expected)
+    })
+
     it('unique foreign key', async () => {
       const { value } = await processor(/* Ruby */ `
         create_table "posts" do |t|

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -317,13 +317,13 @@ function extractForeignKeyOptions(
             }
             break
         }
-
-        // ref: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
-        if (relation.foreignColumnName === '') {
-          relation.foreignColumnName = `${singularize(relation.primaryTableName)}_id`
-        }
       }
     }
+  }
+
+  // ref: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
+  if (relation.foreignColumnName === '') {
+    relation.foreignColumnName = `${singularize(relation.primaryTableName)}_id`
   }
 }
 

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -31,6 +31,7 @@ import { type ProcessError, WarningError } from '../errors.js'
 import type { ProcessResult, Processor } from '../types.js'
 import { handleOneToOneRelationships } from '../utils/index.js'
 import { convertColumnType } from './convertColumnType.js'
+import { singularize } from './singularize.js'
 
 export class UnsupportedTokenError extends WarningError {
   constructor(message: string) {
@@ -315,6 +316,11 @@ function extractForeignKeyOptions(
               )
             }
             break
+        }
+
+        // ref: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
+        if (relation.foreignColumnName === '') {
+          relation.foreignColumnName = `${singularize(relation.primaryTableName)}_id`
         }
       }
     }

--- a/frontend/packages/db-structure/src/parser/schemarb/singularize.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/singularize.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { singularize } from './singularize.js'
+
+describe('singularize', () => {
+  it('should convert addresses to address', () => {
+    expect(singularize('addresses')).toBe('address')
+  })
+
+  it('should convert analyses to analysis', () => {
+    expect(singularize('analyses')).toBe('analysis')
+  })
+
+  it('should convert buses to bus', () => {
+    expect(singularize('buses')).toBe('bus')
+  })
+
+  it('should convert movies to movie', () => {
+    expect(singularize('movies')).toBe('movie')
+  })
+
+  it('should convert oxen to ox', () => {
+    expect(singularize('oxen')).toBe('ox')
+  })
+
+  it('should convert indices to index', () => {
+    expect(singularize('indices')).toBe('index')
+  })
+
+  it('should convert matrices to matrix', () => {
+    expect(singularize('matrices')).toBe('matrix')
+  })
+
+  it('should convert quizzes to quiz', () => {
+    expect(singularize('quizzes')).toBe('quiz')
+  })
+
+  it('should convert databases to database', () => {
+    expect(singularize('databases')).toBe('database')
+  })
+
+  it('should convert aliases to alias', () => {
+    expect(singularize('aliases')).toBe('alias')
+  })
+
+  it('should convert statuses to status', () => {
+    expect(singularize('statuses')).toBe('status')
+  })
+
+  it('should convert shoes to shoe', () => {
+    expect(singularize('shoes')).toBe('shoe')
+  })
+
+  it('should convert parties to party', () => {
+    expect(singularize('parties')).toBe('party')
+  })
+
+  it('should convert calves to calf', () => {
+    expect(singularize('calves')).toBe('calf')
+  })
+
+  it('should convert wolves to wolf', () => {
+    expect(singularize('wolves')).toBe('wolf')
+  })
+
+  it('should convert lives to life', () => {
+    expect(singularize('lives')).toBe('life')
+  })
+
+  it('should convert series to series', () => {
+    expect(singularize('series')).toBe('series')
+  })
+
+  it('should convert status to status', () => {
+    expect(singularize('status')).toBe('status')
+  })
+})

--- a/frontend/packages/db-structure/src/parser/schemarb/singularize.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/singularize.ts
@@ -1,0 +1,47 @@
+// ref: https://github.com/rails/rails/blob/v8.0.0/activesupport/lib/active_support/inflections.rb#L35-L61
+const rules = [
+  [/(s)$/i, ''],
+  [/(ss)$/i, '$1'],
+  [/(n)ews$/i, '$1ews'],
+  [/([ti])a$/i, '$1um'],
+  [
+    /((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i,
+    '$1sis',
+  ],
+  [/^(analy)(sis|ses)$/i, '$1sis'],
+  [/([^f])ves$/i, '$1fe'],
+  [/(hive)s$/i, '$1'],
+  [/(tive)s$/i, '$1'],
+  [/([lr])ves$/i, '$1f'],
+  [/([^aeiouy]|qu)ies$/i, '$1y'],
+  [/(s)eries$/i, '$1eries'],
+  [/(m)ovies$/i, '$1ovie'],
+  [/(x|ch|ss|sh)es$/i, '$1'],
+  [/^(m|l)ice$/i, '$1ouse'],
+  [/(bus)(es)?$/i, '$1'],
+  [/(o)es$/i, '$1'],
+  [/(shoe)s$/i, '$1'],
+  [/(cris|test)(is|es)$/i, '$1is'],
+  [/^(a)x[ie]s$/i, '$1xis'],
+  [/(octop|vir)(us|i)$/i, '$1us'],
+  [/(alias|status)(es)?$/i, '$1'],
+  [/^(ox)en/i, '$1'],
+  [/(vert|ind)ices$/i, '$1ex'],
+  [/(matr)ices$/i, '$1ix'],
+  [/(quiz)zes$/i, '$1'],
+  [/(database)s$/i, '$1'],
+] as const
+
+export const singularize = (word: string): string => {
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i]
+    if (rule) {
+      const [regex, replacement] = rule
+      if (regex.test(word)) {
+        return word.replace(regex, replacement)
+      }
+    }
+  }
+
+  return word
+}


### PR DESCRIPTION
## Description

`add_column_key()` to retrieve relationships even if the column name is omitted.
I have ported the method of `ActiveSupport::Inflector#singularize`.