### PR TITLE
Refactor hidden node cardinalities

### DIFF
--- a/frontend/.changeset/plenty-masks-smash.md
+++ b/frontend/.changeset/plenty-masks-smash.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+Refactor visibility for hidden node cardinalities

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
@@ -1,3 +1,4 @@
+import { useHiddenNodesStore } from '@/stores/hiddenNodes'
 import type { Column, Relationships, Table } from '@liam-hq/db-structure'
 import { DiamondFillIcon, DiamondIcon, KeyRound } from '@liam-hq/ui'
 import { Handle, Position } from '@xyflow/react'
@@ -25,14 +26,19 @@ export const TableColumn: FC<TableColumnProps> = ({
 }) => {
   const handleId = `${table.name}-${column.name}`
 
-  const isSource = Object.values(relationships).some(
+  const hiddenNodes = useHiddenNodesStore()
+
+  const isVisibleSourceCardinality = Object.values(relationships).some(
     (relationship) =>
       relationship.primaryTableName === table.name &&
-      relationship.primaryColumnName === column.name,
+      relationship.primaryColumnName === column.name &&
+      !hiddenNodes.includes(relationship.foreignTableName),
   )
   const targetCardinality = Object.values(relationships).find(
-    ({ foreignTableName, foreignColumnName }) =>
-      foreignTableName === table.name && foreignColumnName === column.name,
+    ({ foreignTableName, foreignColumnName, primaryTableName }) =>
+      foreignTableName === table.name &&
+      foreignColumnName === column.name &&
+      !hiddenNodes.includes(primaryTableName),
   )?.cardinality
 
   return (
@@ -70,7 +76,7 @@ export const TableColumn: FC<TableColumnProps> = ({
         <span className={styles.columnType}>{column.type}</span>
       </span>
 
-      {isSource && (
+      {isVisibleSourceCardinality && (
         <>
           <Handle
             id={handleId}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
@@ -1,3 +1,4 @@
+import { addHiddenNode, removeHiddenNode } from '@/stores/hiddenNodes'
 import { Eye, EyeClosed, SidebarMenuAction } from '@liam-hq/ui'
 import { useReactFlow } from '@xyflow/react'
 import { type FC, type MouseEvent, useCallback } from 'react'
@@ -14,9 +15,10 @@ export const VisibilityButton: FC<Props> = ({ tableName, hidden }) => {
   const handleClick = useCallback(
     (event: MouseEvent) => {
       event.stopPropagation()
+      !hidden ? addHiddenNode(tableName) : removeHiddenNode(tableName)
       updateNode(tableName, (node) => ({ ...node, hidden: !node.hidden }))
     },
-    [updateNode, tableName],
+    [updateNode, tableName, hidden],
   )
 
   return (

--- a/frontend/packages/erd-core/src/stores/hiddenNodes/actions.ts
+++ b/frontend/packages/erd-core/src/stores/hiddenNodes/actions.ts
@@ -1,0 +1,14 @@
+import { hiddenNodesStore } from './store'
+
+export const addHiddenNode = (nodeId: string) => {
+  if (!hiddenNodesStore.nodes.includes(nodeId)) {
+    hiddenNodesStore.nodes.push(nodeId)
+  }
+}
+
+export const removeHiddenNode = (nodeId: string) => {
+  const index = hiddenNodesStore.nodes.indexOf(nodeId)
+  if (index !== -1) {
+    hiddenNodesStore.nodes.splice(index, 1)
+  }
+}

--- a/frontend/packages/erd-core/src/stores/hiddenNodes/hooks.ts
+++ b/frontend/packages/erd-core/src/stores/hiddenNodes/hooks.ts
@@ -1,0 +1,7 @@
+import { useSnapshot } from 'valtio'
+import { hiddenNodesStore } from './store'
+
+export const useHiddenNodesStore = () => {
+  const { nodes } = useSnapshot(hiddenNodesStore)
+  return nodes
+}

--- a/frontend/packages/erd-core/src/stores/hiddenNodes/index.ts
+++ b/frontend/packages/erd-core/src/stores/hiddenNodes/index.ts
@@ -1,0 +1,3 @@
+export * from './store'
+export * from './actions'
+export * from './hooks'

--- a/frontend/packages/erd-core/src/stores/hiddenNodes/store.ts
+++ b/frontend/packages/erd-core/src/stores/hiddenNodes/store.ts
@@ -1,0 +1,9 @@
+import { proxy } from 'valtio'
+
+type HiddenNodesStore = {
+  nodes: string[]
+}
+
+export const hiddenNodesStore = proxy<HiddenNodesStore>({
+  nodes: [],
+})


### PR DESCRIPTION
## Summary

When hiding node, cardinalities also should be hidden.
The case of using hidden tables function from Related Tables will be another PR.

### before

https://github.com/user-attachments/assets/90d3424f-c1a5-4d8f-b42e-f419043a6ac4

### after

https://github.com/user-attachments/assets/e3fa2a85-bb55-47e7-bfee-354b73986cb5


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
