### PR TITLE
💄 feat: add nuance shadow for TableNode

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
@@ -5,6 +5,7 @@
   transition: border-color 300ms var(--default-timing-function), border-width
     300ms var(--default-timing-function);
   opacity: 1;
+  box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.4);
 }
 
 :global([data-loading='true']) .wrapper {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Added shadow to Table Node to add a floating nuance to give the impression that it is not too attached to an unrelated Edge.

https://github.com/user-attachments/assets/78e1f4ef-dfa7-4269-90fe-3341f2c87d65

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

- Add nuance shadow for TableNode.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
