### PR TITLE
docs: rewrite top page for first release

### DIFF
--- a/frontend/apps/docs/app/layout.config.tsx
+++ b/frontend/apps/docs/app/layout.config.tsx
@@ -1,5 +1,6 @@
 import { LiamLogo } from '@/components'
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared'
+import { FolderKanban } from 'lucide-react'
 
 /**
  * Shared layout configurations
@@ -14,4 +15,11 @@ export const baseOptions: BaseLayoutProps = {
     url: '/docs',
   },
   githubUrl: 'https://github.com/liam-hq/liam',
+  links: [
+    {
+      icon: <FolderKanban />,
+      text: 'Roadmap',
+      url: 'https://github.com/orgs/liam-hq/projects/1',
+    },
+  ],
 }

--- a/frontend/apps/docs/content/docs/index.mdx
+++ b/frontend/apps/docs/content/docs/index.mdx
@@ -1,44 +1,68 @@
 ---
-title: Getting Started
-description: Getting Started with Liam ERD
+title: Welcome to Liam ERD
+description: Liam ERD is a tool that effortlessly generates beautiful and easy-to-read ER diagrams.
 ---
 
 import { Package, Globe } from "lucide-react";
 
-Welcome to **Liam ERD**, the open-source tool designed to simplify database design and visualization. Whether you're working on a public open-source project or managing private repositories, Liam ERD makes it easy to generate and share **beautiful, interactive ER diagrams**.
-
 ![Liam logo](/images/default.png)
+
+Liam ERD is an open-source tool that instantly generates beautiful, interactive ER diagrams from your database. Whether you’re working on public or private repositories, Liam ERD helps you visualize complex schemas with ease.
 
 ## Why Choose Liam ERD?
 
-Liam ERD stands out with its:
+- **Beautiful UI & Interactive**: A clean design and intuitive features (like panning, zooming, and filtering) make it easy to understand even the most complex databases.
+- **Simple Reverse Engineering**: Seamlessly turn your existing database schemas into clear, readable diagrams.
+- **Effortless Setup**: Get started with zero configuration—just provide your schema, and you’re good to go.
+- **High Performance**: Optimized for both small and large projects, easily handling 100+ tables.
+- **Fully Open-Source**: Contribute to the project and shape Liam ERD to fit your needs.
 
-- **Open-Source**: Fully open for customization and contributions.
-- **Modern, Beautiful UI**: Enjoy a clean, interactive experience with features like pan, zoom, and Cmd+K search.
-- **Effortless Setup**: Get started faster than ever with zero configuration required.
-- **Scalability**: Handles large-scale database schemas, like 100-table structures, with ease.
-- **PostgreSQL and Popular ORMs Support**: Works seamlessly with PostgreSQL, Prisma, and Ruby on Rails.
+## Explore Diagrams
+
+Curious about what Liam ERD can do? Visit https://liambx.com/erd/galaxy to browse a variety of example ER diagrams from real-world schemas.
+
+## Supported Schemas
+
+Legend:
+
+- ✅: Supported
+- ❌: Not in progress
+- ⌛️: In progress
+
+| Technology                                  | Schema DSL Parsing | Support via database URL (PostgreSQL) |
+| ------------------------------------------- | ------------------ | ------------------------------------- |
+| [PostgreSQL](/docs/static-build/postgresql) | ✅                 | ✅                                    |
+| [Ruby on Rails](/docs/static-build/rails)   | ✅                 | ✅                                    |
+| [Prisma](/docs/static-build/prisma)         | ❌                 | ✅                                    |
+| [Drizzle](/docs/static-build/drizzle)       | ❌                 | ✅                                    |
+| MySQL                                       | ❌                 | ❌                                    |
+
+If there’s another database schema or ORM you’d love to see supported, please let us know in the [GitHub Discussions](https://github.com/liam-hq/liam/discussions/364).
 
 ## How to Get Started
 
-Choose one of the following workflows depending on your needs:
+### Public Project Setup
 
-<Cards>
-  <Card icon={<Globe />} title="URL-Based access" href="/docs/url-based-access">
-    Generate ER diagrams from your schema URL without any configuration. Ideal
-    for public repositories!
-  </Card>
-  <Card icon={<Package />} title="Static build" href="/docs/static-build/getting-started">
-    Use this method to secure your diagrams in private repositories or host them
-    within your internal environment.
-  </Card>
-</Cards>
+Want a quick setup for a public repository? Just drop the URL of your schema file!
 
-## Features in Action
+<input />
+<button>Generate</button>
 
-Liam ERD is built to streamline your workflow:
+For detailed instructions, check out [URL-based access](/docs/url-based-access).
 
-- **Interactive UI**: Filter tables, explore relationships, and focus on what matters.
-- **Cmd+K Search**: Quickly locate specific tables or columns.
-- **Scalable Layouts**: Optimized for large databases with 100+ tables.
-- **No Maintenance Overhead**: Automatically update diagrams with your schema changes.
+### Private Project Setup
+
+For internal or private repositories, run this command to start an interactive setup:
+
+```package-install
+npx @liam-hq/cli init
+```
+
+Then follow the prompts to build a static version of your diagrams.
+
+For more info, see [Static Build](/docs/static-build).
+
+## Need More?
+
+- **Feature Requests & Ideas**: Share your thoughts on our [GitHub Discussions](https://github.com/liam-hq/liam/discussions).
+- **Roadmap**: Check our latest progress on the [Roadmap](https://github.com/orgs/liam-hq/projects/1/views/1).

--- a/frontend/apps/docs/content/docs/index.mdx
+++ b/frontend/apps/docs/content/docs/index.mdx
@@ -26,16 +26,16 @@ Curious about what Liam ERD can do? Visit https://liambx.com/erd/galaxy to brows
 Legend:
 
 - ✅: Supported
-- ❌: Not in progress
+- ⛔: Not in progress
 - ⌛️: In progress
 
 | Technology                                  | Schema DSL Parsing | Support via database URL (PostgreSQL) |
 | ------------------------------------------- | ------------------ | ------------------------------------- |
 | [PostgreSQL](/docs/static-build/postgresql) | ✅                 | ✅                                    |
 | [Ruby on Rails](/docs/static-build/rails)   | ✅                 | ✅                                    |
-| [Prisma](/docs/static-build/prisma)         | ❌                 | ✅                                    |
-| [Drizzle](/docs/static-build/drizzle)       | ❌                 | ✅                                    |
-| MySQL                                       | ❌                 | ❌                                    |
+| [Prisma](/docs/static-build/prisma)         | ⛔                 | ✅                                    |
+| [Drizzle](/docs/static-build/drizzle)       | ⛔                 | ✅                                    |
+| MySQL                                       | ⛔                 | ⛔                                    |
 
 If there’s another database schema or ORM you’d love to see supported, please let us know in the [GitHub Discussions](https://github.com/liam-hq/liam/discussions/364).
 

--- a/frontend/apps/docs/content/docs/static-build/drizzle.mdx
+++ b/frontend/apps/docs/content/docs/static-build/drizzle.mdx
@@ -1,0 +1,5 @@
+---
+title: Drizzle
+---
+
+TBD

--- a/frontend/apps/docs/content/docs/static-build/index.mdx
+++ b/frontend/apps/docs/content/docs/static-build/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Static Build
+---
+
+```package-install
+npx @liam-hq/cli init
+```

--- a/frontend/apps/docs/content/docs/static-build/postgresql.mdx
+++ b/frontend/apps/docs/content/docs/static-build/postgresql.mdx
@@ -1,0 +1,5 @@
+---
+title: PostgreSQL
+---
+
+TBD

--- a/frontend/apps/docs/content/docs/static-build/prisma.mdx
+++ b/frontend/apps/docs/content/docs/static-build/prisma.mdx
@@ -1,0 +1,5 @@
+---
+title: Prisma
+---
+
+TBD

--- a/frontend/apps/docs/content/docs/static-build/rails.mdx
+++ b/frontend/apps/docs/content/docs/static-build/rails.mdx
@@ -1,0 +1,5 @@
+---
+title: schema.rb (Ruby on Rails)
+---
+
+TBD

--- a/frontend/apps/docs/package.json
+++ b/frontend/apps/docs/package.json
@@ -7,6 +7,7 @@
     "fumadocs-docgen": "1.3.2",
     "fumadocs-mdx": "11.1.2",
     "fumadocs-ui": "14.5.4",
+    "lucide-react": "0.451.0",
     "next": "15.1.2",
     "react": "18.3.1",
     "react-dom": "18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       fumadocs-ui:
         specifier: 14.5.4
         version: 14.5.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(next@15.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.15(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.2)))
+      lucide-react:
+        specifier: 0.451.0
+        version: 0.451.0(react@18.3.1)
       next:
         specifier: 15.1.2
         version: 15.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Only the top page was seriously rewritten.

- **🔧 Add lucide-react dependency to package.json**
- **🔧 Add 'Roadmap' link to layout configuration**
- **docs: re-write the docs index page**
