### PR TITLE
Enable clicking while Table Detail opened

### DIFF
--- a/frontend/.changeset/stale-bags-join.md
+++ b/frontend/.changeset/stale-bags-join.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+Enable clicking while Table Detail opened

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.module.css
@@ -2,6 +2,9 @@
   display: grid;
   grid-template-rows: auto 1fr;
   height: 100%;
+  /* NOTE: workaround for that drawer with modal={false} does not work */
+  /* ref: https://github.com/emilkowalski/vaul/issues/492 */
+  pointer-events: all;
 }
 
 .mainWrapper {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -25,6 +25,7 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
       snapPoints={[]}
       open={open}
       onClose={handleClose}
+      modal={false}
     >
       {children}
     </DrawerRoot>


### PR DESCRIPTION
## Summary

Enable clicking AppBar (mainly `Copy Link`) while Table Detail opened.

https://github.com/user-attachments/assets/2cb0a089-1645-4f43-b42c-9d8468168716

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information

There is an Issue that option `modal={false} leaves Drawer open with `pointer-events: none`.
This PR includes the workaround.

* https://github.com/emilkowalski/vaul/issues/492
