### PR TITLE
maintenance: enhance parser test cases 4

### DIFF
--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -124,4 +124,40 @@ export const parserTestCases = {
       }),
     },
   }),
+  'foreign key (one-to-many)': (name: string) => ({
+    [name]: {
+      name,
+      primaryTableName: 'users',
+      primaryColumnName: 'id',
+      foreignTableName: 'posts',
+      foreignColumnName: 'user_id',
+      cardinality: 'ONE_TO_MANY',
+      updateConstraint: 'NO_ACTION',
+      deleteConstraint: 'NO_ACTION',
+    },
+  }),
+  'foreign key (one-to-one)': {
+    users_id_to_posts_user_id: {
+      name: 'users_id_to_posts_user_id',
+      primaryTableName: 'users',
+      primaryColumnName: 'id',
+      foreignTableName: 'posts',
+      foreignColumnName: 'user_id',
+      cardinality: 'ONE_TO_ONE',
+      updateConstraint: 'NO_ACTION',
+      deleteConstraint: 'NO_ACTION',
+    },
+  },
+  'foreign key with action': {
+    fk_posts_user_id: {
+      name: 'fk_posts_user_id',
+      primaryTableName: 'users',
+      primaryColumnName: 'id',
+      foreignTableName: 'posts',
+      foreignColumnName: 'user_id',
+      cardinality: 'ONE_TO_MANY',
+      updateConstraint: 'RESTRICT',
+      deleteConstraint: 'CASCADE',
+    },
+  },
 }

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { Table } from '../../schema/index.js'
-import {
-  aColumn,
-  aDBStructure,
-  aRelationship,
-  aTable,
-} from '../../schema/index.js'
+import { aColumn, aDBStructure, aTable } from '../../schema/index.js'
 import { UnsupportedTokenError, processor } from './index.js'
 
 import { parserTestCases } from '../__tests__/index.js'
@@ -214,90 +209,62 @@ describe(processor, () => {
       expect(value).toEqual(parserTestCases['index (unique: true)'])
     })
 
-    it('foreign key', async () => {
+    it('foreign key (one-to-many)', async () => {
+      const keyName = 'fk_posts_user_id'
       const { value } = await processor(/* Ruby */ `
-        add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
+        add_foreign_key "posts", "users", column: "user_id", name: "${keyName}"
       `)
 
-      const rel = aRelationship({
-        name: 'fk_posts_user_id',
-        primaryTableName: 'users',
-        primaryColumnName: 'id',
-        foreignTableName: 'posts',
-        foreignColumnName: 'user_id',
-        cardinality: 'ONE_TO_MANY',
-        updateConstraint: 'RESTRICT',
-        deleteConstraint: 'CASCADE',
-      })
-
-      const expected = { fk_posts_user_id: rel }
-
-      expect(value.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(
+        parserTestCases['foreign key (one-to-many)'](keyName),
+      )
     })
 
-    it('foreign key(omit column name)', async () => {
+    it('foreign key with omit column name', async () => {
+      const keyName = 'fk_posts_user_id'
       const { value } = await processor(/* Ruby */ `
-        add_foreign_key "posts", "users", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
+        add_foreign_key "posts", "users", name: "${keyName}"
       `)
 
-      const rel = aRelationship({
-        name: 'fk_posts_user_id',
-        primaryTableName: 'users',
-        primaryColumnName: 'id',
-        foreignTableName: 'posts',
-        foreignColumnName: 'user_id',
-        cardinality: 'ONE_TO_MANY',
-        updateConstraint: 'RESTRICT',
-        deleteConstraint: 'CASCADE',
-      })
-
-      const expected = { fk_posts_user_id: rel }
-
-      expect(value.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(
+        parserTestCases['foreign key (one-to-many)'](keyName),
+      )
     })
 
-    it('foreign key(omit key name)', async () => {
+    it('foreign key with omit key name', async () => {
       const { value } = await processor(/* Ruby */ `
-        add_foreign_key "posts", "users", column: "user_id", on_update: :restrict, on_delete: :cascade
+        add_foreign_key "posts", "users", column: "user_id"
       `)
 
-      const rel = aRelationship({
-        name: 'users_id_to_posts_user_id',
-        primaryTableName: 'users',
-        primaryColumnName: 'id',
-        foreignTableName: 'posts',
-        foreignColumnName: 'user_id',
-        cardinality: 'ONE_TO_MANY',
-        updateConstraint: 'RESTRICT',
-        deleteConstraint: 'CASCADE',
-      })
-
-      const expected = { users_id_to_posts_user_id: rel }
-
-      expect(value.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(
+        parserTestCases['foreign key (one-to-many)'](
+          'users_id_to_posts_user_id',
+        ),
+      )
     })
 
-    it('unique foreign key', async () => {
+    it('foreign key (one-to-one)', async () => {
       const { value } = await processor(/* Ruby */ `
         create_table "posts" do |t|
           t.bigint "user_id", unique: true
         end
 
-        add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id"
+        add_foreign_key "posts", "users", column: "user_id"
       `)
 
-      const rel = aRelationship({
-        name: 'fk_posts_user_id',
-        primaryTableName: 'users',
-        primaryColumnName: 'id',
-        foreignTableName: 'posts',
-        foreignColumnName: 'user_id',
-        cardinality: 'ONE_TO_ONE',
-      })
+      expect(value.relationships).toEqual(
+        parserTestCases['foreign key (one-to-one)'],
+      )
+    })
 
-      const expected = { fk_posts_user_id: rel }
+    it('foreign keys with action', async () => {
+      const { value } = await processor(/* Ruby */ `
+        add_foreign_key "posts", "users", column: "user_id", name: "fk_posts_user_id", on_update: :restrict, on_delete: :cascade
+      `)
 
-      expect(value.relationships).toEqual(expected)
+      expect(value.relationships).toEqual(
+        parserTestCases['foreign key with action'],
+      )
     })
   })
 


### PR DESCRIPTION
The commonisation of test cases implemented at https://github.com/liam-hq/liam/pull/169, https://github.com/liam-hq/liam/pull/181, https://github.com/liam-hq/liam/pull/185 are reflected in some of the tests.
Looks like it's a done deal once and for all.

- test: Add foreign key test cases for one-to-many, one-to-one, and actions

