### PR TITLE
fix: Fixed an issue where opening an active table from a query parameter would not highlight it

### DIFF
--- a/frontend/.changeset/happy-toes-speak.md
+++ b/frontend/.changeset/happy-toes-speak.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 Fixed an issue where opening an active table from a query parameter would not highlight it

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -16,9 +16,9 @@ import { ERDContentProvider, useERDContentContext } from './ERDContentContext'
 import { RelationshipEdge } from './RelationshipEdge'
 import { Spinner } from './Spinner'
 import { TableNode } from './TableNode'
-import { highlightNodesAndEdges } from './highlightNodesAndEdges'
 import { useFitViewWhenActiveTableChange } from './useFitViewWhenActiveTableChange'
 import { useInitialAutoLayout } from './useInitialAutoLayout'
+import { useSyncHighlightsActiveTableChange } from './useSyncHighlightsActiveTableChange'
 import { useUpdateNodeCardinalities } from './useUpdateNodeCardinalities'
 
 const nodeTypes = {
@@ -95,6 +95,7 @@ export const ERDContentInner: FC<Props> = ({
   const {
     state: { loading },
   } = useERDContentContext()
+  // TODO: remove activeNodeId state
   const [activeNodeId, setActiveNodeId] = useState<string | null>(null)
 
   useUpdateNodeCardinalities(nodes, relationships, setNodes)
@@ -102,34 +103,17 @@ export const ERDContentInner: FC<Props> = ({
   useFitViewWhenActiveTableChange(
     enabledFeatures?.fitViewWhenActiveTableChange ?? true,
   )
+  useSyncHighlightsActiveTableChange()
 
-  const handleNodeClick = useCallback(
-    (nodeId: string) => {
-      setActiveNodeId(nodeId)
-      updateActiveTableName(nodeId)
-
-      const { nodes: updatedNodes, edges: updatedEdges } =
-        highlightNodesAndEdges(nodes, edges, nodeId)
-
-      setEdges(updatedEdges)
-      setNodes(updatedNodes)
-    },
-    [edges, nodes, setNodes, setEdges],
-  )
+  const handleNodeClick = useCallback((nodeId: string) => {
+    setActiveNodeId(nodeId)
+    updateActiveTableName(nodeId)
+  }, [])
 
   const handlePaneClick = useCallback(() => {
     setActiveNodeId(null)
     updateActiveTableName(undefined)
-
-    const { nodes: updatedNodes, edges: updatedEdges } = highlightNodesAndEdges(
-      nodes,
-      edges,
-      undefined,
-    )
-
-    setEdges(updatedEdges)
-    setNodes(updatedNodes)
-  }, [edges, nodes, setNodes, setEdges])
+  }, [])
 
   const handleMouseEnterNode: NodeMouseHandler<Node> = useCallback(
     (_, { id }) => {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.tsx
@@ -20,7 +20,8 @@ export const TableNode: FC<Props> = ({ data }) => {
     showMode,
   } = useUserEditingStore()
 
-  const isActive = tableName === data.table.name
+  // TODO: remove tableName and isRelatedToTable() from here
+  const isActive = data.isActiveHighlighted || tableName === data.table.name
 
   const isTableHighlighted =
     data.isHighlighted ||

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useSyncHighlightsActiveTableChange.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useSyncHighlightsActiveTableChange.ts
@@ -1,0 +1,30 @@
+import { useUserEditingActiveStore } from '@/stores'
+import { useReactFlow } from '@xyflow/react'
+import { useEffect } from 'react'
+import { useERDContentContext } from './ERDContentContext'
+import { highlightNodesAndEdges } from './highlightNodesAndEdges'
+
+export const useSyncHighlightsActiveTableChange = () => {
+  const {
+    state: { initializeComplete },
+  } = useERDContentContext()
+  const { getNodes, setNodes, getEdges, setEdges } = useReactFlow()
+  const { tableName } = useUserEditingActiveStore()
+
+  useEffect(() => {
+    if (!initializeComplete) {
+      return
+    }
+
+    const nodes = getNodes()
+    const edges = getEdges()
+    const { nodes: updatedNodes, edges: updatedEdges } = highlightNodesAndEdges(
+      nodes,
+      edges,
+      tableName,
+    )
+
+    setEdges(updatedEdges)
+    setNodes(updatedNodes)
+  }, [initializeComplete, tableName, getNodes, getEdges, setNodes, setEdges])
+}


### PR DESCRIPTION
Fixed an issue where opening an active table from a query parameter would not highlight it 👍🏻 

## Blocking

~Merge after the following PR merged.~

- https://github.com/liam-hq/liam/pull/312

## Testing

- Click on table node → Target node becomes active
- Click on table name in LeftPane → target node becomes active
- URL contains `?active=${tableName}` → target node becomes active

