### PR TITLE
Restored columnType visibility

### DIFF
--- a/frontend/.changeset/twenty-eggs-beam.md
+++ b/frontend/.changeset/twenty-eggs-beam.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+Restored columnType visibility.

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.module.css
@@ -48,7 +48,7 @@
   transition: opacity 300ms var(--default-timing-function);
 }
 
-.wrapper:hover .columnType {
+:global([data-erd='table-node']):hover .columnType {
   opacity: 1;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -44,6 +44,7 @@ export const TableNode: FC<Props> = ({ data }) => {
         isActive && styles.wrapperActive,
       )}
       onClick={handleClick}
+      data-erd="table-node"
     >
       <TableHeader data={data} />
       {showMode === 'ALL_FIELDS' && <TableColumnList data={data} />}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Resolved the problem that prevented the **column type** from being shown on TableNode hover.

### Before
![ss 2510](https://github.com/user-attachments/assets/66d967bd-273e-4be6-aa83-d7ae297116d0)

### After
![ss 2511](https://github.com/user-attachments/assets/e83fbb70-e14a-4e1d-8137-51ce26e9ae74)



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->

In contrast to the design, where column types are shown for all relevant TableNodes on hover, this implementation displays the column type only for the hovered TableNode.（In order to fix the bug quickly.）
