### PR TITLE
🐛 : move RelationshipEdgeParticleMarker for gradient rendering to ERDRenderer

### DIFF
--- a/.changeset/khaki-pandas-shout.md
+++ b/.changeset/khaki-pandas-shout.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 : move RelationshipEdgeParticleMarker for gradient rendering to ERDRenderer

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -50,23 +50,6 @@ export const RelationshipEdge: FC<Props> = ({
         }
         className={clsx(styles.edge, data?.isHighlighted && styles.hovered)}
       />
-      <defs>
-        <radialGradient
-          id="myGradient"
-          cx="50%"
-          cy="50%"
-          r="50%"
-          fx="50%"
-          fy="50%"
-        >
-          <stop offset="0%" stopColor="var(--node-layout)" stopOpacity="1" />
-          <stop
-            offset="100%"
-            stopColor="var(--node-layout)"
-            stopOpacity="0.4"
-          />
-        </radialGradient>
-      </defs>
       {data?.isHighlighted &&
         [...Array(PARTICLE_COUNT)].map((_, i) => (
           <ellipse

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -13,6 +13,7 @@ import { useDBStructureStore, useUserEditingStore } from '@/stores'
 import { CardinalityMarkers } from './CardinalityMarkers'
 // biome-ignore lint/nursery/useImportRestrictions: Fixed in the next PR.
 import { Toolbar } from './ERDContent/Toolbar'
+import { RelationshipEdgeParticleMarker } from './RelationshipEdgeParticleMarker'
 import { TableDetailDrawer, TableDetailDrawerRoot } from './TableDetailDrawer'
 import { convertDBStructureToNodes } from './convertDBStructureToNodes'
 
@@ -47,6 +48,7 @@ export const ERDRenderer: FC<Props> = ({ defaultSidebarOpen = false }) => {
   return (
     <div className={styles.wrapper}>
       <CardinalityMarkers />
+      <RelationshipEdgeParticleMarker />
       <ToastProvider>
         <AppBar />
         <SidebarProvider open={open} onOpenChange={handleChangeOpen}>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/RelationshipEdgeParticleMarker/RelationshipEdgeParticleMarker.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/RelationshipEdgeParticleMarker/RelationshipEdgeParticleMarker.module.css
@@ -1,0 +1,7 @@
+.wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  overflow: hidden;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/RelationshipEdgeParticleMarker/RelationshipEdgeParticleMarker.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/RelationshipEdgeParticleMarker/RelationshipEdgeParticleMarker.tsx
@@ -1,0 +1,32 @@
+import type { FC } from 'react'
+import styles from './RelationshipEdgeParticleMarker.module.css'
+
+export const RelationshipEdgeParticleMarker: FC = () => {
+  return (
+    <svg
+      width="0"
+      height="0"
+      role="img"
+      aria-label="Relationship Edge Particle Marker"
+      className={styles.wrapper}
+    >
+      <defs>
+        <radialGradient
+          id="myGradient"
+          cx="50%"
+          cy="50%"
+          r="50%"
+          fx="50%"
+          fy="50%"
+        >
+          <stop offset="0%" stopColor="var(--node-layout)" stopOpacity="1" />
+          <stop
+            offset="100%"
+            stopColor="var(--node-layout)"
+            stopOpacity="0.4"
+          />
+        </radialGradient>
+      </defs>
+    </svg>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/RelationshipEdgeParticleMarker/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/RelationshipEdgeParticleMarker/index.ts
@@ -1,0 +1,1 @@
+export * from './RelationshipEdgeParticleMarker'


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I fixed an issue where particles used in RelationshipEdge were not being rendered.
(Similar issue to this https://github.com/liam-hq/liam/pull/387)

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f3fad75c-eebc-4f73-8519-e3d645ed40ad" /> |<video src="https://github.com/user-attachments/assets/163566a6-c1bf-4b4b-861f-271d85116ed0" /> | 

