### PR TITLE
fix: Fixed an issue where edges were displayed incorrectly when switching the show mode

### DIFF
--- a/frontend/.changeset/small-cameras-scream.md
+++ b/frontend/.changeset/small-cameras-scream.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+fix: Fixed an issue where edges were displayed incorrectly when switching the show mode

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -40,7 +40,11 @@ export const ERDRenderer: FC = () => {
                   <SidebarTrigger />
                 </div>
                 <TableDetailDrawerRoot>
-                  <ERDContent key={nodes.length} nodes={nodes} edges={edges} />
+                  <ERDContent
+                    key={`${nodes.length}-${showMode}`}
+                    nodes={nodes}
+                    edges={edges}
+                  />
                   <div className={styles.toolbarWrapper}>
                     <Toolbar />
                   </div>


### PR DESCRIPTION
- https://github.com/liam-hq/liam/pull/274

The above change caused a problem with the display when switching show mode.
This was because re-rendering was also required when changing the show mode.

https://github.com/user-attachments/assets/e3656514-0b31-42ca-8365-9cb5af911a94


