### PR TITLE
✨ Grouping TableNodes without Relationships into a GroupNode and Applying a New Layout Definition

### DIFF
--- a/frontend/.changeset/dry-ligers-work.md
+++ b/frontend/.changeset/dry-ligers-work.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+✨ Enhance node conversion functions to support hierarchical structure and layout options for NonRelatedTableGroup nodes

--- a/frontend/.changeset/mean-rings-walk.md
+++ b/frontend/.changeset/mean-rings-walk.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+✨ Add NonRelatedTableGroupNode component with styling

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -75,7 +75,7 @@ export const ERDContentInner: FC<Props> = ({
   } = useERDContentContext()
   const { tableName: activeTableName } = useUserEditingActiveStore()
 
-  useInitialAutoLayout()
+  useInitialAutoLayout(nodes)
   useFitViewWhenActiveTableChange(
     enabledFeatures?.fitViewWhenActiveTableChange ?? true,
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -17,6 +17,7 @@ import { type FC, useCallback } from 'react'
 import { CardinalityMarkers } from './CardinalityMarkers'
 import styles from './ERDContent.module.css'
 import { ERDContentProvider, useERDContentContext } from './ERDContentContext'
+import { NonRelatedTableGroupNode } from './NonRelatedTableGroupNode'
 import { RelationshipEdge } from './RelationshipEdge'
 import { Spinner } from './Spinner'
 import { TableNode } from './TableNode'
@@ -28,6 +29,7 @@ import { useSyncHighlightsActiveTableChange } from './useSyncHighlightsActiveTab
 
 const nodeTypes = {
   table: TableNode,
+  nonRelatedTableGroup: NonRelatedTableGroupNode,
 }
 
 const edgeTypes = {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/NonRelatedTableGroupNode/NonRelatedTableGroupNode.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/NonRelatedTableGroupNode/NonRelatedTableGroupNode.module.css
@@ -1,0 +1,9 @@
+.wrapper {
+  width: 100%;
+  height: 100%;
+  opacity: 1;
+}
+
+:global([data-loading='true']) .wrapper {
+  opacity: 0;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/NonRelatedTableGroupNode/NonRelatedTableGroupNode.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/NonRelatedTableGroupNode/NonRelatedTableGroupNode.tsx
@@ -1,0 +1,12 @@
+import type { Node } from '@xyflow/react'
+import type { FC } from 'react'
+import styles from './NonRelatedTableGroupNode.module.css'
+
+export type NonRelatedTableGroupNodeType = Node<
+  Record<string, unknown>,
+  'nonRelatedTableGroup'
+>
+
+export const NonRelatedTableGroupNode: FC = () => {
+  return <div className={styles.wrapper} />
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/NonRelatedTableGroupNode/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/NonRelatedTableGroupNode/index.ts
@@ -1,0 +1,1 @@
+export * from './NonRelatedTableGroupNode'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/convertElkNodesToNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/convertElkNodesToNodes.ts
@@ -19,6 +19,12 @@ export function convertElkNodesToNodes(
       width: elkNode.width ?? 0,
       height: elkNode.height ?? 0,
     })
+
+    if (elkNode.children) {
+      for (const child of elkNode.children) {
+        nodes.push(...convertElkNodesToNodes([child], originNodes))
+      }
+    }
   }
 
   return nodes

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/convertNodesToElkNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/convertNodesToElkNodes.ts
@@ -2,9 +2,39 @@ import type { Node } from '@xyflow/react'
 import type { ElkNode } from 'elkjs'
 
 export function convertNodesToElkNodes(nodes: Node[]): ElkNode[] {
-  return nodes.map((node) => ({
-    ...node,
-    width: node.measured?.width ?? 0,
-    height: node.measured?.height ?? 0,
-  }))
+  const nodeMap: Record<string, ElkNode> = {}
+
+  const elkNodes: ElkNode[] = []
+  for (const node of nodes) {
+    const elkNode: ElkNode = {
+      ...node,
+      width: node.measured?.width ?? 0,
+      height: node.measured?.height ?? 0,
+      layoutOptions: {
+        /**
+         * NOTE
+         * For NonRelatedTableGroup Nodes, arrange child Nodes in a vertical layout.
+         * For all other cases, use default values.
+         */
+        'elk.aspectRatio':
+          node.type === 'nonRelatedTableGroup' ? '0.5625' : '1.6f',
+      },
+    }
+    nodeMap[node.id] = elkNode
+
+    if (node.parentId) {
+      const parentNode = nodeMap[node.parentId]
+      if (!parentNode) continue
+
+      if (!parentNode.children) {
+        parentNode.children = []
+      }
+
+      parentNode.children.push(elkNode)
+    } else {
+      elkNodes.push(elkNode)
+    }
+  }
+
+  return elkNodes
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -1,8 +1,8 @@
 import type { QueryParam } from '@/schemas/queryParam'
 import { addHiddenNodeIds, updateActiveTableName } from '@/stores'
 import { decompressFromEncodedURIComponent } from '@/utils'
-import { useReactFlow } from '@xyflow/react'
-import { useEffect } from 'react'
+import type { Node } from '@xyflow/react'
+import { useEffect, useMemo } from 'react'
 import { useERDContentContext } from './ERDContentContext'
 import { useAutoLayout } from './useAutoLayout'
 
@@ -25,9 +25,14 @@ const getHiddenNodeIdsFromUrl = async (): Promise<string[]> => {
   return hiddenNodeIds ? hiddenNodeIds.split(',') : []
 }
 
-export const useInitialAutoLayout = () => {
-  const { getNodes } = useReactFlow()
-  const nodes = getNodes()
+export const useInitialAutoLayout = (nodes: Node[]) => {
+  const tableNodesInitialized = useMemo(
+    () =>
+      nodes
+        .filter((node) => node.type === 'table')
+        .some((node) => node.measured),
+    [nodes],
+  )
 
   const {
     state: { initializeComplete },
@@ -39,10 +44,6 @@ export const useInitialAutoLayout = () => {
       if (initializeComplete) {
         return
       }
-
-      const tableNodesInitialized = nodes
-        .filter((node) => node.type === 'table')
-        .some((node) => node.measured)
 
       const tableNameFromUrl = getActiveTableNameFromUrl()
       updateActiveTableName(tableNameFromUrl)
@@ -59,5 +60,5 @@ export const useInitialAutoLayout = () => {
     }
 
     initialize()
-  }, [initializeComplete, nodes, handleLayout])
+  }, [tableNodesInitialized, initializeComplete, handleLayout])
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -1,7 +1,7 @@
 import type { QueryParam } from '@/schemas/queryParam'
 import { addHiddenNodeIds, updateActiveTableName } from '@/stores'
 import { decompressFromEncodedURIComponent } from '@/utils'
-import { useNodesInitialized } from '@xyflow/react'
+import { useReactFlow } from '@xyflow/react'
 import { useEffect } from 'react'
 import { useERDContentContext } from './ERDContentContext'
 import { useAutoLayout } from './useAutoLayout'
@@ -26,7 +26,9 @@ const getHiddenNodeIdsFromUrl = async (): Promise<string[]> => {
 }
 
 export const useInitialAutoLayout = () => {
-  const nodesInitialized = useNodesInitialized()
+  const { getNodes } = useReactFlow()
+  const nodes = getNodes()
+
   const {
     state: { initializeComplete },
   } = useERDContentContext()
@@ -38,6 +40,10 @@ export const useInitialAutoLayout = () => {
         return
       }
 
+      const tableNodesInitialized = nodes
+        .filter((node) => node.type === 'table')
+        .some((node) => node.measured)
+
       const tableNameFromUrl = getActiveTableNameFromUrl()
       updateActiveTableName(tableNameFromUrl)
       const hiddenNodeIds = await getHiddenNodeIdsFromUrl()
@@ -47,11 +53,11 @@ export const useInitialAutoLayout = () => {
         ? { maxZoom: 1, duration: 300, nodes: [{ id: tableNameFromUrl }] }
         : undefined
 
-      if (nodesInitialized) {
+      if (tableNodesInitialized) {
         handleLayout(fitViewOptions, hiddenNodeIds)
       }
     }
 
     initialize()
-  }, [nodesInitialized, initializeComplete, handleLayout])
+  }, [initializeComplete, nodes, handleLayout])
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I have grouped TableNodes without Relationships into a GroupNode, allowing a new layout definition to be applied. 
The new layout definition arranges the Nodes in a single vertical column.

| Before | After |
|--------|--------|
| <img width="1489" alt="スクリーンショット 2024-12-19 17 36 17" src="https://github.com/user-attachments/assets/d4316eae-01c6-4e7b-8b8e-5a23c4084dda" /> | <img width="1489" alt="スクリーンショット 2024-12-19 17 35 54" src="https://github.com/user-attachments/assets/7ff016ef-7a79-4e12-a08a-7ee64d7b3660" /> | 


