### PR TITLE
💄 feat: update styling sidebar menu

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -33,7 +33,7 @@ export const TableNameMenuButton: FC<Props> = ({ node }) => {
           onClick={handleClickMenuButton(name)}
           onKeyDown={handleClickMenuButton(name)}
         >
-          <Table2 width="10px" />
+          <Table2 size="10px" />
           <span className={styles.tableName}>{name}</span>
           <VisibilityButton tableName={name} hidden={node.hidden} />
         </div>

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -76,6 +76,7 @@
 }
 
 .sidebarMenuButton:hover {
+  padding-right: var(--spacing-9);
   background: var(--pane-background-hover);
 }
 
@@ -83,7 +84,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  right: var(--spacing-2);
+  right: var(--spacing-5);
 }
 
 .sidebarMenuAction.showOnHover {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

- Resolve Issue Where Table Display Toggle Icon Overlaps with Scrollbar in Left Pane

https://github.com/user-attachments/assets/02d78bc9-efe2-4a7e-8aaa-e9a8a34166c7

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

- Adjusted the position, spacing, and alignment of the eye icon for toggling table display in the left pane so that it no longer overlaps with the scrollbar.
- Adjusted the viewBox size of the TableName icon's SVG.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
