### PR TITLE
📈: integrate toggle logging for sidebar and visibility button actions

### DIFF
--- a/frontend/.changeset/ninety-llamas-beam.md
+++ b/frontend/.changeset/ninety-llamas-beam.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+📈: integrate toggle logging for sidebar and visibility button actions

--- a/frontend/.changeset/slimy-cycles-press.md
+++ b/frontend/.changeset/slimy-cycles-press.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+📈 : add toggleLogEvent utility for logging toggle actions

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -6,12 +6,13 @@ import {
   getSidebarStateFromCookie,
 } from '@liam-hq/ui'
 import { ReactFlowProvider } from '@xyflow/react'
-import type { FC } from 'react'
+import { type FC, useCallback, useState } from 'react'
 import { AppBar } from './AppBar'
 import { ERDContent } from './ERDContent'
 import styles from './ERDRenderer.module.css'
 import { LeftPane } from './LeftPane'
 import '@/styles/globals.css'
+import { toggleLogEvent } from '@/features/gtm/utils'
 import { useDBStructureStore, useUserEditingStore } from '@/stores'
 // biome-ignore lint/nursery/useImportRestrictions: Fixed in the next PR.
 import { Toolbar } from './ERDContent/Toolbar'
@@ -20,6 +21,8 @@ import { convertDBStructureToNodes } from './convertDBStructureToNodes'
 
 export const ERDRenderer: FC = () => {
   const defaultOpen = getSidebarStateFromCookie()
+  const [open, setOpen] = useState(defaultOpen)
+
   const { showMode } = useUserEditingStore()
   const dbStructure = useDBStructureStore()
   const { nodes, edges } = convertDBStructureToNodes({
@@ -27,11 +30,23 @@ export const ERDRenderer: FC = () => {
     showMode,
   })
 
+  const handleChangeOpen = useCallback((open: boolean) => {
+    setOpen(open)
+    toggleLogEvent({
+      element: 'leftPane',
+      isShow: open,
+    })
+  }, [])
+
   return (
     <div className={styles.wrapper}>
       <ToastProvider>
         <AppBar />
-        <SidebarProvider defaultOpen={defaultOpen}>
+        <SidebarProvider
+          open={open}
+          defaultOpen={defaultOpen}
+          onOpenChange={handleChangeOpen}
+        >
           <ReactFlowProvider>
             <div className={styles.mainWrapper}>
               <LeftPane />

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
@@ -1,3 +1,4 @@
+import { toggleLogEvent } from '@/features/gtm/utils'
 import { toggleHiddenNodeId } from '@/stores'
 import { Eye, EyeClosed, SidebarMenuAction } from '@liam-hq/ui'
 import { type FC, type MouseEvent, useCallback } from 'react'
@@ -13,8 +14,13 @@ export const VisibilityButton: FC<Props> = ({ tableName, hidden }) => {
     (event: MouseEvent) => {
       event.stopPropagation()
       toggleHiddenNodeId(tableName)
+      toggleLogEvent({
+        element: 'tableNameMenuButton',
+        isShow: !!hidden,
+        tableId: tableName,
+      })
     },
-    [tableName],
+    [tableName, hidden],
   )
 
   return (

--- a/frontend/packages/erd-core/src/features/gtm/utils/index.ts
+++ b/frontend/packages/erd-core/src/features/gtm/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './clickLogEvent'
 export * from './selectTableLogEvent'
+export * from './toggleLogEvent'

--- a/frontend/packages/erd-core/src/features/gtm/utils/toggleLogEvent.ts
+++ b/frontend/packages/erd-core/src/features/gtm/utils/toggleLogEvent.ts
@@ -1,0 +1,14 @@
+import { pushToDataLayer } from './pushToDataLayer'
+
+type ToggleLogEvent = {
+  element: string
+  isShow: boolean
+  tableId?: string
+}
+
+export const toggleLogEvent = (params: ToggleLogEvent) => {
+  pushToDataLayer({
+    event: 'toggle',
+    ...params,
+  })
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I have implemented a feature to send toggle logs when showing/hiding the Left Pane and displaying/hiding the Table.

## Demo 

| toggle LeftPane |
|--------|
| <video src="https://github.com/user-attachments/assets/8838f732-b964-4310-9f13-2f92871c84c0" /> |

| toggle TableName |
|--------|
| <video src="https://github.com/user-attachments/assets/93bad96c-f79c-4cc7-b593-2026e6d4cb38" /> |



