### PR TITLE
refactor: integrate highlightNodesAndEdges function for improved node and edge highlighting on hover

### DIFF
--- a/frontend/.changeset/big-impalas-call.md
+++ b/frontend/.changeset/big-impalas-call.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+refactor: integrate highlightNodesAndEdges function for improved node and edge highlighting on hover

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
@@ -62,11 +62,9 @@ describe(highlightNodesAndEdges, () => {
 
   describe('nodes', () => {
     it('When the users is active, the users and related tables are highlighted', () => {
-      const { nodes: updatedNodes } = highlightNodesAndEdges(
-        nodes,
-        edges,
-        'users',
-      )
+      const { nodes: updatedNodes } = highlightNodesAndEdges(nodes, edges, {
+        activeTableName: 'users',
+      })
 
       expect(updatedNodes).toEqual([
         aTableNode('users', {
@@ -89,11 +87,9 @@ describe(highlightNodesAndEdges, () => {
     })
 
     it('When no active table, no tables are highlighted', () => {
-      const { nodes: updatedNodes } = highlightNodesAndEdges(
-        nodes,
-        edges,
-        undefined,
-      )
+      const { nodes: updatedNodes } = highlightNodesAndEdges(nodes, edges, {
+        activeTableName: undefined,
+      })
 
       expect(updatedNodes).toEqual([
         aTableNode('users', {
@@ -114,15 +110,37 @@ describe(highlightNodesAndEdges, () => {
         }),
       ])
     })
+    it('When the users is hovered, the users and related tables are highlighted', () => {
+      const { nodes: updatedNodes } = highlightNodesAndEdges(nodes, edges, {
+        hoverTableName: 'users',
+      })
+
+      expect(updatedNodes).toEqual([
+        aTableNode('users', {
+          data: aTableData('users', { isHighlighted: true }),
+        }),
+        aTableNode('posts', {
+          data: aTableData('posts', {
+            isHighlighted: true,
+            highlightedHandles: ['posts-user_id'],
+          }),
+        }),
+        aTableNode('comments'),
+        aTableNode('comment_users', {
+          data: aTableData('comment_users', {
+            isHighlighted: true,
+            highlightedHandles: ['comment_users-user_id'],
+          }),
+        }),
+      ])
+    })
   })
 
   describe('edges', () => {
     it('When the users is active, the users and related edges are highlighted', () => {
-      const { edges: updatedEdges } = highlightNodesAndEdges(
-        nodes,
-        edges,
-        'users',
-      )
+      const { edges: updatedEdges } = highlightNodesAndEdges(nodes, edges, {
+        activeTableName: 'users',
+      })
 
       expect(updatedEdges).toEqual([
         anEdge('users', 'posts', 'users-id', 'posts-user_id', {
@@ -143,11 +161,9 @@ describe(highlightNodesAndEdges, () => {
     })
 
     it('When no active table, no edges are highlighted', () => {
-      const { edges: updatedEdges } = highlightNodesAndEdges(
-        nodes,
-        edges,
-        undefined,
-      )
+      const { edges: updatedEdges } = highlightNodesAndEdges(nodes, edges, {
+        activeTableName: undefined,
+      })
 
       expect(updatedEdges).toEqual([
         anEdge('users', 'posts', 'users-id', 'posts-user_id', {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
@@ -182,5 +182,27 @@ describe(highlightNodesAndEdges, () => {
         ),
       ])
     })
+    it('When the users is hovered, the users and related edges are highlighted', () => {
+      const { edges: updatedEdges } = highlightNodesAndEdges(nodes, edges, {
+        hoverTableName: 'users',
+      })
+
+      expect(updatedEdges).toEqual([
+        anEdge('users', 'posts', 'users-id', 'posts-user_id', {
+          animated: true,
+          data: { isHighlighted: true },
+        }),
+        anEdge('users', 'comment_users', 'users-id', 'comment_users-user_id', {
+          animated: true,
+          data: { isHighlighted: true },
+        }),
+        anEdge(
+          'comments',
+          'comment_users',
+          'comments-id',
+          'comment_users-comment_id',
+        ),
+      ])
+    })
   })
 })

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
@@ -134,6 +134,33 @@ describe(highlightNodesAndEdges, () => {
         }),
       ])
     })
+    it('When the users is active, and the comments is hovered, then the users and comments and related tables are highlighted', () => {
+      const { nodes: updatedNodes } = highlightNodesAndEdges(nodes, edges, {
+        activeTableName: 'users',
+        hoverTableName: 'comments',
+      })
+
+      expect(updatedNodes).toEqual([
+        aTableNode('users', {
+          data: aTableData('users', { isActiveHighlighted: true }),
+        }),
+        aTableNode('posts', {
+          data: aTableData('posts', {
+            isHighlighted: true,
+            highlightedHandles: ['posts-user_id'],
+          }),
+        }),
+        aTableNode('comments', {
+          data: aTableData('comments', { isHighlighted: true }),
+        }),
+        aTableNode('comment_users', {
+          data: aTableData('comment_users', {
+            isHighlighted: true,
+            highlightedHandles: ['comment_users-user_id'],
+          }),
+        }),
+      ])
+    })
   })
 
   describe('edges', () => {
@@ -201,6 +228,33 @@ describe(highlightNodesAndEdges, () => {
           'comment_users',
           'comments-id',
           'comment_users-comment_id',
+        ),
+      ])
+    })
+    it('When the users is active, and the comments is hovered, then the users and comments and related edges are highlighted', () => {
+      const { edges: updatedEdges } = highlightNodesAndEdges(nodes, edges, {
+        activeTableName: 'users',
+        hoverTableName: 'comments',
+      })
+
+      expect(updatedEdges).toEqual([
+        anEdge('users', 'posts', 'users-id', 'posts-user_id', {
+          animated: true,
+          data: { isHighlighted: true },
+        }),
+        anEdge('users', 'comment_users', 'users-id', 'comment_users-user_id', {
+          animated: true,
+          data: { isHighlighted: true },
+        }),
+        anEdge(
+          'comments',
+          'comment_users',
+          'comments-id',
+          'comment_users-comment_id',
+          {
+            animated: true,
+            data: { isHighlighted: true },
+          },
         ),
       ])
     })

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
@@ -158,7 +158,10 @@ export const highlightNodesAndEdges = (
   })
 
   const updatedEdges = edges.map((edge) => {
-    if (isRelatedEdgeToTarget(activeTableName ?? hoverTableName, edge)) {
+    if (
+      isRelatedEdgeToTarget(activeTableName, edge) ||
+      isRelatedEdgeToTarget(hoverTableName, edge)
+    ) {
       return highlightEdge(edge)
     }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
@@ -12,16 +12,16 @@ const isActiveNode = (
   return node.data.table.name === activeTableName
 }
 
-const isActivelyRelatedNode = (
-  activeTableName: string | undefined,
+const isRelatedNodeToTarget = (
+  targetTableName: string | undefined,
   edgeMap: EdgeMap,
   node: TableNodeType,
 ): boolean => {
-  if (!activeTableName) {
+  if (!targetTableName) {
     return false
   }
 
-  return edgeMap.get(activeTableName)?.includes(node.data.table.name) ?? false
+  return edgeMap.get(targetTableName)?.includes(node.data.table.name) ?? false
 }
 
 const isHoveredNode = (
@@ -29,18 +29,6 @@ const isHoveredNode = (
   node: TableNodeType,
 ): boolean => {
   return node.data.table.name === hoverTableName
-}
-
-const isHoverRelatedNode = (
-  hoverTableName: string | undefined,
-  edgeMap: EdgeMap,
-  node: TableNodeType,
-): boolean => {
-  if (!hoverTableName) {
-    return false
-  }
-
-  return edgeMap.get(hoverTableName)?.includes(node.data.table.name) ?? false
 }
 
 const isActivelyRelatedEdge = (
@@ -51,11 +39,11 @@ const isActivelyRelatedEdge = (
 }
 
 const getHighlightedHandlesForRelatedNode = (
-  activeTableName: string | undefined,
+  targetTableName: string | undefined,
   edges: Edge[],
   node: TableNodeType,
 ): string[] => {
-  if (!activeTableName) {
+  if (!targetTableName) {
     return []
   }
 
@@ -64,7 +52,7 @@ const getHighlightedHandlesForRelatedNode = (
     if (
       edge.targetHandle !== undefined &&
       edge.targetHandle !== null &&
-      edge.source === activeTableName &&
+      edge.source === targetTableName &&
       edge.target === node.data.table.name
     ) {
       handles.push(edge.targetHandle)
@@ -74,7 +62,7 @@ const getHighlightedHandlesForRelatedNode = (
       edge.sourceHandle !== undefined &&
       edge.sourceHandle !== null &&
       edge.source === node.data.table.name &&
-      edge.target === activeTableName
+      edge.target === targetTableName
     ) {
       handles.push(edge.sourceHandle)
     }
@@ -154,9 +142,9 @@ export const highlightNodesAndEdges = (
     }
 
     if (
-      isActivelyRelatedNode(activeTableName, edgeMap, node) ||
+      isRelatedNodeToTarget(activeTableName, edgeMap, node) ||
       isHoveredNode(hoverTableName, node) ||
-      isHoverRelatedNode(hoverTableName, edgeMap, node)
+      isRelatedNodeToTarget(hoverTableName, edgeMap, node)
     ) {
       const highlightedHandles = getHighlightedHandlesForRelatedNode(
         activeTableName ?? hoverTableName,

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
@@ -31,11 +31,11 @@ const isHoveredNode = (
   return node.data.table.name === hoverTableName
 }
 
-const isActivelyRelatedEdge = (
-  activeTableName: string | undefined,
+const isRelatedEdgeToTarget = (
+  targetTableName: string | undefined,
   edge: Edge,
 ): boolean => {
-  return edge.source === activeTableName || edge.target === activeTableName
+  return edge.source === targetTableName || edge.target === targetTableName
 }
 
 const getHighlightedHandlesForRelatedNode = (
@@ -158,7 +158,7 @@ export const highlightNodesAndEdges = (
   })
 
   const updatedEdges = edges.map((edge) => {
-    if (isActivelyRelatedEdge(activeTableName, edge)) {
+    if (isRelatedEdgeToTarget(activeTableName ?? hoverTableName, edge)) {
       return highlightEdge(edge)
     }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
@@ -24,6 +24,25 @@ const isActivelyRelatedNode = (
   return edgeMap.get(activeTableName)?.includes(node.data.table.name) ?? false
 }
 
+const isHoveredNode = (
+  hoverTableName: string | undefined,
+  node: TableNodeType,
+): boolean => {
+  return node.data.table.name === hoverTableName
+}
+
+const isHoverRelatedNode = (
+  hoverTableName: string | undefined,
+  edgeMap: EdgeMap,
+  node: TableNodeType,
+): boolean => {
+  if (!hoverTableName) {
+    return false
+  }
+
+  return edgeMap.get(hoverTableName)?.includes(node.data.table.name) ?? false
+}
+
 const isActivelyRelatedEdge = (
   activeTableName: string | undefined,
   edge: Edge,
@@ -109,8 +128,12 @@ const unhighlightEdge = (edge: Edge): Edge => ({
 export const highlightNodesAndEdges = (
   nodes: Node[],
   edges: Edge[],
-  activeTableName?: string | undefined,
+  trigger: {
+    activeTableName?: string | undefined
+    hoverTableName?: string | undefined
+  },
 ): { nodes: Node[]; edges: Edge[] } => {
+  const { activeTableName, hoverTableName } = trigger
   const edgeMap: EdgeMap = new Map()
   for (const edge of edges) {
     const sourceTableName = edge.source
@@ -130,9 +153,13 @@ export const highlightNodesAndEdges = (
       return activeHighlightNode(node)
     }
 
-    if (isActivelyRelatedNode(activeTableName, edgeMap, node)) {
+    if (
+      isActivelyRelatedNode(activeTableName, edgeMap, node) ||
+      isHoveredNode(hoverTableName, node) ||
+      isHoverRelatedNode(hoverTableName, edgeMap, node)
+    ) {
       const highlightedHandles = getHighlightedHandlesForRelatedNode(
-        activeTableName,
+        activeTableName ?? hoverTableName,
         edges,
         node,
       )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useSyncHighlightsActiveTableChange.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useSyncHighlightsActiveTableChange.ts
@@ -21,7 +21,7 @@ export const useSyncHighlightsActiveTableChange = () => {
     const { nodes: updatedNodes, edges: updatedEdges } = highlightNodesAndEdges(
       nodes,
       edges,
-      tableName,
+      { activeTableName: tableName },
     )
 
     setEdges(updatedEdges)


### PR DESCRIPTION
- ref: https://github.com/liam-hq/liam/pull/313
- ref: https://github.com/liam-hq/liam/pull/312
- ref: https://github.com/liam-hq/liam/pull/309

Highlighting on hover is now also supported with `highlightNodesAndEdges()`.

## Blocking
~Merge after the following PR merged.~

- https://github.com/liam-hq/liam/pull/313

## Testing

- Click on table node → Target node becomes active
- Click on table name in LeftPane → target node becomes active
- URL contains ?active=${tableName} → target node becomes active
- Hover on table node → Target node becomes hovered state

