### PR TITLE
fix: Update css module for edge marker

### DIFF
--- a/frontend/.changeset/warm-suits-love.md
+++ b/frontend/.changeset/warm-suits-love.md
@@ -3,4 +3,4 @@
 "@liam-hq/cli": patch
 ---
 
-fix: Update css module for edge marker
+:recycle: Update css module for edge marker

--- a/frontend/.changeset/warm-suits-love.md
+++ b/frontend/.changeset/warm-suits-love.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+fix: Update css module for edge marker

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
@@ -9,10 +9,6 @@
   opacity: 0;
 }
 
-marker {
-  transition: stroke 0.3s var(--default-timing-function);
-}
-
 .hovered {
   stroke: var(--node-layout);
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

**There was error when compiling on Next.js:**

```
Parsing css source code failed
Selector is not pure (pure selectors must contain at least one local class or id), (lightningcss, Selector(marker, specificity = 0x1))
```

**This error means:**

In CSS Modules, “selectors that do not contain local classes or IDs” will result in an error, so if you write an element selector like this marker { ... } as is, you will get the following error } as it is, the following error will occur.

**Solution:**

Edge markers have different IDs depending on whether they are highlighted or not. Changing the color is implemented by replacing the SVG element because the color of markers can not be dynamically changed by CSS. Therefore, this CSS was not actually applied. Currently it is difficult to make the transition work because the elements are different.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
