### PR TITLE
:bug: fix: Comment component to use `<span>` instead of `<p>`

### DIFF
--- a/.changeset/dirty-crabs-happen.md
+++ b/.changeset/dirty-crabs-happen.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+:bug: fix: Comment component to use `<span>` instead of `<p>`

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Comment/Comment.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Comment/Comment.tsx
@@ -9,7 +9,7 @@ type Props = {
 export const Comment: FC<Props> = ({ comment }) => {
   return (
     <DrawerDescription className={styles.wrapper}>
-      <p className={styles.text}>{comment}</p>
+      <span className={styles.text}>{comment}</span>
     </DrawerDescription>
   )
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

fix: Comment component to use `<span>` instead of `<p>`

## Related Issue
<!-- Mention the related issue number if applicable. -->

closes https://github.com/liam-hq/liam/issues/370

## Changes
<!-- List the main changes made in this PR. -->



## Testing
<!-- Briefly describe the testing steps or results. -->

### before

`<p>` nesting exists.

<img width="793" alt="スクリーンショット 2024-12-24 18 16 52" src="https://github.com/user-attachments/assets/3feccfd7-0143-4119-9516-1d0656302cc5" />


### after

<img width="795" alt="スクリーンショット 2024-12-24 18 16 16" src="https://github.com/user-attachments/assets/bdfbee44-216c-4a3e-bcfa-27daada7b00c" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->


