### PR TITLE
Add error logging to parse function for debugging purposes

### DIFF
--- a/frontend/packages/db-structure/src/parser/sql/postgresql/parser.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/parser.ts
@@ -6,6 +6,8 @@ import Module from 'pg-query-emscripten'
 export const parse = async (str: string): Promise<RawStmtWrapper[]> => {
   const pgQuery = await new Module()
   const result = pgQuery.parse(str)
+  // should we have --verbose or --debug mode?
+  if (result.error) console.error(result.error)
   return result
 }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Add error logging to parse function for debugging purposes

## Related Issue
<!-- Mention the related issue number if applicable. -->
N/A

## Changes
<!-- List the main changes made in this PR. -->


## Testing
<!-- Briefly describe the testing steps or results. -->

### Manually tested:

Make diff

```diff
--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
@@ -12,7 +12,7 @@ export const processSQLInChunks = async (
 ): Promise<void> => {
   const semicolon = ';'
   // Even though the parser can handle "--", we remove such lines for ease of splitting by semicolons.
-  const lines = input.split('\n').filter((line) => !line.startsWith('--'))
+  const lines = input.split('\n')
   let partialStmt = ''
```

Then, built the project and attempted to parse the problematic SQL, which resulted in the following error:

```
$ node dist-cli/bin/cli.js erd build --input /Users/hoshino/.local/share/go/src/github.com/giselles-ai/giselle/dump.sql --format postgres
(node:95908) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
{
  message: 'syntax error at or near "Owner"',
  funcname: 'scanner_yyerror',
  filename: 'scan.l',
  lineno: 1259,
  cursorpos: 2,
  context: ''
}
```

<img width="856" alt="2024-12-12 17 07 29" src="https://github.com/user-attachments/assets/aa826fbe-0765-4ad5-bd39-279ee76626fb" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->

This is only for `--format postgres` for now. 🙏 