### PR TITLE
Stop git commit only timestamp update in license report

### DIFF
--- a/.github/workflows/license-frontend.yml
+++ b/.github/workflows/license-frontend.yml
@@ -93,6 +93,8 @@ jobs:
         run: |
           mkdir -p "$(dirname "$LICENSE_REPORT")"
           license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
+          # Delete the timestamp line because there will be a difference even if there is no change in licenses
+          sed -e '/^As of /d' -i "$LICENSE_REPORT"
         working-directory: ${{ env.working-directory }}
       - name: Commit license report and push
         if: |
@@ -101,6 +103,10 @@ jobs:
           && github.ref_name != github.event.repository.default_branch
           && github.event_name != 'merge_group' 
         run: |
+          if git diff --quiet; then
+            echo 'No changes to commit'
+            exit 0
+          fi
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "$LICENSE_REPORT"

--- a/frontend/docs/packages-license.md
+++ b/frontend/docs/packages-license.md
@@ -1,6 +1,5 @@
 # frontend
 
-As of December  9, 2024 12:25pm. 1020 total
 
 ## Summary
 * 888 MIT
@@ -11268,3 +11267,5 @@ Unknown manually approved
 * /home/runner/work/liam/liam/frontend
 
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Stop git commit only timestamp update in license report.
e.g. https://github.com/liam-hq/liam/commit/0a5510d877c1e6575f2675aeb9cfc8a8e9fa444d

## Related Issue
<!-- Mention the related issue number if applicable. -->
N/A

## Changes
<!-- List the main changes made in this PR. -->
Removed the timestamp line from license report in GitHub Actions workflow.

## Testing
<!-- Briefly describe the testing steps or results. -->
✅ This job removed the timestamp line.
https://github.com/liam-hq/liam/actions/runs/12269897007/job/34234220798
