### PR TITLE
feat: Enable panning on scroll

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -181,6 +181,8 @@ export const ERDContent: FC<Props> = ({
     [setEdges],
   )
 
+  const panOnDrag = [1, 2]
+
   return (
     <div className={styles.wrapper}>
       <ReactFlow
@@ -196,6 +198,9 @@ export const ERDContent: FC<Props> = ({
         onNodeMouseLeave={handleMouseLeaveNode}
         onEdgeMouseEnter={handleMouseEnterEdge}
         onEdgeMouseLeave={handleMouseLeaveEdge}
+        panOnScroll
+        panOnDrag={panOnDrag}
+        selectionOnDrag
       >
         <Background
           color="var(--color-gray-600)"


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Enable Figma-like Viewport Controls:

* pan: Space + scroll, middle or right mouse
* zoom: pitch or cmd + scroll
* create selection: drag mouse

ref: https://reactflow.dev/learn/concepts/the-viewport#figma-like-viewport-controls

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
