### PR TITLE
refactor: Reduced performance degradation caused by calculations for source and target

### DIFF
--- a/frontend/.changeset/thirty-rabbits-travel.md
+++ b/frontend/.changeset/thirty-rabbits-travel.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+refactor: Reduced performance degradation caused by calculations for source and target

--- a/frontend/packages/db-structure/src/index.ts
+++ b/frontend/packages/db-structure/src/index.ts
@@ -7,6 +7,7 @@ export {
   type Index,
   type Indices,
   type Relationships,
+  type Cardinality,
   dbStructureSchema,
   aTable,
   aColumn,

--- a/frontend/packages/db-structure/src/schema/dbStructure.ts
+++ b/frontend/packages/db-structure/src/schema/dbStructure.ts
@@ -43,6 +43,8 @@ const tableSchema = v.object({
 export type Table = v.InferOutput<typeof tableSchema>
 
 const cardinalitySchema = v.picklist(['ONE_TO_ONE', 'ONE_TO_MANY'])
+export type Cardinality = v.InferOutput<typeof cardinalitySchema>
+
 const foreignKeyConstraintSchema = v.picklist([
   'CASCADE',
   'RESTRICT',

--- a/frontend/packages/db-structure/src/schema/index.ts
+++ b/frontend/packages/db-structure/src/schema/index.ts
@@ -10,6 +10,7 @@ export type {
   Index,
   Indices,
   ForeignKeyConstraint,
+  Cardinality,
 } from './dbStructure.js'
 export {
   aColumn,

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/Cardinality/Cardinality.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/Cardinality/Cardinality.tsx
@@ -1,3 +1,4 @@
+import type { Cardinality as CardinalityType } from '@liam-hq/db-structure'
 import {
   CardinalityZeroOrManyLeftIcon,
   CardinalityZeroOrOneLeftIcon,
@@ -9,7 +10,7 @@ import styles from './Cardinality.module.css'
 
 type CardinalityProps = {
   direction: 'left' | 'right'
-  cardinality: 'ONE_TO_ONE' | 'ONE_TO_MANY'
+  cardinality: CardinalityType
   isHighlighted: boolean
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
@@ -15,6 +15,7 @@ type TableColumnProps = {
   relationships: Relationships
   isHighlighted: boolean
   highlightedHandles: string[]
+  isSource: boolean
 }
 
 export const TableColumn: FC<TableColumnProps> = ({
@@ -23,25 +24,21 @@ export const TableColumn: FC<TableColumnProps> = ({
   relationships,
   isHighlighted,
   highlightedHandles,
+  isSource,
 }) => {
   const handleId = `${table.name}-${column.name}`
 
-  const { sourceColumns, targetCardinalities } = useMemo(() => {
-    const sourceColumns: Set<string> = new Set()
+  const { targetCardinalities } = useMemo(() => {
     const targetCardinalities: Record<string, string | undefined> = {}
 
     for (const relationship of Object.values(relationships)) {
-      const sourceKey = `${relationship.primaryTableName}-${relationship.primaryColumnName}`
-      sourceColumns.add(sourceKey)
-
       const targetKey = `${relationship.foreignTableName}-${relationship.foreignColumnName}`
       targetCardinalities[targetKey] = relationship.cardinality
     }
 
-    return { sourceColumns, targetCardinalities }
+    return { targetCardinalities }
   }, [relationships])
 
-  const isSource = sourceColumns.has(handleId)
   const targetCardinality = targetCardinalities[handleId]
 
   return (

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
@@ -1,8 +1,11 @@
-import type { Column, Relationships, Table } from '@liam-hq/db-structure'
+import type {
+  Cardinality as CardinalityType,
+  Column,
+  Table,
+} from '@liam-hq/db-structure'
 import { DiamondFillIcon, DiamondIcon, KeyRound } from '@liam-hq/ui'
 import { Handle, Position } from '@xyflow/react'
 import clsx from 'clsx'
-import { useMemo } from 'react'
 import type { FC } from 'react'
 import { match } from 'ts-pattern'
 import { Cardinality } from './Cardinality'
@@ -12,34 +15,21 @@ import styles from './TableColumn.module.css'
 type TableColumnProps = {
   table: Table
   column: Column
-  relationships: Relationships
   isHighlighted: boolean
   highlightedHandles: string[]
   isSource: boolean
+  targetCardinality?: CardinalityType | undefined
 }
 
 export const TableColumn: FC<TableColumnProps> = ({
   table,
   column,
-  relationships,
   isHighlighted,
   highlightedHandles,
   isSource,
+  targetCardinality,
 }) => {
   const handleId = `${table.name}-${column.name}`
-
-  const { targetCardinalities } = useMemo(() => {
-    const targetCardinalities: Record<string, string | undefined> = {}
-
-    for (const relationship of Object.values(relationships)) {
-      const targetKey = `${relationship.foreignTableName}-${relationship.foreignColumnName}`
-      targetCardinalities[targetKey] = relationship.cardinality
-    }
-
-    return { targetCardinalities }
-  }, [relationships])
-
-  const targetCardinality = targetCardinalities[handleId]
 
   return (
     <li key={column.name} className={styles.columnWrapper}>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumnList.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumnList.tsx
@@ -1,27 +1,22 @@
-import type { Relationships } from '@liam-hq/db-structure'
 import type { FC } from 'react'
 import type { Data } from '../type'
 import { TableColumn } from './TableColumn'
 
 type TableColumnListProps = {
   data: Data
-  relationships: Relationships
 }
 
-export const TableColumnList: FC<TableColumnListProps> = ({
-  data,
-  relationships,
-}) => (
+export const TableColumnList: FC<TableColumnListProps> = ({ data }) => (
   <ul>
     {Object.values(data.table.columns).map((column) => (
       <TableColumn
         key={column.name}
         table={data.table}
         column={column}
-        relationships={relationships}
         isHighlighted={data.isHighlighted}
         highlightedHandles={data.highlightedHandles ?? []}
         isSource={data.sourceColumnName === column.name}
+        targetCardinality={data.targetColumnCardinalities?.[column.name]}
       />
     ))}
   </ul>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumnList.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumnList.tsx
@@ -1,29 +1,27 @@
-import type { Relationships, Table } from '@liam-hq/db-structure'
+import type { Relationships } from '@liam-hq/db-structure'
 import type { FC } from 'react'
+import type { Data } from '../type'
 import { TableColumn } from './TableColumn'
 
 type TableColumnListProps = {
-  table: Table
+  data: Data
   relationships: Relationships
-  isHighlighted: boolean
-  highlightedHandles: string[]
 }
 
 export const TableColumnList: FC<TableColumnListProps> = ({
-  table,
+  data,
   relationships,
-  isHighlighted,
-  highlightedHandles,
 }) => (
   <ul>
-    {Object.values(table.columns).map((column) => (
+    {Object.values(data.table.columns).map((column) => (
       <TableColumn
         key={column.name}
-        table={table}
+        table={data.table}
         column={column}
         relationships={relationships}
-        isHighlighted={isHighlighted}
-        highlightedHandles={highlightedHandles}
+        isHighlighted={data.isHighlighted}
+        highlightedHandles={data.highlightedHandles ?? []}
+        isSource={data.sourceColumnName === column.name}
       />
     ))}
   </ul>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableHeader/TableHeader.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableHeader/TableHeader.tsx
@@ -1,4 +1,4 @@
-import { useDBStructureStore, useUserEditingStore } from '@/stores'
+import { useUserEditingStore } from '@/stores'
 import {
   Table2,
   TooltipContent,
@@ -10,22 +10,19 @@ import {
 import { Handle, Position } from '@xyflow/react'
 import clsx from 'clsx'
 import type { FC } from 'react'
+import type { Data } from '../type'
 import styles from './TableHeader.module.css'
 
 type Props = {
-  name: string
+  data: Data
 }
 
-export const TableHeader: FC<Props> = ({ name }) => {
+export const TableHeader: FC<Props> = ({ data }) => {
+  const name = data.table.name
   const { showMode } = useUserEditingStore()
-  const { relationships } = useDBStructureStore()
 
-  const isTarget = Object.values(relationships).some(
-    (relationship) => relationship.foreignTableName === name,
-  )
-  const isSource = Object.values(relationships).some(
-    (relationship) => relationship.primaryTableName === name,
-  )
+  const isTarget = data.targetColumnCardinalities !== undefined
+  const isSource = data.sourceColumnName !== undefined
 
   return (
     <div

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -46,9 +46,7 @@ export const TableNode: FC<Props> = ({ data }) => {
       onClick={handleClick}
     >
       <TableHeader name={data.table.name} />
-      {showMode === 'ALL_FIELDS' && (
-        <TableColumnList data={data} relationships={relationships} />
-      )}
+      {showMode === 'ALL_FIELDS' && <TableColumnList data={data} />}
     </button>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -17,24 +17,23 @@ export const isTableNode = (node: Node): node is TableNodeType =>
 
 type Props = NodeProps<TableNodeType>
 
-export const TableNode: FC<Props> = ({
-  data: { table, isRelated, isHighlighted, highlightedHandles },
-}) => {
+export const TableNode: FC<Props> = ({ data }) => {
   const { relationships } = useDBStructureStore()
   const {
     active: { tableName },
   } = useUserEditingStore()
 
-  const isActive = tableName === table.name
+  const isActive = tableName === data.table.name
 
   const isTableRelated =
-    isRelated || isRelatedToTable(relationships, table.name, tableName)
+    data.isRelated ||
+    isRelatedToTable(relationships, data.table.name, tableName)
 
   const { showMode } = useUserEditingStore()
 
   const handleClick = useCallback(() => {
-    updateActiveTableName(table.name)
-  }, [table])
+    updateActiveTableName(data.table.name)
+  }, [data])
 
   return (
     <button
@@ -46,14 +45,9 @@ export const TableNode: FC<Props> = ({
       )}
       onClick={handleClick}
     >
-      <TableHeader name={table.name} />
+      <TableHeader name={data.table.name} />
       {showMode === 'ALL_FIELDS' && (
-        <TableColumnList
-          table={table}
-          relationships={relationships}
-          isHighlighted={isHighlighted}
-          highlightedHandles={highlightedHandles ?? []}
-        />
+        <TableColumnList data={data} relationships={relationships} />
       )}
     </button>
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -45,7 +45,7 @@ export const TableNode: FC<Props> = ({ data }) => {
       )}
       onClick={handleClick}
     >
-      <TableHeader name={data.table.name} />
+      <TableHeader data={data} />
       {showMode === 'ALL_FIELDS' && <TableColumnList data={data} />}
     </button>
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -3,7 +3,6 @@ import {
   useDBStructureStore,
   useUserEditingStore,
 } from '@/stores'
-import type { Table } from '@liam-hq/db-structure'
 import type { Node, NodeProps } from '@xyflow/react'
 import clsx from 'clsx'
 import { type FC, useCallback } from 'react'
@@ -11,15 +10,7 @@ import { isRelatedToTable } from '../ERDContent'
 import { TableColumnList } from './TableColumnList'
 import { TableHeader } from './TableHeader'
 import styles from './TableNode.module.css'
-
-type Data = {
-  table: Table
-  isHighlighted: boolean
-  isRelated: boolean
-  highlightedHandles: string[]
-}
-
-export type TableNodeType = Node<Data, 'table'>
+import type { TableNodeType } from './type'
 
 export const isTableNode = (node: Node): node is TableNodeType =>
   node.type === 'table'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/index.ts
@@ -1,1 +1,2 @@
 export * from './TableNode'
+export * from './type'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
@@ -1,0 +1,12 @@
+import type { Table } from '@liam-hq/db-structure'
+import type { Node } from '@xyflow/react'
+
+export type Data = {
+  table: Table
+  isHighlighted: boolean
+  isRelated: boolean
+  highlightedHandles: string[]
+  sourceColumnName: string | undefined
+}
+
+export type TableNodeType = Node<Data, 'table'>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
@@ -1,4 +1,4 @@
-import type { Table } from '@liam-hq/db-structure'
+import type { Cardinality, Table } from '@liam-hq/db-structure'
 import type { Node } from '@xyflow/react'
 
 export type Data = {
@@ -7,6 +7,7 @@ export type Data = {
   isRelated: boolean
   highlightedHandles: string[]
   sourceColumnName: string | undefined
+  targetColumnCardinalities?: Record<string, Cardinality> | undefined
 }
 
 export type TableNodeType = Node<Data, 'table'>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
@@ -1,5 +1,5 @@
 import type { ShowMode } from '@/schemas/showMode'
-import type { DBStructure } from '@liam-hq/db-structure'
+import type { Cardinality, DBStructure } from '@liam-hq/db-structure'
 import type { Edge, Node } from '@xyflow/react'
 
 type Params = {
@@ -17,11 +17,19 @@ export const convertDBStructureToNodes = ({
   const tables = Object.values(dbStructure.tables)
   const relationships = Object.values(dbStructure.relationships)
   const sourceColumns = new Map<string, string>()
+  const tableColumnCardinalities = new Map<
+    string,
+    Record<string, Cardinality>
+  >()
   for (const relationship of relationships) {
     sourceColumns.set(
       relationship.primaryTableName,
       relationship.primaryColumnName,
     )
+    tableColumnCardinalities.set(relationship.foreignTableName, {
+      ...tableColumnCardinalities.get(relationship.foreignTableName),
+      [relationship.foreignColumnName]: relationship.cardinality,
+    })
   }
 
   const nodes: Node[] = tables.map((table) => {
@@ -31,6 +39,7 @@ export const convertDBStructureToNodes = ({
       data: {
         table,
         sourceColumnName: sourceColumns.get(table.name),
+        targetColumnCardinalities: tableColumnCardinalities.get(table.name),
       },
       position: { x: 0, y: 0 },
       zIndex: 1,

--- a/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
@@ -16,6 +16,13 @@ export const convertDBStructureToNodes = ({
 } => {
   const tables = Object.values(dbStructure.tables)
   const relationships = Object.values(dbStructure.relationships)
+  const sourceColumns = new Map<string, string>()
+  for (const relationship of relationships) {
+    sourceColumns.set(
+      relationship.primaryTableName,
+      relationship.primaryColumnName,
+    )
+  }
 
   const nodes: Node[] = tables.map((table) => {
     return {
@@ -23,6 +30,7 @@ export const convertDBStructureToNodes = ({
       type: 'table',
       data: {
         table,
+        sourceColumnName: sourceColumns.get(table.name),
       },
       position: { x: 0, y: 0 },
       zIndex: 1,


### PR DESCRIPTION
- Continued from https://github.com/liam-hq/liam/pull/278

The source and handle are now calculated only once at the beginning.
In addition to TableColumn, calculated values are now used in TableHeader.

## Experiment

Triggered `handleMouseLeaveNode` manually on the accounts table node to measure performance impact. (It is same as #278 )
I then checked the Ranked tab in the React Dev tool.

### Before

TableHeader calculations are at the top of the list.

<img width="1008" alt="スクリーンショット 2024-12-16 20 51 55" src="https://github.com/user-attachments/assets/3d3aba65-dbb9-464b-af19-b4efb1d80f32" />


### After

TableHeader calculations have disappeared from the top!

<img width="1008" alt="スクリーンショット 2024-12-16 20 52 27" src="https://github.com/user-attachments/assets/c7fdd1fe-f69d-40ff-9f7d-c8f0d2e3b422" />
