### PR TITLE
fix: Fixed an issue where sidebar state could not be set from cookie in web version

### DIFF
--- a/.changeset/spicy-donkeys-wink.md
+++ b/.changeset/spicy-donkeys-wink.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+"@liam-hq/ui": patch
+---
+
+:recycle: Refactoring the process of getting sidebar state from cookie

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
@@ -12,9 +12,13 @@ import * as v from 'valibot'
 
 type ERDViewerProps = {
   dbStructure: DBStructure
+  defaultSidebarOpen: boolean
 }
 
-export default function ERDViewer({ dbStructure }: ERDViewerProps) {
+export default function ERDViewer({
+  dbStructure,
+  defaultSidebarOpen,
+}: ERDViewerProps) {
   useEffect(() => {
     initDBStructureStore(dbStructure)
   }, [dbStructure])
@@ -32,7 +36,7 @@ export default function ERDViewer({ dbStructure }: ERDViewerProps) {
   return (
     <div style={{ height: '100vh' }}>
       <CliVersionProvider cliVersion={cliVersion}>
-        <ERDRenderer />
+        <ERDRenderer defaultSidebarOpen={defaultSidebarOpen} />
       </CliVersionProvider>
     </div>
   )

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx
@@ -1,4 +1,5 @@
 import { parse } from '@liam-hq/db-structure/parser'
+import { cookies } from 'next/headers'
 import { notFound } from 'next/navigation'
 import ERDViewer from './erdViewer'
 
@@ -30,5 +31,13 @@ export default async function Page({
     }
   }
 
-  return <ERDViewer dbStructure={dbStructure} />
+  const cookieStore = await cookies()
+  const defaultSidebarOpen = cookieStore.get('sidebar:state')?.value === 'true'
+
+  return (
+    <ERDViewer
+      dbStructure={dbStructure}
+      defaultSidebarOpen={defaultSidebarOpen}
+    />
+  )
 }

--- a/frontend/packages/cli/src/App.tsx
+++ b/frontend/packages/cli/src/App.tsx
@@ -35,10 +35,18 @@ const cliVersionData = {
 }
 const cliVersion = v.parse(cliVersionSchema, cliVersionData)
 
+function getSidebarStateFromCookie(): boolean {
+  const cookies = document.cookie.split('; ').map((cookie) => cookie.split('='))
+  const cookie = cookies.find(([key]) => key === 'sidebar:state')
+  return cookie ? cookie[1] === 'true' : false
+}
+
 function App() {
+  const defaultSidebarOpen = getSidebarStateFromCookie()
+
   return (
     <CliVersionProvider cliVersion={cliVersion}>
-      <ERDRenderer />
+      <ERDRenderer defaultSidebarOpen={defaultSidebarOpen} />
     </CliVersionProvider>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -1,10 +1,5 @@
 import '@xyflow/react/dist/style.css'
-import {
-  SidebarProvider,
-  SidebarTrigger,
-  ToastProvider,
-  getSidebarStateFromCookie,
-} from '@liam-hq/ui'
+import { SidebarProvider, SidebarTrigger, ToastProvider } from '@liam-hq/ui'
 import { ReactFlowProvider } from '@xyflow/react'
 import { type FC, useCallback, useState } from 'react'
 import { AppBar } from './AppBar'
@@ -20,9 +15,12 @@ import { Toolbar } from './ERDContent/Toolbar'
 import { TableDetailDrawer, TableDetailDrawerRoot } from './TableDetailDrawer'
 import { convertDBStructureToNodes } from './convertDBStructureToNodes'
 
-export const ERDRenderer: FC = () => {
-  const defaultOpen = getSidebarStateFromCookie()
-  const [open, setOpen] = useState(defaultOpen)
+type Props = {
+  defaultSidebarOpen?: boolean | undefined
+}
+
+export const ERDRenderer: FC<Props> = ({ defaultSidebarOpen = false }) => {
+  const [open, setOpen] = useState(defaultSidebarOpen)
 
   const { showMode } = useUserEditingStore()
   const dbStructure = useDBStructureStore()
@@ -49,11 +47,7 @@ export const ERDRenderer: FC = () => {
     <div className={styles.wrapper}>
       <ToastProvider>
         <AppBar />
-        <SidebarProvider
-          open={open}
-          defaultOpen={defaultOpen}
-          onOpenChange={handleChangeOpen}
-        >
+        <SidebarProvider open={open} onOpenChange={handleChangeOpen}>
           <ReactFlowProvider>
             <div className={styles.mainWrapper}>
               <LeftPane />

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -457,16 +457,6 @@ const SidebarMenuSubButton = forwardRef<
 })
 SidebarMenuSubButton.displayName = 'SidebarMenuSubButton'
 
-function getSidebarStateFromCookie(): boolean {
-  // NOTE: adhoc workaround for SSR
-  if (typeof document === 'undefined') {
-    return true
-  }
-  const cookies = document.cookie.split('; ').map((cookie) => cookie.split('='))
-  const cookie = cookies.find(([key]) => key === SIDEBAR_COOKIE_NAME)
-  return cookie ? cookie[1] === 'true' : false
-}
-
 export {
   Sidebar,
   SidebarContent,
@@ -488,5 +478,4 @@ export {
   SidebarRail,
   SidebarTrigger,
   useSidebar,
-  getSidebarStateFromCookie,
 }


### PR DESCRIPTION
The web version has been modified to take cookies out of Node.js for SSR.

## Testing

Sidebar remains open when reloading with sidebar open ✅ 

https://github.com/user-attachments/assets/9b045021-7efc-4343-a62f-ce708005f5f1

ref: https://liam-erd-7b18wh3x2-route-06-core.vercel.app/erd/p/raw.githubusercontent.com/ekylibre/ekylibre/refs/heads/main/db/structure.sql