### PR TITLE
refactor: optimize edge highlighting using useReactFlow hooks

### DIFF
--- a/.changeset/tiny-needles-refuse.md
+++ b/.changeset/tiny-needles-refuse.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+refactor: optimize edge highlighting using useReactFlow hooks

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -10,6 +10,7 @@ import {
   ReactFlow,
   useEdgesState,
   useNodesState,
+  useReactFlow,
 } from '@xyflow/react'
 import { type FC, useCallback, useEffect } from 'react'
 import styles from './ERDContent.module.css'
@@ -61,6 +62,7 @@ export const ERDContent: FC<Props> = ({
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
   const { relationships } = useDBStructureStore()
+  const { updateEdgeData, updateEdge } = useReactFlow()
 
   useEffect(() => {
     setNodes(_nodes)
@@ -153,32 +155,18 @@ export const ERDContent: FC<Props> = ({
 
   const handleMouseEnterEdge: EdgeMouseHandler<Edge> = useCallback(
     (_, { id }) => {
-      setEdges((edges) =>
-        edges.map((e) =>
-          e.id === id
-            ? { ...e, animated: true, data: { ...e.data, isHighlighted: true } }
-            : e,
-        ),
-      )
+      updateEdge(id, { animated: true })
+      updateEdgeData(id, { isHighlighted: true })
     },
-    [setEdges],
+    [updateEdge, updateEdgeData],
   )
 
   const handleMouseLeaveEdge: EdgeMouseHandler<Edge> = useCallback(
     (_, { id }) => {
-      setEdges((edges) =>
-        edges.map((e) =>
-          e.id === id
-            ? {
-                ...e,
-                animated: false,
-                data: { ...e.data, isHighlighted: false },
-              }
-            : e,
-        ),
-      )
+      updateEdge(id, { animated: false })
+      updateEdgeData(id, { isHighlighted: false })
     },
-    [setEdges],
+    [updateEdge, updateEdgeData],
   )
 
   const panOnDrag = [1, 2]


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

When there is only one target for updating, it is simpler to use the updateEdge function instead of the setEdges function, so I replaced it with the updateEdge function.

ref. https://github.com/xyflow/xyflow/discussions/4496#discussioncomment-10189904