### PR TITLE
Highlight related edges and cardinalities when a TableNode is active.

### DIFF
--- a/frontend/.changeset/sour-candles-pay.md
+++ b/frontend/.changeset/sour-candles-pay.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+Highlight related edges and cardinalities when a TableNode is active.

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -65,7 +65,7 @@ export const ERDContentInner: FC<Props> = ({
   const {
     state: { loading },
   } = useERDContentContext()
-  const [clickedNodeId, setClickedNodeId] = useState<string | null>(null)
+  const [activeNodeId, setActiveNodeId] = useState<string | null>(null)
 
   useInitialAutoLayout()
   useActiveTableNameFromUrl()
@@ -75,7 +75,7 @@ export const ERDContentInner: FC<Props> = ({
 
   const handleNodeClick = useCallback(
     (nodeId: string) => {
-      setClickedNodeId(nodeId)
+      setActiveNodeId(nodeId)
 
       const relatedEdges = edges.filter(
         (e) => e.source === nodeId || e.target === nodeId,
@@ -136,7 +136,7 @@ export const ERDContentInner: FC<Props> = ({
   )
 
   const handlePaneClick = useCallback(() => {
-    setClickedNodeId(null)
+    setActiveNodeId(null)
 
     const updatedEdges = edges.map((e) => ({
       ...e,
@@ -208,10 +208,10 @@ export const ERDContentInner: FC<Props> = ({
 
   const handleMouseLeaveNode: NodeMouseHandler<Node> = useCallback(
     (_, { id }) => {
-      // If a node is clicked, do not remove the highlight
-      if (clickedNodeId) {
+      // If a node is active, do not remove the highlight
+      if (activeNodeId) {
         const relatedEdges = edges.filter(
-          (e) => e.source === clickedNodeId || e.target === clickedNodeId,
+          (e) => e.source === activeNodeId || e.target === activeNodeId,
         )
         const updatedEdges = edges.map((e) =>
           relatedEdges.includes(e)
@@ -232,25 +232,25 @@ export const ERDContentInner: FC<Props> = ({
           const isRelated = isRelatedToTable(
             relationships,
             node.id,
-            clickedNodeId,
+            activeNodeId,
           )
 
-          if (node.id === clickedNodeId || isRelated) {
+          if (node.id === activeNodeId || isRelated) {
             const highlightedTargetHandles = relatedEdges
               .filter(
                 (edge) =>
-                  edge.source === clickedNodeId && edge.target === node.id,
+                  edge.source === activeNodeId && edge.target === node.id,
               )
               .map((edge) => edge.targetHandle)
 
             const highlightedSourceHandles = relatedEdges
               .filter(
                 (edge) =>
-                  edge.target === clickedNodeId && edge.source === node.id,
+                  edge.target === activeNodeId && edge.source === node.id,
               )
               .map((edge) => edge.sourceHandle)
 
-            const isHighlighted = node.id === clickedNodeId
+            const isHighlighted = node.id === activeNodeId
 
             return {
               ...node,
@@ -301,7 +301,7 @@ export const ERDContentInner: FC<Props> = ({
         setNodes(updatedNodes)
       }
     },
-    [edges, nodes, setNodes, setEdges, clickedNodeId, relationships],
+    [edges, nodes, setNodes, setEdges, activeNodeId, relationships],
   )
 
   const panOnDrag = [1, 2]

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
@@ -8,7 +8,6 @@ export type Data = {
   highlightedHandles: string[]
   sourceColumnName: string | undefined
   targetColumnCardinalities?: Record<string, Cardinality> | undefined
-  onClick?: (tableName: string) => void
 }
 
 export type TableNodeType = Node<Data, 'table'>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/type.ts
@@ -8,6 +8,7 @@ export type Data = {
   highlightedHandles: string[]
   sourceColumnName: string | undefined
   targetColumnCardinalities?: Record<string, Cardinality> | undefined
+  onClick?: (tableName: string) => void
 }
 
 export type TableNodeType = Node<Data, 'table'>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Highlight related edges and cardinalities when a TableNode is active.
Preview: https://liam-erd-sample-gx3t0p2yn-route-06-core.vercel.app/

### Before
![ss 2506](https://github.com/user-attachments/assets/73ddb0ff-1d03-4a74-918c-de89ae69aa5c)


### After
![ss 2507](https://github.com/user-attachments/assets/f22b2c5a-9e39-43f7-a422-3ae2c5260284)



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
