### PR TITLE
feat: Enabled toggling the visibility of Table Nodes from the Left Pane

### DIFF
--- a/frontend/.changeset/hot-pillows-give.md
+++ b/frontend/.changeset/hot-pillows-give.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+SidebarMenuAction component is now available

--- a/frontend/.changeset/shaggy-plants-tan.md
+++ b/frontend/.changeset/shaggy-plants-tan.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+Enabled toggling the visibility of Table Nodes from the Left Pane.

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -26,7 +26,10 @@ type Data = {
   highlightedHandles: string[]
 }
 
-type TableNodeType = Node<Data, 'Table'>
+export type TableNodeType = Node<Data, 'table'>
+
+export const isTableNode = (node: Node): node is TableNodeType =>
+  node.type === 'table'
 
 type Props = NodeProps<TableNodeType>
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/index.ts
@@ -1,1 +1,2 @@
 export * from './ERDContent'
+export * from './TableNode'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -30,23 +30,23 @@ export const ERDRenderer: FC = () => {
     <div className={styles.wrapper}>
       <AppBar />
       <SidebarProvider defaultOpen={defaultOpen}>
-        <div className={styles.mainWrapper}>
-          <LeftPane />
-          <main className={styles.main}>
-            <div className={styles.triggerWrapper}>
-              <SidebarTrigger />
-            </div>
-            <TableDetailDrawerRoot>
-              <ReactFlowProvider>
+        <ReactFlowProvider>
+          <div className={styles.mainWrapper}>
+            <LeftPane />
+            <main className={styles.main}>
+              <div className={styles.triggerWrapper}>
+                <SidebarTrigger />
+              </div>
+              <TableDetailDrawerRoot>
                 <ERDContent nodes={nodes} edges={edges} />
                 <div className={styles.toolbarWrapper}>
                   <Toolbar />
                 </div>
-              </ReactFlowProvider>
-              <TableDetailDrawer />
-            </TableDetailDrawerRoot>
-          </main>
-        </div>
+                <TableDetailDrawer />
+              </TableDetailDrawerRoot>
+            </main>
+          </div>
+        </ReactFlowProvider>
       </SidebarProvider>
     </div>
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -6,28 +6,14 @@ import {
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
   SidebarRail,
 } from '@liam-hq/ui'
-import { Table2 } from '@liam-hq/ui'
-import {
-  updateActiveTableName,
-  useDBStructureStore,
-  useUserEditingStore,
-} from '../../../stores'
-import styles from './LeftPane.module.css'
+import { useDBStructureStore } from '../../../stores'
 import { TableCounter } from './TableCounter'
-
-const handleClickMenuButton = (tableId: string) => () => {
-  updateActiveTableName(tableId)
-}
+import { TableNameMenuButton } from './TableNameMenuButton'
 
 export const LeftPane = () => {
   const { tables } = useDBStructureStore()
-  const {
-    active: { tableName },
-  } = useUserEditingStore()
 
   return (
     <Sidebar>
@@ -37,15 +23,7 @@ export const LeftPane = () => {
           <SidebarGroupContent>
             <SidebarMenu>
               {Object.values(tables).map((table) => (
-                <SidebarMenuItem key={table.name}>
-                  <SidebarMenuButton
-                    onClick={handleClickMenuButton(table.name)}
-                    className={table.name === tableName ? styles.active : ''}
-                  >
-                    <Table2 width="10px" />
-                    <span className={styles.tableName}>{table.name}</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
+                <TableNameMenuButton key={table.name} table={table} />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -8,12 +8,15 @@ import {
   SidebarMenu,
   SidebarRail,
 } from '@liam-hq/ui'
-import { useDBStructureStore } from '../../../stores'
+import { useNodes } from '@xyflow/react'
+import { useMemo } from 'react'
+import { isTableNode } from '../ERDContent'
 import { TableCounter } from './TableCounter'
 import { TableNameMenuButton } from './TableNameMenuButton'
 
 export const LeftPane = () => {
-  const { tables } = useDBStructureStore()
+  const nodes = useNodes()
+  const tableNodes = useMemo(() => nodes.filter(isTableNode), [nodes])
 
   return (
     <Sidebar>
@@ -22,8 +25,8 @@ export const LeftPane = () => {
           <SidebarGroupLabel>Tables</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {Object.values(tables).map((table) => (
-                <TableNameMenuButton key={table.name} table={table} />
+              {tableNodes.map((node) => (
+                <TableNameMenuButton key={node.id} node={node} />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -1,30 +1,33 @@
 import { updateActiveTableName, useUserEditingStore } from '@/stores'
-import type { Table } from '@liam-hq/db-structure'
 import { SidebarMenuButton, SidebarMenuItem, Table2 } from '@liam-hq/ui'
 import type { FC } from 'react'
+import type { TableNodeType } from '../../ERDContent'
 import styles from '../LeftPane.module.css'
+import { VisibilityButton } from './VisibilityButton'
 
 const handleClickMenuButton = (tableId: string) => () => {
   updateActiveTableName(tableId)
 }
 
 type Props = {
-  table: Table
+  node: TableNodeType
 }
 
-export const TableNameMenuButton: FC<Props> = ({ table }) => {
+export const TableNameMenuButton: FC<Props> = ({ node }) => {
   const {
     active: { tableName },
   } = useUserEditingStore()
+  const name = node.data.table.name
 
   return (
-    <SidebarMenuItem key={table.name}>
+    <SidebarMenuItem>
       <SidebarMenuButton
-        onClick={handleClickMenuButton(table.name)}
-        className={table.name === tableName ? styles.active : ''}
+        onClick={handleClickMenuButton(name)}
+        className={name === tableName ? styles.active : ''}
       >
         <Table2 width="10px" />
-        <span className={styles.tableName}>{table.name}</span>
+        <span className={styles.tableName}>{name}</span>
+        <VisibilityButton tableName={name} hidden={node.hidden} />
       </SidebarMenuButton>
     </SidebarMenuItem>
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -1,0 +1,31 @@
+import { updateActiveTableName, useUserEditingStore } from '@/stores'
+import type { Table } from '@liam-hq/db-structure'
+import { SidebarMenuButton, SidebarMenuItem, Table2 } from '@liam-hq/ui'
+import type { FC } from 'react'
+import styles from '../LeftPane.module.css'
+
+const handleClickMenuButton = (tableId: string) => () => {
+  updateActiveTableName(tableId)
+}
+
+type Props = {
+  table: Table
+}
+
+export const TableNameMenuButton: FC<Props> = ({ table }) => {
+  const {
+    active: { tableName },
+  } = useUserEditingStore()
+
+  return (
+    <SidebarMenuItem key={table.name}>
+      <SidebarMenuButton
+        onClick={handleClickMenuButton(table.name)}
+        className={table.name === tableName ? styles.active : ''}
+      >
+        <Table2 width="10px" />
+        <span className={styles.tableName}>{table.name}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.module.css
@@ -1,0 +1,4 @@
+.icon {
+  width: 12px;
+  height: 12px;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
@@ -1,0 +1,31 @@
+import { Eye, EyeClosed, SidebarMenuAction } from '@liam-hq/ui'
+import { useReactFlow } from '@xyflow/react'
+import { type FC, type MouseEvent, useCallback } from 'react'
+import styles from './VisibilityButton.module.css'
+
+type Props = {
+  tableName: string
+  hidden?: boolean | undefined
+}
+
+export const VisibilityButton: FC<Props> = ({ tableName, hidden }) => {
+  const { updateNode } = useReactFlow()
+
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation()
+      updateNode(tableName, (node) => ({ ...node, hidden: !node.hidden }))
+    },
+    [updateNode, tableName],
+  )
+
+  return (
+    <SidebarMenuAction showOnHover onClick={handleClick}>
+      {hidden ? (
+        <EyeClosed className={styles.icon} />
+      ) : (
+        <Eye className={styles.icon} />
+      )}
+    </SidebarMenuAction>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/index.ts
@@ -1,0 +1,1 @@
+export * from './TableNameMenuButton'

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -59,6 +59,10 @@
   overflow-y: auto;
 }
 
+.sidebarMenuItem {
+  position: relative;
+}
+
 .sidebarMenuButton {
   padding: var(--spacing-2);
   display: flex;
@@ -73,6 +77,23 @@
 
 .sidebarMenuButton:hover {
   background: var(--pane-background-hover);
+}
+
+.sidebarMenuAction {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: var(--spacing-2);
+}
+
+.sidebarMenuAction.showOnHover {
+  opacity: 0;
+  transition: opacity var(--default-hover-animation-duration)
+    var(--default-timing-function);
+}
+
+[data-sidebar='menu-item']:hover .sidebarMenuAction.showOnHover {
+  opacity: 1;
 }
 
 .sidebarGroupLabel {

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -332,7 +332,12 @@ SidebarMenu.displayName = 'SidebarMenu'
 
 const SidebarMenuItem = forwardRef<HTMLLIElement, ComponentProps<'li'>>(
   ({ className, ...props }, ref) => (
-    <li ref={ref} data-sidebar="menu-item" {...props} />
+    <li
+      ref={ref}
+      data-sidebar="menu-item"
+      className={clsx(styles.sidebarMenuItem, className)}
+      {...props}
+    />
   ),
 )
 SidebarMenuItem.displayName = 'SidebarMenuItem'
@@ -396,7 +401,18 @@ const SidebarMenuAction = forwardRef<
 >(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
   const Comp = asChild ? Slot : 'button'
 
-  return <Comp ref={ref} data-sidebar="menu-action" {...props} />
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="menu-action"
+      className={clsx(
+        styles.sidebarMenuAction,
+        showOnHover && styles.showOnHover,
+        className,
+      )}
+      {...props}
+    />
+  )
 })
 SidebarMenuAction.displayName = 'SidebarMenuAction'
 

--- a/frontend/packages/ui/src/icons/Eye.tsx
+++ b/frontend/packages/ui/src/icons/Eye.tsx
@@ -1,0 +1,8 @@
+import { Eye as PrimitiveEye } from 'lucide-react'
+import type { ComponentPropsWithoutRef, FC } from 'react'
+
+type Props = ComponentPropsWithoutRef<typeof PrimitiveEye>
+
+export const Eye: FC<Props> = (props) => (
+  <PrimitiveEye strokeWidth={1.5} {...props} />
+)

--- a/frontend/packages/ui/src/icons/EyeClosed.tsx
+++ b/frontend/packages/ui/src/icons/EyeClosed.tsx
@@ -1,0 +1,8 @@
+import { EyeClosed as PrimitiveEyeClosed } from 'lucide-react'
+import type { ComponentPropsWithoutRef, FC } from 'react'
+
+type Props = ComponentPropsWithoutRef<typeof PrimitiveEyeClosed>
+
+export const EyeClosed: FC<Props> = (props) => (
+  <PrimitiveEyeClosed strokeWidth={1.5} {...props} />
+)

--- a/frontend/packages/ui/src/icons/index.ts
+++ b/frontend/packages/ui/src/icons/index.ts
@@ -22,5 +22,7 @@ export * from './XIcon'
 export * from './CardinalityZeroOrManyLeftIcon'
 export * from './CardinalityZeroOrOneRightIcon'
 export * from './CardinalityZeroOrOneLeftIcon'
+export * from './Eye'
+export * from './EyeClosed'
 
 export { KeyRound, Hash } from 'lucide-react'


### PR DESCRIPTION
https://github.com/user-attachments/assets/e9cb717d-dd4f-4e84-a7f1-6fbbfdd0be25

Currently, a fitView is executed when a Table node is returned from hidden to visible. This will be fixed in another PR.