### PR TITLE
feat: update ELK layout options for improved node placement and spacing

### DIFF
--- a/.changeset/ten-ravens-wave.md
+++ b/.changeset/ten-ravens-wave.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+feat: update ELK layout options for improved node placement and spacing

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/getElkLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/getElkLayout.ts
@@ -6,9 +6,17 @@ import { convertElkNodesToNodes } from './convertElkNodesToNodes'
 import { convertNodesToElkNodes } from './convertNodesToElkNodes'
 
 const elk = new ELK()
+
 const layoutOptions: LayoutOptions = {
-  'elk.algorithm': 'org.eclipse.elk.layered',
-  'elk.layered.spacing.baseValue': '32',
+  'elk.algorithm': 'layered',
+  'elk.layered.spacing.baseValue': '40',
+  'elk.spacing.componentComponent': '80',
+  'elk.layered.spacing.edgeNodeBetweenLayers': '120',
+  'elk.layered.considerModelOrder.strategy': 'PREFER_EDGES',
+  'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
+  'elk.layered.mergeEdges': 'true',
+  'elk.layered.nodePlacement.strategy': 'INTERACTIVE',
+  'elk.layered.layering.strategy': 'INTERACTIVE',
 }
 
 type Params = {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I adjusted the layout so that the nodes are arranged from left to right.


![スクリーンショット 2024-12-13 18 29 33](https://github.com/user-attachments/assets/6fb3e355-ec31-4dee-9634-2ff6b1a7442f)
