### PR TITLE
Ensure `related tables` reload when any table node becomes active

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.tsx
@@ -39,7 +39,7 @@ export const TableDetail: FC<Props> = ({ table }) => {
         <Columns columns={table.columns} />
         <Indices indices={table.indices} />
         <Unique columns={table.columns} />
-        <RelatedTables table={table} />
+        <RelatedTables key={table.name} table={table} />
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

For now, it appears that setting `modal={false}` in https://github.com/liam-hq/liam/pull/292 suppresses the re-rendering of the `RelatedTables` component. Therefore, I explicitly specified the `key` property.

https://github.com/liam-hq/liam/pull/316/commits/690b1594bb2e7a45150dca7eb4a1747c9b9975c2

https://github.com/user-attachments/assets/888f476b-9db8-490f-af65-d3d4bf4ed7e5



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
