### PR TITLE
fix: Fixed an issue where URL sharing in TableDetail sometimes did not work correctly

### DIFF
--- a/frontend/.changeset/twelve-impalas-type.md
+++ b/frontend/.changeset/twelve-impalas-type.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+fix: Fixed an issue where URL sharing in TableDetail sometimes did not work correctly

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -1,7 +1,7 @@
 import {
   updateActiveTableName,
   useDBStructureStore,
-  useUserEditingStore,
+  useUserEditingActiveStore,
 } from '@/stores'
 import { DrawerContent, DrawerPortal, DrawerRoot } from '@liam-hq/ui'
 import type { FC, PropsWithChildren } from 'react'
@@ -12,9 +12,9 @@ import styles from './TableDetailDrawer.module.css'
 const handleClose = () => updateActiveTableName(undefined)
 
 export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
-  const {
-    active: { tableName },
-  } = useUserEditingStore()
+  const { tableName } = useUserEditingActiveStore()
+  const { tables } = useDBStructureStore()
+  const open = Object.keys(tables).length > 0 && tableName !== undefined
 
   return (
     <DrawerRoot
@@ -23,7 +23,7 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
       // This behavior is an undocumented, unofficial usage and might change in the future.
       // ref: https://github.com/emilkowalski/vaul/blob/main/src/use-snap-points.ts
       snapPoints={[]}
-      open={tableName !== undefined}
+      open={open}
       onClose={handleClose}
     >
       {children}
@@ -33,9 +33,7 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
 
 export const TableDetailDrawer: FC = () => {
   const { tables } = useDBStructureStore()
-  const {
-    active: { tableName },
-  } = useUserEditingStore()
+  const { tableName } = useUserEditingActiveStore()
   const table = tables[tableName ?? '']
   const ariaDescribedBy =
     table?.comment == null

--- a/frontend/packages/erd-core/src/stores/userEditing/hooks.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/hooks.ts
@@ -2,3 +2,5 @@ import { useSnapshot } from 'valtio'
 import { userEditingStore } from './store'
 
 export const useUserEditingStore = () => useSnapshot(userEditingStore)
+export const useUserEditingActiveStore = () =>
+  useSnapshot(userEditingStore.active)


### PR DESCRIPTION
The feature to open TableDetail when opened with a URL with a query parameter did not work in some cases, which will be corrected.

https://liam-erd-sample-pzarkcxaz-route-06-core.vercel.app/?active=featured_tags

