### PR TITLE
feat: hidden nodes can now be reflected from query parameters

### DIFF
--- a/frontend/.changeset/empty-parents-knock.md
+++ b/frontend/.changeset/empty-parents-knock.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+feat: hidden nodes can now be reflected from query parameters

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -20,6 +20,7 @@ import { TableNode } from './TableNode'
 import { highlightNodesAndEdges } from './highlightNodesAndEdges'
 import { useFitViewWhenActiveTableChange } from './useFitViewWhenActiveTableChange'
 import { useInitialAutoLayout } from './useInitialAutoLayout'
+import { useSyncHiddenNodesChange } from './useSyncHiddenNodesChange'
 import { useSyncHighlightsActiveTableChange } from './useSyncHighlightsActiveTableChange'
 
 const nodeTypes = {
@@ -74,6 +75,7 @@ export const ERDContentInner: FC<Props> = ({
     enabledFeatures?.fitViewWhenActiveTableChange ?? true,
   )
   useSyncHighlightsActiveTableChange()
+  useSyncHiddenNodesChange()
 
   const handleNodeClick = useCallback((nodeId: string) => {
     updateActiveTableName(nodeId)

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
@@ -1,5 +1,9 @@
 import { convertDBStructureToNodes } from '@/components/ERDRenderer/convertDBStructureToNodes'
-import { updateActiveTableName, useDBStructureStore } from '@/stores'
+import {
+  replaceHiddenNodeIds,
+  updateActiveTableName,
+  useDBStructureStore,
+} from '@/stores'
 import type { Table } from '@liam-hq/db-structure'
 import { GotoIcon, IconButton } from '@liam-hq/ui'
 import { ReactFlowProvider, useReactFlow } from '@xyflow/react'
@@ -19,17 +23,17 @@ export const RelatedTables: FC<Props> = ({ table }) => {
     dbStructure: extractedDBStructure,
     showMode: 'TABLE_NAME',
   })
-  const { setNodes } = useReactFlow()
+  const { getNodes } = useReactFlow()
   const handleClick = useCallback(() => {
     const visibleNodeIds: string[] = nodes.map((node) => node.id)
-    setNodes((mainPaneNodes) => {
-      return mainPaneNodes.map((node) => ({
-        ...node,
-        hidden: !visibleNodeIds.includes(node.id),
-      }))
-    })
+    const mainPaneNodes = getNodes()
+    const hiddenNodeIds = mainPaneNodes
+      .filter((node) => !visibleNodeIds.includes(node.id))
+      .map((node) => node.id)
+
+    replaceHiddenNodeIds(hiddenNodeIds)
     updateActiveTableName(undefined)
-  }, [nodes, setNodes])
+  }, [nodes, getNodes])
 
   return (
     <div className={styles.wrapper}>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/useAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/useAutoLayout.ts
@@ -11,12 +11,23 @@ export const useAutoLayout = () => {
   } = useERDContentContext()
 
   const handleLayout = useCallback(
-    async (fitViewOptions?: FitViewOptions) => {
+    async (
+      fitViewOptions: FitViewOptions = {},
+      initialHiddenNodeIds: string[] = [],
+    ) => {
       setLoading(true)
       const nodes = getNodes()
       const edges = getEdges()
-      const visibleNodes: Node[] = nodes.filter((node) => !node.hidden)
-      const hiddenNodes: Node[] = nodes.filter((node) => node.hidden)
+
+      const hiddenNodes: Node[] = []
+      const visibleNodes: Node[] = []
+      for (const node of nodes) {
+        if (initialHiddenNodeIds.includes(node.id) || node.hidden) {
+          hiddenNodes.push({ ...node, hidden: true })
+        } else {
+          visibleNodes.push(node)
+        }
+      }
 
       // NOTE: Only include edges where both the source and target are in the nodes
       const nodeMap = new Map(visibleNodes.map((node) => [node.id, node]))

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -1,5 +1,5 @@
 import type { QueryParam } from '@/schemas/queryParam'
-import { updateActiveTableName } from '@/stores'
+import { addHiddenNodeIds, updateActiveTableName } from '@/stores'
 import { useNodesInitialized } from '@xyflow/react'
 import { useEffect } from 'react'
 import { useERDContentContext } from './ERDContentContext'
@@ -11,6 +11,14 @@ const getActiveTableNameFromUrl = (): string | undefined => {
   const tableName = urlParams.get(activeQueryParam)
 
   return tableName || undefined
+}
+
+const getHiddenNodeIdsFromUrl = (): string[] => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const hiddenQueryParam: QueryParam = 'hidden'
+  const hiddenNodeIds = urlParams.get(hiddenQueryParam)
+
+  return hiddenNodeIds ? hiddenNodeIds.split(',') : []
 }
 
 export const useInitialAutoLayout = () => {
@@ -27,12 +35,15 @@ export const useInitialAutoLayout = () => {
 
     const tableNameFromUrl = getActiveTableNameFromUrl()
     updateActiveTableName(tableNameFromUrl)
+    const hiddenNodeIds = getHiddenNodeIdsFromUrl()
+    addHiddenNodeIds(hiddenNodeIds)
+
     const fitViewOptions = tableNameFromUrl
       ? { maxZoom: 1, duration: 300, nodes: [{ id: tableNameFromUrl }] }
       : undefined
 
     if (nodesInitialized) {
-      handleLayout(fitViewOptions)
+      handleLayout(fitViewOptions, hiddenNodeIds)
     }
   }, [nodesInitialized, initializeComplete, handleLayout])
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useSyncHiddenNodesChange.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useSyncHiddenNodesChange.ts
@@ -1,0 +1,25 @@
+import { useUserEditingStore } from '@/stores'
+import { useReactFlow } from '@xyflow/react'
+import { useEffect } from 'react'
+import { useERDContentContext } from './ERDContentContext'
+
+export const useSyncHiddenNodesChange = () => {
+  const {
+    state: { initializeComplete },
+  } = useERDContentContext()
+  const { getNodes, setNodes } = useReactFlow()
+  const { hiddenNodeIds } = useUserEditingStore()
+
+  useEffect(() => {
+    if (!initializeComplete) {
+      return
+    }
+    const nodes = getNodes()
+    const updatedNodes = nodes.map((node) => {
+      const hidden = hiddenNodeIds.has(node.id)
+      return { ...node, hidden }
+    })
+
+    setNodes(updatedNodes)
+  }, [initializeComplete, getNodes, setNodes, hiddenNodeIds])
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/VisibilityButton.tsx
@@ -1,5 +1,5 @@
+import { toggleHiddenNodeId } from '@/stores'
 import { Eye, EyeClosed, SidebarMenuAction } from '@liam-hq/ui'
-import { useReactFlow } from '@xyflow/react'
 import { type FC, type MouseEvent, useCallback } from 'react'
 import styles from './VisibilityButton.module.css'
 
@@ -9,14 +9,12 @@ type Props = {
 }
 
 export const VisibilityButton: FC<Props> = ({ tableName, hidden }) => {
-  const { updateNode } = useReactFlow()
-
   const handleClick = useCallback(
     (event: MouseEvent) => {
       event.stopPropagation()
-      updateNode(tableName, (node) => ({ ...node, hidden: !node.hidden }))
+      toggleHiddenNodeId(tableName)
     },
-    [updateNode, tableName],
+    [tableName],
   )
 
   return (

--- a/frontend/packages/erd-core/src/schemas/queryParam/schemas.ts
+++ b/frontend/packages/erd-core/src/schemas/queryParam/schemas.ts
@@ -1,3 +1,3 @@
 import { picklist } from 'valibot'
 
-export const queryParamSchema = picklist(['active'])
+export const queryParamSchema = picklist(['active', 'hidden'])

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -8,3 +8,22 @@ export const updateActiveTableName = (tableName: string | undefined) => {
 export const updateShowMode = (showMode: ShowMode) => {
   userEditingStore.showMode = showMode
 }
+
+export const toggleHiddenNodeId = (nodeId: string) => {
+  if (userEditingStore.hiddenNodeIds.has(nodeId)) {
+    userEditingStore.hiddenNodeIds.delete(nodeId)
+  } else {
+    userEditingStore.hiddenNodeIds.add(nodeId)
+  }
+}
+
+const addHiddenNodeIds = (nodeIds: string[]) => {
+  for (const id of nodeIds) {
+    userEditingStore.hiddenNodeIds.add(id)
+  }
+}
+
+export const replaceHiddenNodeIds = (nodeIds: string[]) => {
+  userEditingStore.hiddenNodeIds.clear()
+  addHiddenNodeIds(nodeIds)
+}

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -17,7 +17,7 @@ export const toggleHiddenNodeId = (nodeId: string) => {
   }
 }
 
-const addHiddenNodeIds = (nodeIds: string[]) => {
+export const addHiddenNodeIds = (nodeIds: string[]) => {
   for (const id of nodeIds) {
     userEditingStore.hiddenNodeIds.add(id)
   }

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -32,3 +32,16 @@ subscribe(userEditingStore.active, () => {
 
   window.history.pushState({}, '', url)
 })
+
+subscribe(userEditingStore.hiddenNodeIds, () => {
+  const url = new URL(window.location.href)
+  const activeQueryParam: QueryParam = 'hidden'
+  const hiddenNodeIds = Array.from(userEditingStore.hiddenNodeIds).join(',')
+
+  url.searchParams.delete(activeQueryParam)
+  if (hiddenNodeIds) {
+    url.searchParams.set(activeQueryParam, hiddenNodeIds)
+  }
+
+  window.history.pushState({}, '', url)
+})

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -1,12 +1,14 @@
 import type { QueryParam } from '@/schemas/queryParam'
 import type { ShowMode } from '@/schemas/showMode'
 import { proxy, subscribe } from 'valtio'
+import { proxySet } from 'valtio/utils'
 
 type UserEditingStore = {
   active: {
     tableName: string | undefined
   }
   showMode: ShowMode
+  hiddenNodeIds: Set<string>
 }
 
 export const userEditingStore = proxy<UserEditingStore>({
@@ -14,6 +16,7 @@ export const userEditingStore = proxy<UserEditingStore>({
     tableName: undefined,
   },
   showMode: 'TABLE_NAME',
+  hiddenNodeIds: proxySet<string>(),
 })
 
 subscribe(userEditingStore.active, () => {


### PR DESCRIPTION
hidden nodes can now be reflected from query parameters!


https://github.com/user-attachments/assets/c287e2a5-be9c-47f0-906a-6b0ed39a540a

As a side effect, the hidden information can now be maintained even if the showMode is changed 👍🏻 

However, the URL looks a little bad, as following:

https://liam-erd-sample-a6smzxm8k-route-06-core.vercel.app/?hidden=account_aliases%2Caccount_conversations%2Caccount_deletion_requests%2Caccount_domain_blocks%2Caccount_migrations%2Caccount_moderation_notes%2Caccount_notes%2Caccount_pins%2Caccount_relationship_severance_events%2Caccount_stats%2Caccount_statuses_cleanup_policies%2Caccount_warning_presets%2Caccount_warnings%2Caccounts%2Caccounts_tags%2Cadmin_action_logs%2Cannouncement_mutes%2Cannouncement_reactions%2Cannouncements%2Cannual_report_statuses_per_account_counts%2Cappeals%2Cbackups%2Cblocks%2Cbookmarks%2Cbulk_import_rows%2Cbulk_imports%2Ccanonical_email_blocks%2Cconversation_mutes%2Cconversations%2Ccustom_emoji_categories%2Ccustom_emojis%2Ccustom_filter_keywords%2Ccustom_filter_statuses%2Ccustom_filters%2Cdomain_allows%2Cdomain_blocks%2Cemail_domain_blocks%2Cfavourites%2Cfeatured_tags%2Cfollow_recommendation_mutes%2Cfollow_recommendation_suppressions%2Cfollow_requests%2Cfollows%2Cgenerated_annual_reports%2Cidentities%2Cimports%2Cinvites%2Cip_blocks%2Clist_accounts%2Clists%2Clogin_activities%2Cmarkers%2Cmedia_attachments%2Cmentions%2Cmutes%2Cnotification_permissions%2Cnotification_policies%2Cnotification_requests%2Cnotifications%2Coauth_access_grants%2Coauth_access_tokens%2Coauth_applications%2Cpghero_space_stats%2Cpoll_votes%2Cpolls%2Cpreview_card_providers%2Cpreview_card_trends%2Cpreview_cards%2Cpreview_cards_statuses%2Crelationship_severance_events%2Crelays%2Creport_notes%2Creports%2Crules%2Cscheduled_statuses%2Csession_activations%2Csettings%2Csevered_relationships%2Csite_uploads%2Csoftware_updates%2Cstatus_edits%2Cstatus_pins%2Cstatus_stats%2Cstatus_trends%2Cstatuses%2Cstatuses_tags%2Ctag_follows%2Ctag_trends%2Ctags%2Cterms_of_services%2Ctombstones%2Cunavailable_domains%2Cuser_invite_requests%2Cweb_push_subscriptions%2Cweb_settings%2Cwebauthn_credentials%2Cwebhooks

It may be possible to compress using `CompressionStream`. This will be considered for support in the next PR.

ref:
- [CompressionStream - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream)
- in japanese post: [続・URLシェアを支える技術 CompressionStream](https://zenn.dev/chot/articles/lz-string-vs-compression-stream)