### PR TITLE
Fix handling of `--` comment lines with semicolons in `processSQLInChunks`

### DIFF
--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.test.ts
@@ -47,5 +47,18 @@ describe(processSQLInChunks, () => {
 
       expect(callback).not.toHaveBeenCalled()
     })
+
+    it('should correctly process SQL chunks while ignoring semicolons in comment lines starting with "--"', async () => {
+      const input =
+        'SELECT 1;\nSELECT 2;\n-- This is a comment line; additional text here should be ignored.\nSELECT 3;\nSELECT 4;'
+      const chunkSize = 3
+      const callback = vi.fn()
+
+      await processSQLInChunks(input, chunkSize, callback)
+
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(callback).toHaveBeenCalledWith('SELECT 1;\nSELECT 2;\nSELECT 3;')
+      expect(callback).toHaveBeenCalledWith('SELECT 4;')
+    })
   })
 })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
@@ -10,14 +10,17 @@ export const processSQLInChunks = async (
   chunkSize: number,
   callback: (chunk: string) => Promise<void>,
 ): Promise<void> => {
-  const lines = input.split('\n')
+  const semicolon = ';'
+  // Even though the parser can handle "--", we remove such lines for ease of splitting by semicolons.
+  const lines = input.split('\n').filter((line) => !line.startsWith('--'))
+
   let partialStmt = ''
 
   for (let i = 0; i < lines.length; i += chunkSize) {
     const chunk = lines.slice(i, i + chunkSize).join('\n')
     const combined = partialStmt + chunk
 
-    const lastSemicolonIndex = combined.lastIndexOf(';')
+    const lastSemicolonIndex = combined.lastIndexOf(semicolon)
     if (lastSemicolonIndex === -1) {
       partialStmt = combined
       continue


### PR DESCRIPTION

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Updated `processSQLInChunks` to ignore lines starting with `--` during processing by filtering them out.


## Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

- tested manually ✔️ 


## Other Information
<!-- Add any other relevant information for the reviewer. -->
