### PR TITLE
feat: store active table name

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
@@ -57,18 +57,6 @@
   opacity: 1;
 }
 
-.content {
-  top: var(--default-header-height);
-  right: 0;
-  bottom: 0;
-}
-
-.content[data-vaul-drawer] {
-  transition-duration: 165ms;
-  animation-duration: 165ms;
-  user-select: auto;
-}
-
 .handle {
   top: auto;
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -1,17 +1,8 @@
 import { useDBStructureStore } from '@/stores'
 import type { Table } from '@liam-hq/db-structure'
-import {
-  DiamondFillIcon,
-  DiamondIcon,
-  DrawerContent,
-  DrawerPortal,
-  DrawerRoot,
-  DrawerTrigger,
-  KeyRound,
-} from '@liam-hq/ui'
+import { DiamondFillIcon, DiamondIcon, KeyRound } from '@liam-hq/ui'
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react'
 import type { FC } from 'react'
-import { TableDetail } from './TableDetail'
 import { TableHeader } from './TableHeader'
 import styles from './TableNode.module.css'
 
@@ -26,94 +17,78 @@ type Props = NodeProps<TableNodeType>
 export const TableNode: FC<Props> = ({ data: { table } }) => {
   const { relationships } = useDBStructureStore()
   return (
-    <>
-      {/*
-      Set snapPoints to an empty array to disable the drawer snapping functionality.
-      This behavior is an undocumented, unofficial usage and might change in the future.
-      ref: https://github.com/emilkowalski/vaul/blob/main/src/use-snap-points.ts
-      */}
-      <DrawerRoot direction="right" snapPoints={[]}>
-        <DrawerTrigger>
-          <div className={styles.wrapper}>
-            <TableHeader name={table.name} />
-            <ul>
-              {Object.values(table.columns).map((column) => {
-                const handleId = `${table.name}-${column.name}`
-                const isSource = Object.values(relationships).some(
-                  (relationship) =>
-                    relationship.primaryTableName === table.name &&
-                    relationship.primaryColumnName === column.name,
-                )
-                const isTarget = Object.values(relationships).some(
-                  (relationship) =>
-                    relationship.foreignTableName === table.name &&
-                    relationship.foreignColumnName === column.name,
-                )
+    <div className={styles.wrapper}>
+      <TableHeader name={table.name} />
+      <ul>
+        {Object.values(table.columns).map((column) => {
+          const handleId = `${table.name}-${column.name}`
+          const isSource = Object.values(relationships).some(
+            (relationship) =>
+              relationship.primaryTableName === table.name &&
+              relationship.primaryColumnName === column.name,
+          )
+          const isTarget = Object.values(relationships).some(
+            (relationship) =>
+              relationship.foreignTableName === table.name &&
+              relationship.foreignColumnName === column.name,
+          )
 
-                return (
-                  <li key={column.name} className={styles.columnWrapper}>
-                    {column.primary && (
-                      <KeyRound
-                        width={16}
-                        height={16}
-                        className={styles.primaryKeyIcon}
-                        role="img"
-                        aria-label="Primary Key"
-                      />
-                    )}
-                    {!column.primary &&
-                      (column.notNull ? (
-                        <DiamondFillIcon
-                          width={16}
-                          height={16}
-                          className={styles.diamondIcon}
-                          role="img"
-                          aria-label="Not Null"
-                        />
-                      ) : (
-                        <DiamondIcon
-                          width={16}
-                          height={16}
-                          className={styles.diamondIcon}
-                          role="img"
-                          aria-label="Nullable"
-                        />
-                      ))}
+          return (
+            <li key={column.name} className={styles.columnWrapper}>
+              {column.primary && (
+                <KeyRound
+                  width={16}
+                  height={16}
+                  className={styles.primaryKeyIcon}
+                  role="img"
+                  aria-label="Primary Key"
+                />
+              )}
+              {!column.primary &&
+                (column.notNull ? (
+                  <DiamondFillIcon
+                    width={16}
+                    height={16}
+                    className={styles.diamondIcon}
+                    role="img"
+                    aria-label="Not Null"
+                  />
+                ) : (
+                  <DiamondIcon
+                    width={16}
+                    height={16}
+                    className={styles.diamondIcon}
+                    role="img"
+                    aria-label="Nullable"
+                  />
+                ))}
 
-                    <span className={styles.columnNameWrapper}>
-                      <span className={styles.columnName}>{column.name}</span>
-                      <span className={styles.columnType}>{column.type}</span>
-                    </span>
+              <span className={styles.columnNameWrapper}>
+                <span className={styles.columnName}>{column.name}</span>
+                <span className={styles.columnType}>{column.type}</span>
+              </span>
 
-                    {isSource && (
-                      <Handle
-                        id={handleId}
-                        type="source"
-                        position={Position.Right}
-                        className={styles.handle}
-                      />
-                    )}
+              {isSource && (
+                <Handle
+                  id={handleId}
+                  type="source"
+                  position={Position.Right}
+                  className={styles.handle}
+                />
+              )}
 
-                    {isTarget && (
-                      <Handle
-                        id={handleId}
-                        type="target"
-                        position={Position.Left}
-                        className={styles.handle}
-                      />
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        </DrawerTrigger>
-        <DrawerPortal>
-          <DrawerContent className={styles.content}>
-            <TableDetail table={table} />
-          </DrawerContent>
-        </DrawerPortal>
-      </DrawerRoot>
-    </>
+              {isTarget && (
+                <Handle
+                  id={handleId}
+                  type="target"
+                  position={Position.Left}
+                  className={styles.handle}
+                />
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -1,8 +1,8 @@
-import { useDBStructureStore } from '@/stores'
+import { updateActiveTableId, useDBStructureStore } from '@/stores'
 import type { Table } from '@liam-hq/db-structure'
 import { DiamondFillIcon, DiamondIcon, KeyRound } from '@liam-hq/ui'
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react'
-import type { FC } from 'react'
+import { type FC, useCallback } from 'react'
 import { TableHeader } from './TableHeader'
 import styles from './TableNode.module.css'
 
@@ -16,8 +16,12 @@ type Props = NodeProps<TableNodeType>
 
 export const TableNode: FC<Props> = ({ data: { table } }) => {
   const { relationships } = useDBStructureStore()
+  const handleClick = useCallback(() => {
+    updateActiveTableId(table.name)
+  }, [table])
+
   return (
-    <div className={styles.wrapper}>
+    <button type="button" className={styles.wrapper} onClick={handleClick}>
       <TableHeader name={table.name} />
       <ul>
         {Object.values(table.columns).map((column) => {
@@ -89,6 +93,6 @@ export const TableNode: FC<Props> = ({ data: { table } }) => {
           )
         })}
       </ul>
-    </div>
+    </button>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -1,4 +1,4 @@
-import { updateActiveTableId, useDBStructureStore } from '@/stores'
+import { updateActiveTableName, useDBStructureStore } from '@/stores'
 import type { Table } from '@liam-hq/db-structure'
 import { DiamondFillIcon, DiamondIcon, KeyRound } from '@liam-hq/ui'
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react'
@@ -17,7 +17,7 @@ type Props = NodeProps<TableNodeType>
 export const TableNode: FC<Props> = ({ data: { table } }) => {
   const { relationships } = useDBStructureStore()
   const handleClick = useCallback(() => {
-    updateActiveTableId(table.name)
+    updateActiveTableName(table.name)
   }, [table])
 
   return (

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -12,6 +12,7 @@ import styles from './ERDRenderer.module.css'
 import { LeftPane } from './LeftPane'
 import '@/styles/globals.css'
 import { useDBStructureStore } from '@/stores'
+import { TableDetailDrawer, TableDetailDrawerRoot } from './TableDetailDrawer'
 import { convertDBStructureToNodes } from './convertDBStructureToNodes'
 
 export const ERDRenderer: FC = () => {
@@ -29,9 +30,12 @@ export const ERDRenderer: FC = () => {
             <div className={styles.triggerWrapper}>
               <SidebarTrigger />
             </div>
-            <ReactFlowProvider>
-              <ERDContent nodes={nodes} edges={edges} />
-            </ReactFlowProvider>
+            <TableDetailDrawerRoot>
+              <ReactFlowProvider>
+                <ERDContent nodes={nodes} edges={edges} />
+              </ReactFlowProvider>
+              <TableDetailDrawer />
+            </TableDetailDrawerRoot>
           </main>
         </div>
       </SidebarProvider>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -3,3 +3,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.active {
+  background: linear-gradient(
+      0deg,
+      var(--primary-accent-overlay) 0%,
+      var(--primary-accent-overlay) 100%
+    ), var(--pane-background-active);
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -11,9 +11,13 @@ import {
   SidebarRail,
 } from '@liam-hq/ui'
 import { Table2 } from '@liam-hq/ui'
-import { useDBStructureStore } from '../../../stores'
+import { updateActiveTableId, useDBStructureStore } from '../../../stores'
 import styles from './LeftPane.module.css'
 import { TableCounter } from './TableCounter'
+
+const handleClickMenuButton = (tableId: string) => () => {
+  updateActiveTableId(tableId)
+}
 
 export const LeftPane = () => {
   const { tables } = useDBStructureStore()
@@ -27,7 +31,9 @@ export const LeftPane = () => {
             <SidebarMenu>
               {Object.values(tables).map((table) => (
                 <SidebarMenuItem key={table.name}>
-                  <SidebarMenuButton>
+                  <SidebarMenuButton
+                    onClick={handleClickMenuButton(table.name)}
+                  >
                     <Table2 width="10px" />
                     <span className={styles.tableName}>{table.name}</span>
                   </SidebarMenuButton>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -12,7 +12,7 @@ import {
 } from '@liam-hq/ui'
 import { Table2 } from '@liam-hq/ui'
 import {
-  updateActiveTableId,
+  updateActiveTableName,
   useDBStructureStore,
   useUserEditingStore,
 } from '../../../stores'
@@ -20,13 +20,13 @@ import styles from './LeftPane.module.css'
 import { TableCounter } from './TableCounter'
 
 const handleClickMenuButton = (tableId: string) => () => {
-  updateActiveTableId(tableId)
+  updateActiveTableName(tableId)
 }
 
 export const LeftPane = () => {
   const { tables } = useDBStructureStore()
   const {
-    active: { tableId },
+    active: { tableName },
   } = useUserEditingStore()
 
   return (
@@ -40,7 +40,7 @@ export const LeftPane = () => {
                 <SidebarMenuItem key={table.name}>
                   <SidebarMenuButton
                     onClick={handleClickMenuButton(table.name)}
-                    className={table.name === tableId ? styles.active : ''}
+                    className={table.name === tableName ? styles.active : ''}
                   >
                     <Table2 width="10px" />
                     <span className={styles.tableName}>{table.name}</span>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -11,7 +11,11 @@ import {
   SidebarRail,
 } from '@liam-hq/ui'
 import { Table2 } from '@liam-hq/ui'
-import { updateActiveTableId, useDBStructureStore } from '../../../stores'
+import {
+  updateActiveTableId,
+  useDBStructureStore,
+  useUserEditingStore,
+} from '../../../stores'
 import styles from './LeftPane.module.css'
 import { TableCounter } from './TableCounter'
 
@@ -21,6 +25,9 @@ const handleClickMenuButton = (tableId: string) => () => {
 
 export const LeftPane = () => {
   const { tables } = useDBStructureStore()
+  const {
+    active: { tableId },
+  } = useUserEditingStore()
 
   return (
     <Sidebar>
@@ -33,6 +40,7 @@ export const LeftPane = () => {
                 <SidebarMenuItem key={table.name}>
                   <SidebarMenuButton
                     onClick={handleClickMenuButton(table.name)}
+                    className={table.name === tableId ? styles.active : ''}
                   >
                     <Table2 width="10px" />
                     <span className={styles.tableName}>{table.name}</span>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.module.css
@@ -1,0 +1,11 @@
+.content {
+  top: var(--default-header-height);
+  right: 0;
+  bottom: 0;
+}
+
+.content[data-vaul-drawer] {
+  transition-duration: 165ms;
+  animation-duration: 165ms;
+  user-select: auto;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.module.css
@@ -5,7 +5,7 @@
 }
 
 .content[data-vaul-drawer] {
-  transition-duration: 165ms;
-  animation-duration: 165ms;
+  transition-duration: var(--drawer-animation-duration);
+  animation-duration: var(--drawer-animation-duration);
   user-select: auto;
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -4,16 +4,33 @@ import {
   useUserEditingStore,
 } from '@/stores'
 import { DrawerContent, DrawerPortal, DrawerRoot } from '@liam-hq/ui'
-import type { FC, PropsWithChildren } from 'react'
+import {
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react'
 import { TableDetail } from '../ERDContent/TableNode/TableDetail'
 import styles from './TableDetailDrawer.module.css'
 
-const handleClose = () => updateActiveTableId(undefined)
+const ANIMATION_DURATION = 165
 
 export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
   const {
     active: { tableId },
   } = useUserEditingStore()
+  const [open, setOpen] = useState(tableId !== undefined)
+
+  useEffect(() => {
+    setOpen(tableId !== undefined)
+  }, [tableId])
+
+  const handleClose = useCallback(() => {
+    setOpen(false)
+    // NOTE: Wait for the drawer to close before updating the active table ID.
+    setTimeout(() => updateActiveTableId(undefined), ANIMATION_DURATION)
+  }, [])
 
   return (
     <DrawerRoot
@@ -22,7 +39,7 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
       // This behavior is an undocumented, unofficial usage and might change in the future.
       // ref: https://github.com/emilkowalski/vaul/blob/main/src/use-snap-points.ts
       snapPoints={[]}
-      open={tableId !== undefined}
+      open={open}
       onClose={handleClose}
     >
       {children}
@@ -39,7 +56,10 @@ export const TableDetailDrawer: FC = () => {
 
   return (
     <DrawerPortal>
-      <DrawerContent className={styles.content}>
+      <DrawerContent
+        style={{ '--drawer-animation-duration': `${ANIMATION_DURATION}ms` }}
+        className={styles.content}
+      >
         {table !== undefined && <TableDetail table={table} />}
       </DrawerContent>
     </DrawerPortal>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -1,5 +1,5 @@
 import {
-  updateActiveTableId,
+  updateActiveTableName,
   useDBStructureStore,
   useUserEditingStore,
 } from '@/stores'
@@ -19,7 +19,7 @@ const ANIMATION_DURATION = 165
 
 export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
   const {
-    active: { tableId },
+    active: { tableName: tableId },
   } = useUserEditingStore()
   const [open, setOpen] = useState(tableId !== undefined)
 
@@ -29,8 +29,8 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
 
   const handleClose = useCallback(() => {
     setOpen(false)
-    // NOTE: Wait for the drawer to close before updating the active table ID.
-    setTimeout(() => updateActiveTableId(undefined), ANIMATION_DURATION)
+    // NOTE: Wait for the drawer to close before updating the active table name.
+    setTimeout(() => updateActiveTableName(undefined), ANIMATION_DURATION)
   }, [])
 
   return (
@@ -51,9 +51,9 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
 export const TableDetailDrawer: FC = () => {
   const { tables } = useDBStructureStore()
   const {
-    active: { tableId },
+    active: { tableName },
   } = useUserEditingStore()
-  const table = tables[tableId ?? '']
+  const table = tables[tableName ?? '']
 
   return (
     <DrawerPortal>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -1,0 +1,29 @@
+import { useDBStructureStore } from '@/stores'
+import { DrawerContent, DrawerPortal, DrawerRoot } from '@liam-hq/ui'
+import type { FC, PropsWithChildren } from 'react'
+import { TableDetail } from '../ERDContent/TableNode/TableDetail'
+import styles from './TableDetailDrawer.module.css'
+
+export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    // Set snapPoints to an empty array to disable the drawer snapping functionality.
+    // This behavior is an undocumented, unofficial usage and might change in the future.
+    // ref: https://github.com/emilkowalski/vaul/blob/main/src/use-snap-points.ts
+    <DrawerRoot direction="right" snapPoints={[]}>
+      {children}
+    </DrawerRoot>
+  )
+}
+
+export const TableDetailDrawer: FC = () => {
+  const { tables } = useDBStructureStore()
+  const table = Object.values(tables)[0]
+
+  return (
+    <DrawerPortal>
+      <DrawerContent className={styles.content}>
+        {table !== undefined && <TableDetail table={table} />}
+      </DrawerContent>
+    </DrawerPortal>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -1,15 +1,30 @@
-import { useDBStructureStore } from '@/stores'
+import {
+  updateActiveTableId,
+  useDBStructureStore,
+  useUserEditingStore,
+} from '@/stores'
 import { DrawerContent, DrawerPortal, DrawerRoot } from '@liam-hq/ui'
 import type { FC, PropsWithChildren } from 'react'
 import { TableDetail } from '../ERDContent/TableNode/TableDetail'
 import styles from './TableDetailDrawer.module.css'
 
+const handleClose = () => updateActiveTableId(undefined)
+
 export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
+  const {
+    active: { tableId },
+  } = useUserEditingStore()
+
   return (
-    // Set snapPoints to an empty array to disable the drawer snapping functionality.
-    // This behavior is an undocumented, unofficial usage and might change in the future.
-    // ref: https://github.com/emilkowalski/vaul/blob/main/src/use-snap-points.ts
-    <DrawerRoot direction="right" snapPoints={[]}>
+    <DrawerRoot
+      direction="right"
+      // Set snapPoints to an empty array to disable the drawer snapping functionality.
+      // This behavior is an undocumented, unofficial usage and might change in the future.
+      // ref: https://github.com/emilkowalski/vaul/blob/main/src/use-snap-points.ts
+      snapPoints={[]}
+      open={tableId !== undefined}
+      onClose={handleClose}
+    >
       {children}
     </DrawerRoot>
   )
@@ -17,7 +32,10 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
 
 export const TableDetailDrawer: FC = () => {
   const { tables } = useDBStructureStore()
-  const table = Object.values(tables)[0]
+  const {
+    active: { tableId },
+  } = useUserEditingStore()
+  const table = tables[tableId ?? '']
 
   return (
     <DrawerPortal>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -11,6 +11,7 @@ import {
   useEffect,
   useState,
 } from 'react'
+// biome-ignore lint/nursery/useImportRestrictions: Fixed in the next PR.
 import { TableDetail } from '../ERDContent/TableNode/TableDetail'
 import styles from './TableDetailDrawer.module.css'
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/index.ts
@@ -1,0 +1,1 @@
+export * from './TableDetailDrawer'

--- a/frontend/packages/erd-core/src/stores/index.ts
+++ b/frontend/packages/erd-core/src/stores/index.ts
@@ -1,1 +1,2 @@
 export * from './dbStructure'
+export * from './userEditing'

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -1,5 +1,5 @@
 import { userEditingStore } from './store'
 
-export const updateActiveTableId = (tableId: string | undefined) => {
-  userEditingStore.active.tableId = tableId
+export const updateActiveTableName = (tableName: string | undefined) => {
+  userEditingStore.active.tableName = tableName
 }

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -1,0 +1,5 @@
+import { userEditingStore } from './store'
+
+export const updateActiveTableId = (tableId: string | undefined) => {
+  userEditingStore.active.tableId = tableId
+}

--- a/frontend/packages/erd-core/src/stores/userEditing/hooks.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/hooks.ts
@@ -1,0 +1,4 @@
+import { useSnapshot } from 'valtio'
+import { userEditingStore } from './store'
+
+export const useUserEditingStore = () => useSnapshot(userEditingStore)

--- a/frontend/packages/erd-core/src/stores/userEditing/index.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks'
+export * from './actions'

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -1,0 +1,13 @@
+import { proxy } from 'valtio'
+
+type UserEditingStore = {
+  active: {
+    tableId: string | undefined
+  }
+}
+
+export const userEditingStore = proxy<UserEditingStore>({
+  active: {
+    tableId: undefined,
+  },
+})

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -2,12 +2,12 @@ import { proxy } from 'valtio'
 
 type UserEditingStore = {
   active: {
-    tableId: string | undefined
+    tableName: string | undefined
   }
 }
 
 export const userEditingStore = proxy<UserEditingStore>({
   active: {
-    tableId: undefined,
+    tableName: undefined,
   },
 })

--- a/frontend/packages/erd-core/src/types/css.d.ts
+++ b/frontend/packages/erd-core/src/types/css.d.ts
@@ -1,0 +1,10 @@
+import 'react'
+
+// NOTE: React.CSSProperties does not accept CSS Variables by default, so override them here
+// @see: https://stackoverflow.com/questions/52005083/how-to-define-css-variables-in-style-attribute-in-react-and-typescript
+// @see: https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+declare module 'react' {
+  interface CSSProperties {
+    [key: `--${string}`]: string
+  }
+}

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -67,6 +67,8 @@
   font-size: var(--font-size-2);
   color: var(--link-default);
   width: 100%;
+  transition: background-color var(--default-hover-animation-duration)
+    var(--default-timing-function);
 }
 
 .sidebarMenuButton:hover {


### PR DESCRIPTION
Keep the active table in the global state, so that the TableDetail can also be opened from the left pane.


https://github.com/user-attachments/assets/dd0052aa-04bd-46b0-bd3d-e6a5ab1188b0

## TODO(will be separated other PRs)

- [ ] Change style TableNode when active
- [ ] Fit view when changed active table
- [ ] Move files of TableDetail
