### PR TITLE
refactor: reduce throwing errors

### DIFF
--- a/frontend/packages/cli/src/cli/runPreprocess.ts
+++ b/frontend/packages/cli/src/cli/runPreprocess.ts
@@ -21,19 +21,11 @@ export async function runPreprocess(
     )
   }
 
-  let json = null
-  try {
-    const { value, errors } = await parse(input, format)
-    json = value
-    if (errors.length > 0) {
-      for (const error of errors) {
-        console.error(error)
-      }
+  const { value: json, errors } = await parse(input, format)
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(error)
     }
-  } catch (error) {
-    throw new Error(
-      `Failed to parse ${format} file: ${error instanceof Error ? error.message : String(error)}`,
-    )
   }
 
   const filePath = path.join(outputDir, 'schema.json')

--- a/frontend/packages/db-structure/src/parser/index.ts
+++ b/frontend/packages/db-structure/src/parser/index.ts
@@ -10,7 +10,6 @@ export const supportedFormatSchema = v.union([
 
 export type SupportedFormat = v.InferOutput<typeof supportedFormatSchema>
 
-// TODO: Add error handling and tests
 export const parse = (
   str: string,
   format: SupportedFormat,
@@ -20,7 +19,5 @@ export const parse = (
       return schemarbProcessor(str)
     case 'postgres':
       return postgresqlProcessor(str)
-    default:
-      throw new Error(`Unsupported format: ${format}`)
   }
 }


### PR DESCRIPTION
Stop throwing errors and return the error class to the caller.
This makes it easier to take error handling into account on the CLI side. For example, adjusting the log level.