### PR TITLE
🚸 Add animated particles to highlighted relationship edges

### DIFF
--- a/frontend/.changeset/angry-ravens-greet.md
+++ b/frontend/.changeset/angry-ravens-greet.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+⚡️ Disable edge animation in highlightNodesAndEdges

--- a/frontend/.changeset/eleven-islands-buy.md
+++ b/frontend/.changeset/eleven-islands-buy.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🚸 Add animated particles to highlighted relationship edges

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.module.css
@@ -1,6 +1,6 @@
 .edge {
   stroke: var(--pane-border-hover);
-  stroke-dasharray: 2;
+  stroke-width: 1px;
   transition: stroke 0.3s var(--default-timing-function);
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -6,7 +6,7 @@ import styles from './RelationshipEdge.module.css'
 import type { RelationshipEdgeType } from './type'
 
 const PARTICLE_COUNT = 6
-const ANIMATE_DURATION = 3
+const ANIMATE_DURATION = 6
 
 type Props = EdgeProps<RelationshipEdgeType>
 
@@ -72,7 +72,7 @@ export const RelationshipEdge: FC<Props> = ({
           <ellipse
             key={`particle-${i}-${ANIMATE_DURATION}`}
             rx="5"
-            ry="1.6"
+            ry="1.2"
             fill="url(#myGradient)"
           >
             <animateMotion

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -5,6 +5,9 @@ import type { FC } from 'react'
 import styles from './RelationshipEdge.module.css'
 import type { RelationshipEdgeType } from './type'
 
+const PARTICLE_COUNT = 6
+const ANIMATE_DURATION = 3
+
 type Props = EdgeProps<RelationshipEdgeType>
 
 export const RelationshipEdge: FC<Props> = ({
@@ -47,6 +50,42 @@ export const RelationshipEdge: FC<Props> = ({
         }
         className={clsx(styles.edge, data?.isHighlighted && styles.hovered)}
       />
+      <defs>
+        <radialGradient
+          id="myGradient"
+          cx="50%"
+          cy="50%"
+          r="50%"
+          fx="50%"
+          fy="50%"
+        >
+          <stop offset="0%" stopColor="var(--node-layout)" stopOpacity="1" />
+          <stop
+            offset="100%"
+            stopColor="var(--node-layout)"
+            stopOpacity="0.4"
+          />
+        </radialGradient>
+      </defs>
+      {data?.isHighlighted &&
+        [...Array(PARTICLE_COUNT)].map((_, i) => (
+          <ellipse
+            key={`particle-${i}-${ANIMATE_DURATION}`}
+            rx="5"
+            ry="1.6"
+            fill="url(#myGradient)"
+          >
+            <animateMotion
+              begin={`${i * (ANIMATE_DURATION / PARTICLE_COUNT)}s`}
+              dur={`${ANIMATE_DURATION}s`}
+              repeatCount="indefinite"
+              rotate="auto"
+              path={edgePath}
+              calcMode="spline"
+              keySplines="0.42, 0, 0.58, 1.0"
+            />
+          </ellipse>
+        ))}
     </>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.test.ts
@@ -181,12 +181,12 @@ describe(highlightNodesAndEdges, () => {
 
       expect(updatedEdges).toEqual([
         anEdge('users', 'posts', 'users-id', 'posts-user_id', {
-          animated: true,
+          animated: false,
           zIndex: zIndex.edgeHighlighted,
           data: { isHighlighted: true },
         }),
         anEdge('users', 'comment_users', 'users-id', 'comment_users-user_id', {
-          animated: true,
+          animated: false,
           zIndex: zIndex.edgeHighlighted,
           data: { isHighlighted: true },
         }),
@@ -228,12 +228,12 @@ describe(highlightNodesAndEdges, () => {
 
       expect(updatedEdges).toEqual([
         anEdge('users', 'posts', 'users-id', 'posts-user_id', {
-          animated: true,
+          animated: false,
           zIndex: zIndex.edgeHighlighted,
           data: { isHighlighted: true },
         }),
         anEdge('users', 'comment_users', 'users-id', 'comment_users-user_id', {
-          animated: true,
+          animated: false,
           zIndex: zIndex.edgeHighlighted,
           data: { isHighlighted: true },
         }),
@@ -253,12 +253,12 @@ describe(highlightNodesAndEdges, () => {
 
       expect(updatedEdges).toEqual([
         anEdge('users', 'posts', 'users-id', 'posts-user_id', {
-          animated: true,
+          animated: false,
           zIndex: zIndex.edgeHighlighted,
           data: { isHighlighted: true },
         }),
         anEdge('users', 'comment_users', 'users-id', 'comment_users-user_id', {
-          animated: true,
+          animated: false,
           zIndex: zIndex.edgeHighlighted,
           data: { isHighlighted: true },
         }),
@@ -268,7 +268,7 @@ describe(highlightNodesAndEdges, () => {
           'comments-id',
           'comment_users-comment_id',
           {
-            animated: true,
+            animated: false,
             zIndex: zIndex.edgeHighlighted,
             data: { isHighlighted: true },
           },

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/highlightNodesAndEdges.ts
@@ -66,7 +66,7 @@ const unhighlightNode = (node: TableNodeType): TableNodeType => ({
 
 const highlightEdge = (edge: Edge): Edge => ({
   ...edge,
-  animated: true,
+  animated: false,
   zIndex: zIndex.edgeHighlighted,
   data: { ...edge.data, isHighlighted: true },
 })


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Drawing multiple strokes with stroke-dasharray specified causes performance degradation, especially in Safari browser.

Therefore, I stopped using stroke-dasharray.
Additionally, since stroke-dasharray is also used when 'animated' is set to true in Edge, I made sure that 'animated' is always set to false.

Furthermore, since setting 'animated' to false made it difficult to visually distinguish the flow of Edges, I used animateMotion instead to express Edge animations.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/17596874-3c80-4a18-99dd-2e58bdcb7c0c" /> | <video src="https://github.com/user-attachments/assets/f8420ee8-edd5-4251-ad4c-1a1b1796375f" /> | 

