### PR TITLE
Add edge styling (animation and coloring)

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -2,12 +2,14 @@ import {
   Background,
   BackgroundVariant,
   type Edge,
+  type EdgeMouseHandler,
   type Node,
+  type NodeMouseHandler,
   ReactFlow,
   useEdgesState,
   useNodesState,
 } from '@xyflow/react'
-import { type FC, useEffect } from 'react'
+import { type FC, useCallback, useEffect } from 'react'
 import styles from './ERDContent.module.css'
 import { RelationshipEdge } from './RelationshipEdge'
 import { TableNode } from './TableNode'
@@ -38,6 +40,58 @@ export const ERDContent: FC<Props> = ({ nodes: _nodes, edges: _edges }) => {
 
   useAutoLayout()
 
+  const handleMouseEnterNode: NodeMouseHandler<Node> = useCallback(
+    (_, { id }) => {
+      setEdges((edges) =>
+        edges.map((e) =>
+          e.source === id
+            ? { ...e, animated: true, data: { ...e.data, isHovered: true } }
+            : e,
+        ),
+      )
+    },
+    [setEdges],
+  )
+
+  const handleMouseLeaveNode: NodeMouseHandler<Node> = useCallback(
+    (_, { id }) => {
+      setEdges((edges) =>
+        edges.map((e) =>
+          e.source === id
+            ? { ...e, animated: false, data: { ...e.data, isHovered: false } }
+            : e,
+        ),
+      )
+    },
+    [setEdges],
+  )
+
+  const handleMouseEnterEdge: EdgeMouseHandler<Edge> = useCallback(
+    (_, { id }) => {
+      setEdges((edges) =>
+        edges.map((e) =>
+          e.id === id
+            ? { ...e, animated: true, data: { ...e.data, isHovered: true } }
+            : e,
+        ),
+      )
+    },
+    [setEdges],
+  )
+
+  const handleMouseLeaveEdge: EdgeMouseHandler<Edge> = useCallback(
+    (_, { id }) => {
+      setEdges((edges) =>
+        edges.map((e) =>
+          e.id === id
+            ? { ...e, animated: false, data: { ...e.data, isHovered: false } }
+            : e,
+        ),
+      )
+    },
+    [setEdges],
+  )
+
   return (
     <div className={styles.wrapper}>
       <ReactFlow
@@ -49,6 +103,10 @@ export const ERDContent: FC<Props> = ({ nodes: _nodes, edges: _edges }) => {
         maxZoom={2}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onNodeMouseEnter={handleMouseEnterNode}
+        onNodeMouseLeave={handleMouseLeaveNode}
+        onEdgeMouseEnter={handleMouseEnterEdge}
+        onEdgeMouseLeave={handleMouseLeaveEdge}
       >
         <Background
           color="var(--color-gray-600)"

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
@@ -1,0 +1,9 @@
+.edge {
+  stroke: var(--global-border);
+  stroke-dasharray: 2;
+  transition: stroke 0.3s var(--default-timing-function);
+}
+
+.hovered {
+  stroke: var(--node-layout);
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -5,7 +5,9 @@ import {
   getSmoothStepPath,
 } from '@xyflow/react'
 
+import clsx from 'clsx'
 import type { FC } from 'react'
+import styles from './RelationshipEdge.module.css'
 
 type Data = {
   isHovered: boolean
@@ -39,13 +41,7 @@ export const RelationshipEdge: FC<Props> = ({
       <BaseEdge
         id={id}
         path={edgePath}
-        style={{
-          stroke: data?.isHovered
-            ? 'var(--node-layout)'
-            : 'var(--global-border)',
-          strokeDasharray: '2',
-          transition: 'stroke 0.3s var(--default-timing-function)',
-        }}
+        className={clsx(styles.edge, data?.isHovered && styles.hovered)}
       />
     </>
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -7,7 +7,13 @@ import {
 
 import type { FC } from 'react'
 
-type Props = EdgeProps<Edge>
+type Data = {
+  isHovered: boolean
+}
+
+export type RelationshipEdgeType = Edge<Data, 'relationship'>
+
+type Props = EdgeProps<RelationshipEdgeType>
 
 export const RelationshipEdge: FC<Props> = ({
   sourceX,
@@ -17,6 +23,7 @@ export const RelationshipEdge: FC<Props> = ({
   targetY,
   targetPosition,
   id,
+  data,
 }) => {
   const [edgePath] = getSmoothStepPath({
     sourceX,
@@ -29,7 +36,17 @@ export const RelationshipEdge: FC<Props> = ({
 
   return (
     <>
-      <BaseEdge id={id} path={edgePath} />
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={{
+          stroke: data?.isHovered
+            ? 'var(--node-layout)'
+            : 'var(--global-border)',
+          strokeDasharray: '2',
+          transition: 'stroke 0.3s var(--default-timing-function)',
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Added RelationshipEdge styling:

* When hovering over a node, only the primary-to-external edges are colored and animated.
* When hovering over a edge, edges are also colored and animated.

https://github.com/user-attachments/assets/b5634ddc-a787-4bae-8f1c-221a8cd202b7

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
