### PR TITLE
Review changeset configuration to resolve errors in GitHub Actions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.4/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "../frontend/node_modules/@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION


## Summary

Follow-up to https://github.com/liam-hq/liam/pull/243

From https://github.com/liam-hq/liam/pull/243, the `Version Package` PR was no longer being created. 🙇 

It seems that the changelog package could not be found, possibly due to the use of a symlink. 

Referring to https://github.com/changesets/changesets/issues/945#issuecomment-1264614341, I attempted to fix it by updating relative path.


## Related Issue
N/A


## Changes
- Updated the `changelog` path in `.changeset/config.json` 


## Testing
- Made a test commit: 011ace0a8e9a71fbb2cc663557d9583112fa1ee5 
- Verified that GitHub Actions ran successfully: 👌 https://github.com/liam-hq/liam/actions/runs/12314225561.
- Confirmed that the `Version Package` PR was successfully created: 👌 https://github.com/liam-hq/liam/pull/254.

Additionally, confirmed that the `pnpm changeset` command works locally in the `frontend/` directory after applying these changes.


## Other Information
N/A