### PR TITLE
Set envName(`production` or `preview`) to cliVersion 

### DIFF
--- a/.github/workflows/vercel-deploy-erd-sample.yml
+++ b/.github/workflows/vercel-deploy-erd-sample.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Update index.html content
         run:  pnpm --filter ${{ matrix.apps.name }} update_dist_content
         working-directory: frontend
-        # if: ${{ main }}
       - name: Build Project Artifacts
         run: vercel build ${{ needs.setup-deployment.outputs.environment == 'production' && '--prod' || '' }}
       - name: Deploy Project Artifacts to Vercel

--- a/frontend/packages/cli/src/App.tsx
+++ b/frontend/packages/cli/src/App.tsx
@@ -28,6 +28,7 @@ loadSchemaContent()
 const cliVersionData = {
   version: import.meta.env.VITE_CLI_VERSION_VERSION,
   gitHash: import.meta.env.VITE_CLI_VERSION_GIT_HASH,
+  envName: import.meta.env.VITE_CLI_VERSION_ENV_NAME,
   isReleasedGitHash:
     import.meta.env.VITE_CLI_VERSION_IS_RELEASED_GIT_HASH === '1',
   date: import.meta.env.VITE_CLI_VERSION_DATE,

--- a/frontend/packages/erd-core/src/schemas/cliVersion/schemas.ts
+++ b/frontend/packages/erd-core/src/schemas/cliVersion/schemas.ts
@@ -3,6 +3,7 @@ import * as v from 'valibot'
 export const cliVersionSchema = v.object({
   version: v.string(),
   gitHash: v.string(),
+  envName: v.string(),
   isReleasedGitHash: v.boolean(),
   date: v.string(),
 })


### PR DESCRIPTION





## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Integrates the current envName(`production` or `preview`)   into the React component's environment variables.

There is no change to the visual behavior of the ERD HTML.



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

In local , make this diff

```diff
--- a/frontend/packages/erd-core/src/components/ERDRenderer/AppBar/HelpButton/ReleaseVersion.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/AppBar/HelpButton/ReleaseVersion.tsx
@@ -5,6 +5,8 @@ import styles from './ReleaseVersion.module.css'
 export const ReleaseVersion: FC = () => {
   const { cliVersion } = useCliVersion()

+  console.log('cliVersion:', cliVersion)
+
   // Example output for cliVersion:
   // - Released version:
   //   v0.0.11 (2024-12-19)
```

and `pnpm dev` , 

I found that `envName` set to `cliVersion`

<img width="537" alt="スクリーンショット 2024-12-20 17 10 56" src="https://github.com/user-attachments/assets/37888696-1926-4215-ada9-afe607c61011" />



## Other Information
<!-- Add any other relevant information for the reviewer. -->
