### PR TITLE
:wrench: Update changeset config to ignore specific packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@liam-hq/erd-web",
+    "@liam-hq/docs",
+    "@liam-hq/figma-to-css-variables"
+  ]
 }


### PR DESCRIPTION
## Background

Currently, even for applications that are not version controlled, versions have been updated.

![image](https://github.com/user-attachments/assets/32669541-2212-4d61-a033-62bab6dd199d)

ref: https://github.com/liam-hq/liam/pull/382

## description

Ignored packages that are not version controlled.

## Testing

You can check the `Version Packages` PR behavior at hand with `pnpm changeset version`.
