### PR TITLE
fix: Remove the highlight on Edge hover to prevent performance degradation

### DIFF
--- a/frontend/.changeset/violet-chicken-mate.md
+++ b/frontend/.changeset/violet-chicken-mate.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+fix: Removed the highlight on Edge hover to prevent performance degradation

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -4,13 +4,11 @@ import {
   Background,
   BackgroundVariant,
   type Edge,
-  type EdgeMouseHandler,
   type Node,
   type NodeMouseHandler,
   ReactFlow,
   useEdgesState,
   useNodesState,
-  useReactFlow,
 } from '@xyflow/react'
 import { type FC, useCallback, useEffect } from 'react'
 import styles from './ERDContent.module.css'
@@ -64,7 +62,6 @@ export const ERDContentInner: FC<Props> = ({
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
   const { relationships } = useDBStructureStore()
-  const { updateEdgeData, updateEdge } = useReactFlow()
   const {
     state: { loading },
   } = useERDContentContext()
@@ -154,22 +151,6 @@ export const ERDContentInner: FC<Props> = ({
     [edges, nodes, setNodes, setEdges],
   )
 
-  const handleMouseEnterEdge: EdgeMouseHandler<Edge> = useCallback(
-    (_, { id }) => {
-      updateEdge(id, { animated: true })
-      updateEdgeData(id, { isHighlighted: true })
-    },
-    [updateEdge, updateEdgeData],
-  )
-
-  const handleMouseLeaveEdge: EdgeMouseHandler<Edge> = useCallback(
-    (_, { id }) => {
-      updateEdge(id, { animated: false })
-      updateEdgeData(id, { isHighlighted: false })
-    },
-    [updateEdge, updateEdgeData],
-  )
-
   const panOnDrag = [1, 2]
 
   return (
@@ -185,8 +166,6 @@ export const ERDContentInner: FC<Props> = ({
         onEdgesChange={onEdgesChange}
         onNodeMouseEnter={handleMouseEnterNode}
         onNodeMouseLeave={handleMouseLeaveNode}
-        onEdgeMouseEnter={handleMouseEnterEdge}
-        onEdgeMouseLeave={handleMouseLeaveEdge}
         panOnScroll
         panOnDrag={panOnDrag}
         selectionOnDrag


### PR DESCRIPTION
The highlighting of single edges is removed as a feature as it does not contribute to the readability of the ER diagram.
This is motivated by the need to reduce the re-rendering that occurs when moving on the canvas.

## Before

https://github.com/user-attachments/assets/e0f08278-3859-43ef-93f1-cda8ced3692c

## After


https://github.com/user-attachments/assets/388e61c4-dcb0-4da0-b93d-dd6e062a1560

## Testing

```sh
npx react-scan@latest https://liam-erd-sample-gz7pse1m5-route-06-core.vercel.app/
```