### PR TITLE
Use version from `package.json` in Liam CLI

### DIFF
--- a/frontend/.changeset/late-clouds-raise.md
+++ b/frontend/.changeset/late-clouds-raise.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": patch
+---
+
+`-V/--version` now displays the correct version number.

--- a/frontend/packages/cli/src/cli/index.test.ts
+++ b/frontend/packages/cli/src/cli/index.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import type { Command } from 'commander'
 import { describe, expect, it, vi } from 'vitest'
 import { buildCommand } from './commands/index.js'
@@ -21,6 +22,9 @@ describe('program', () => {
   it('should have the correct name and description', () => {
     expect(program.name()).toBe('liam')
     expect(program.description()).toBe('CLI tool for Liam')
+    const require = createRequire(import.meta.url)
+    const { version: packageVersion } = require('../../package.json')
+    expect(program.version()).toBe(packageVersion)
   })
 
   it('should have an "erd" command with subcommands', () => {

--- a/frontend/packages/cli/src/cli/index.ts
+++ b/frontend/packages/cli/src/cli/index.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import { Command } from 'commander'
 import { buildCommand } from './commands/index.js'
@@ -6,7 +7,10 @@ const distDir = path.join(process.cwd(), 'dist')
 
 const program = new Command()
 
-program.name('liam').description('CLI tool for Liam').version('0.0.0')
+const require = createRequire(import.meta.url)
+const { version } = require('../../package.json')
+
+program.name('liam').description('CLI tool for Liam').version(version)
 
 const erdCommand = new Command('erd').description('ERD commands')
 program.addCommand(erdCommand)


### PR DESCRIPTION


## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Refactored the CLI initialization to dynamically fetch the version number from `package.json` using `createRequire` from Node.js. This ensures the CLI version is automatically synchronized with the package version.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
