### PR TITLE
feat: Add rehypeCodeOptions for theme customization in MDX configuration

### DIFF
--- a/frontend/apps/docs/source.config.ts
+++ b/frontend/apps/docs/source.config.ts
@@ -7,6 +7,12 @@ export const { docs, meta } = defineDocs({
 
 export default defineConfig({
   mdxOptions: {
+    rehypeCodeOptions: {
+      themes: {
+        light: 'light-plus', // undetermined
+        dark: 'github-dark-high-contrast',
+      },
+    },
     remarkPlugins: [remarkInstall],
   },
 })


### PR DESCRIPTION

|before|after|
| --- | --- |
| <img width="849" alt="スクリーンショット 2024-12-13 17 06 41" src="https://github.com/user-attachments/assets/9d139b1e-1038-477f-b26d-3b0fe9ab0118" /> | <img width="849" alt="スクリーンショット 2024-12-13 17 07 22" src="https://github.com/user-attachments/assets/86a32cf9-a936-4d0b-a6e1-6d254f2f52db" /> |

ref: https://liam-docs-a0f2ekb62-route-06-core.vercel.app/docs/static-build/getting-started
ref: https://github.com/fuma-nama/fumadocs/discussions/946#discussioncomment-10921878

As the document is not to be published, no changeset has been added.
