### PR TITLE
style: Eliminate overlap between sidebar rail and scrollbar

### DIFF
--- a/.changeset/cyan-donkeys-design.md
+++ b/.changeset/cyan-donkeys-design.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/cli": patch
+"@liam-hq/erd-core": patch
+"@liam-hq/ui": patch
+---
+
+:lipstick: Eliminate overlap between rail and scrollbar

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -117,7 +117,7 @@
   top: 0;
   bottom: 0;
   width: 1rem;
-  right: -0.5rem;
+  right: -1rem;
 }
 
 [data-collapsible='offcanvas'] .sidebarRail {
@@ -129,7 +129,7 @@
   width: 2px;
   top: 0px;
   bottom: 0px;
-  left: 50%;
+  left: 0px;
   position: absolute;
   transition: background-color var(--default-hover-animation-duration)
     var(--default-timing-function);


### PR DESCRIPTION
- ref: https://github.com/liam-hq/liam/discussions/376

|before|after|
| --- | --- |
| <img width="1544" alt="スクリーンショット_2024-12-25_11_47_46" src="https://github.com/user-attachments/assets/b935a1ad-4a14-42d7-bf1e-7a650c0161d6" /> | <img width="1544" alt="スクリーンショット_2024-12-25_11_49_06" src="https://github.com/user-attachments/assets/0b6e872b-49dc-4bac-9ed5-fe7f1bd383f8" /> |


