### PR TITLE
📘 Add robots.txt and sitemap to docs

### DIFF
--- a/frontend/apps/docs/app/docs/sitemap.ts
+++ b/frontend/apps/docs/app/docs/sitemap.ts
@@ -2,35 +2,12 @@
 import fs from 'node:fs'
 // biome-ignore lint/correctness/noNodejsModules: This file is used to generate the sitemap and is executed on the server-side only, requiring Node.js modules.
 import path from 'node:path'
+import { source } from '@/lib/source'
 import type { MetadataRoute } from 'next'
 
-const getDocsPaths = (dir: string, basePath = '/docs'): string[] => {
-  const docsDir = path.join(process.cwd(), dir)
-  const files = fs.readdirSync(docsDir)
-
-  let paths: string[] = []
-
-  for (const file of files) {
-    const filePath = path.join(docsDir, file)
-    const stat = fs.statSync(filePath)
-
-    if (stat.isDirectory()) {
-      paths = paths.concat(
-        getDocsPaths(path.join(dir, file), path.join(basePath, file)),
-      )
-    } else if (file.endsWith('.mdx')) {
-      paths.push(`${basePath}/${file.replace(/\.mdx?$/, '')}`)
-    }
-  }
-
-  return paths
-}
-
 export default function sitemap(): MetadataRoute.Sitemap {
-  const staticPaths = ['/docs']
-  const docPaths = getDocsPaths('../docs/content/docs')
-
-  const allPaths = [...staticPaths, ...docPaths]
+  const pages = source.getPages()
+  const allPaths = pages.map((page) => page.url)
 
   return allPaths.map((path) => ({
     url: `https://liam-docs-sigma.vercel.app${path}`,

--- a/frontend/apps/docs/app/docs/sitemap.ts
+++ b/frontend/apps/docs/app/docs/sitemap.ts
@@ -10,7 +10,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const allPaths = pages.map((page) => page.url)
 
   return allPaths.map((path) => ({
-    url: `https://liam-docs-sigma.vercel.app${path}`,
+    url: `${process.env.SERVICE_SITE_URL}${path}`,
     lastModified: new Date().toISOString(),
   }))
 }

--- a/frontend/apps/docs/app/docs/sitemap.ts
+++ b/frontend/apps/docs/app/docs/sitemap.ts
@@ -1,7 +1,3 @@
-// biome-ignore lint/correctness/noNodejsModules: This file is used to generate the sitemap and is executed on the server-side only, requiring Node.js modules.
-import fs from 'node:fs'
-// biome-ignore lint/correctness/noNodejsModules: This file is used to generate the sitemap and is executed on the server-side only, requiring Node.js modules.
-import path from 'node:path'
 import { source } from '@/lib/source'
 import type { MetadataRoute } from 'next'
 

--- a/frontend/apps/docs/app/docs/sitemap.ts
+++ b/frontend/apps/docs/app/docs/sitemap.ts
@@ -1,0 +1,39 @@
+// biome-ignore lint/correctness/noNodejsModules: This file is used to generate the sitemap and is executed on the server-side only, requiring Node.js modules.
+import fs from 'node:fs'
+// biome-ignore lint/correctness/noNodejsModules: This file is used to generate the sitemap and is executed on the server-side only, requiring Node.js modules.
+import path from 'node:path'
+import type { MetadataRoute } from 'next'
+
+const getDocsPaths = (dir: string, basePath = '/docs'): string[] => {
+  const docsDir = path.join(process.cwd(), dir)
+  const files = fs.readdirSync(docsDir)
+
+  let paths: string[] = []
+
+  for (const file of files) {
+    const filePath = path.join(docsDir, file)
+    const stat = fs.statSync(filePath)
+
+    if (stat.isDirectory()) {
+      paths = paths.concat(
+        getDocsPaths(path.join(dir, file), path.join(basePath, file)),
+      )
+    } else if (file.endsWith('.mdx')) {
+      paths.push(`${basePath}/${file.replace(/\.mdx?$/, '')}`)
+    }
+  }
+
+  return paths
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticPaths = ['/docs']
+  const docPaths = getDocsPaths('../docs/content/docs')
+
+  const allPaths = [...staticPaths, ...docPaths]
+
+  return allPaths.map((path) => ({
+    url: `https://liam-docs-sigma.vercel.app${path}`,
+    lastModified: new Date().toISOString(),
+  }))
+}

--- a/frontend/apps/docs/public/robots.txt
+++ b/frontend/apps/docs/public/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Accessing https://liambx.com/docs routes the path to https://liam-docs-sigma.vercel.app/docs.

| repository | service-site | liam-hq/liam| 
| --- | --- | --- |
| URL |  https://liambx.com/ |  https://liam-docs-sigma.vercel.app| 
| Crawl |  ⭕️ |  ❌| 
| sitemap | has own sitemap<br>and refer to  https://liambx.com/docs/sitemap.xml | has own sitemap (/docs) |
		

This time, I created a sitemap for https://liam-docs-sigma.vercel.app/docs.

preview(sitemap): https://liam-docs-7tfe1sai4-route-06-core.vercel.app/docs/sitemap.xml

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->

I don't think a ``changeset`` is needed for this change, but please let me know if I'm mistaken🙏.

