### PR TITLE
Reduce the width of TableDetail to prevent TableNode from being obscured

### DIFF
--- a/frontend/.changeset/many-wasps-join.md
+++ b/frontend/.changeset/many-wasps-join.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+Reduce the width of TableDetail to prevent TableNode from being obscured

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
@@ -1,7 +1,7 @@
 .wrapper {
   display: grid;
   grid-template-rows: auto 1fr;
-  width: 500px;
+  width: 300px;
   height: 100%;
   border-left: 1px solid var(--pane-border, #383a3b);
   background-color: var(--pane-background, #232526);

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
@@ -8,7 +8,6 @@
   box-shadow: 0px 4px 20px 0px var(--shadow-basic-shadow, #000);
   word-break: break-all;
   list-style-position: outside;
-  margin-left: 12px;
 }
 
 .header {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
@@ -6,6 +6,9 @@
   border-left: 1px solid var(--pane-border, #383a3b);
   background-color: var(--pane-background, #232526);
   box-shadow: 0px 4px 20px 0px var(--shadow-basic-shadow, #000);
+  word-break: break-all;
+  list-style-position: outside;
+  margin-left: 12px;
 }
 
 .header {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Reduce the width of TableDetail to prevent TableNode from being obscured . 

width: 500 -> 300. 

#### after:

<img width="1183" alt="500to300" src="https://github.com/user-attachments/assets/b3d5d9c1-a8a1-4156-83c8-544d8b02d9de" />


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
