### PR TITLE
feat: Replace smooth step path with bezier path in RelationshipEdge component

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -2,7 +2,7 @@ import {
   BaseEdge,
   type Edge,
   type EdgeProps,
-  getSmoothStepPath,
+  getBezierPath,
 } from '@xyflow/react'
 
 import clsx from 'clsx'
@@ -27,7 +27,7 @@ export const RelationshipEdge: FC<Props> = ({
   id,
   data,
 }) => {
-  const [edgePath] = getSmoothStepPath({
+  const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
     sourcePosition,


### PR DESCRIPTION
I switched to this one because it was potentially more visible.

![Image](https://github.com/user-attachments/assets/b9ec6be5-b9a8-48b3-a2ef-1090a913b784)