### PR TITLE
fix: Render CardinalityMarkers based on loading state

### DIFF
--- a/frontend/.changeset/gentle-monkeys-remember.md
+++ b/frontend/.changeset/gentle-monkeys-remember.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+fix: Render CardinalityMarkers based on loading state

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -158,7 +158,7 @@ export const ERDContentInner: FC<Props> = ({
         selectionOnDrag
         deleteKeyCode={null} // Turn off because it does not want to be deleted
       >
-        <CardinalityMarkers />
+        {!loading && <CardinalityMarkers />}
         <Background
           color="var(--color-gray-600)"
           variant={BackgroundVariant.Dots}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -158,7 +158,7 @@ export const ERDContentInner: FC<Props> = ({
         selectionOnDrag
         deleteKeyCode={null} // Turn off because it does not want to be deleted
       >
-        {!loading && <CardinalityMarkers />}
+        <CardinalityMarkers />
         <Background
           color="var(--color-gray-600)"
           variant={BackgroundVariant.Dots}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
@@ -6,6 +6,7 @@
 
 :global([data-loading='true']) .edge {
   stroke: transparent;
+  opacity: 0;
 }
 
 marker {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Remove unexpected cardinalities on initial loading.

<img width="600" alt="貼り付けた画像_2024_12_20_16_49" src="https://github.com/user-attachments/assets/e9454770-5750-4447-96fc-5bbca60d6d71" />

### before

https://github.com/user-attachments/assets/e8c46f9c-d8ad-41bf-a675-21a2ff47c7ff

### after

https://github.com/user-attachments/assets/3769c4bd-588a-4956-a140-711a6ce266e8


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
