### PR TITLE
:bug: Fix compatibility issue with Node.js v18 in ERD tool

### DIFF
--- a/.changeset/tall-donuts-swim.md
+++ b/.changeset/tall-donuts-swim.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+:bug: Fix compatibility issue with Node.js v18 in ERD tool

--- a/frontend/packages/db-structure/.gitignore
+++ b/frontend/packages/db-structure/.gitignore
@@ -1,1 +1,2 @@
 dist
+src/parser/schemarb/prism.wasm

--- a/frontend/packages/db-structure/package.json
+++ b/frontend/packages/db-structure/package.json
@@ -21,12 +21,14 @@
     "vitest": "2.1.4"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && pnpm run cp:prism",
+    "cp:prism": "cp node_modules/@ruby/prism/src/prism.wasm dist/parser/schemarb/",
     "fmt": "pnpm run '/^fmt:.*/'",
     "fmt:biome": "biome check --write --unsafe .",
     "lint": "pnpm run '/^lint:.*/'",
     "lint:biome": "biome check .",
     "lint:tsc": "tsc --noEmit",
+    "postinstall": "cp node_modules/@ruby/prism/src/prism.wasm src/parser/schemarb/prism.wasm",
     "test": "vitest --watch=false"
   },
   "types": "dist/index.d.ts"

--- a/frontend/packages/db-structure/src/parser/schemarb/loadPrism.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/loadPrism.ts
@@ -1,0 +1,40 @@
+/*
+The following modifications are applied to a file from:
+https://github.com/ruby/prism/blob/v1.2.0/javascript/src/index.js
+
+To support Node.js versions below 19.8, we substitute:
+WebAssembly.instantiate(wasm, wasi.getImportObject())
+with:
+WebAssembly.instantiate(wasm, { wasi_snapshot_preview1: wasi.wasiImport })
+
+See also https://github.com/ruby/prism/discussions/3310
+
+Consider removing this patch once support for Node.js v18 is no longer necessary
+*/
+
+// biome-ignore lint/correctness/noNodejsModules: This import is server-side specific because loadPrism() is exclusively invoked in server environments.
+import { readFile } from 'node:fs/promises'
+// biome-ignore lint/correctness/noNodejsModules: This import is server-side specific because loadPrism() is exclusively invoked in server environments.
+import { fileURLToPath } from 'node:url'
+// biome-ignore lint/correctness/noNodejsModules: This import is server-side specific because loadPrism() is exclusively invoked in server environments.
+import { WASI } from 'node:wasi'
+import type { ParseResult } from '@ruby/prism/src/deserialize.js'
+import { parsePrism } from '@ruby/prism/src/parsePrism.js'
+
+export async function loadPrism(): Promise<(source: string) => ParseResult> {
+  const path = fileURLToPath(new URL('prism.wasm', import.meta.url))
+  const wasm = await WebAssembly.compile(await readFile(path))
+
+  const wasi = new WASI({ version: 'preview1' })
+
+  // Patch applied for compatibility
+  const instance = await WebAssembly.instantiate(wasm, {
+    wasi_snapshot_preview1: wasi.wasiImport,
+  })
+
+  wasi.initialize(instance)
+
+  return function parse(source: string): ParseResult {
+    return parsePrism(instance.exports, source)
+  }
+}

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -12,7 +12,6 @@ import {
   SymbolNode,
   TrueNode,
   Visitor,
-  loadPrism,
 } from '@ruby/prism'
 import { type Result, err, ok } from 'neverthrow'
 import type {
@@ -38,6 +37,7 @@ import {
   handleOneToOneRelationships,
 } from '../utils/index.js'
 import { convertColumnType } from './convertColumnType.js'
+import { loadPrism } from './loadPrism.js'
 import { singularize } from './singularize.js'
 
 export class UnsupportedTokenError extends WarningError {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

 Fix compatibility issue with Node.js v18 in ERD tool

Addresses a compatibility issue with Node.js v18 that causes the following error when running the command:

```
$ npx @liam-hq/cli erd build --input path/to/schema.rb --format schemarb
```

```
Error: Failed to parse schemarb file: wasi.getImportObject is not a function
```



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->


confirmed v18 test passed in GitHub Actions.

test commit: https://github.com/liam-hq/liam/pull/380/commits/9c298703d3c0b6a1b7b6681d771714fb2475f087
CI: https://github.com/liam-hq/liam/actions/runs/12491595523/job/34857812861


<img width="552" alt="スクリーンショット 2024-12-25 18 18 28" src="https://github.com/user-attachments/assets/60262504-2546-4b02-a3c2-c3500fec993e" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->
