### PR TITLE
fix: disable delete key functionality in ERDContent component

### DIFF
--- a/.changeset/tender-cooks-melt.md
+++ b/.changeset/tender-cooks-melt.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+fix: disable delete key functionality for delete TableNode

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -201,6 +201,7 @@ export const ERDContent: FC<Props> = ({
         panOnScroll
         panOnDrag={panOnDrag}
         selectionOnDrag
+        deleteKeyCode={null} // Turn off because it does not want to be deleted
       >
         <Background
           color="var(--color-gray-600)"


### PR DESCRIPTION
I was reading the react flow documentation and noticed that the Node disappeared when I pressed the delete key during selection 😂


https://github.com/user-attachments/assets/b56c3fd3-809e-44ed-b696-5440b79df7e1

ref: https://reactflow.dev/api-reference/react-flow#keyboard-props

That functionality is not needed and has been turned off.
