### PR TITLE
✨: Changed the default show mode to 'Table name only'

### DIFF
--- a/frontend/.changeset/sharp-queens-repair.md
+++ b/frontend/.changeset/sharp-queens-repair.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+✨Changed the default show mode to 'Table name only'

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -13,7 +13,7 @@ export const userEditingStore = proxy<UserEditingStore>({
   active: {
     tableName: undefined,
   },
-  showMode: 'ALL_FIELDS',
+  showMode: 'TABLE_NAME',
 })
 
 subscribe(userEditingStore.active, () => {


### PR DESCRIPTION
The default mode has been changed to reduce performance issues and affect the user's first-time experience.