### PR TITLE
:bug: Fixed problem with fitView not working properly while displaying only some tables

### DIFF
--- a/.changeset/breezy-olives-decide.md
+++ b/.changeset/breezy-olives-decide.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+:bug: Fixed problem with fitView not working properly while displaying only some tables

--- a/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
@@ -4,7 +4,7 @@ import type { Edge, Node } from '@xyflow/react'
 import { columnHandleId } from './columnHandleId'
 import { zIndex } from './constants'
 
-const NON_RELATED_TABLE_GROUP_NODE_ID = 'non-related-table-group'
+export const NON_RELATED_TABLE_GROUP_NODE_ID = 'non-related-table-group'
 
 type Params = {
   dbStructure: DBStructure


### PR DESCRIPTION
## Reproduction Procedure

1. Select any TableNode 
1. Click “Open in main area” under Related Tables in TableDetail 1.
1. Click “Tidy Up”, the layout will be adjusted and fitView() will be executed, but it will be drawn at the top of the screen

| demo |
|--------|
| <video src="https://github.com/user-attachments/assets/d46ee707-7f4e-404b-9e80-55e47ed2bc14" /> | 


## Cause

The transparent nonRelatedTableGroup remained and was fitViewed including its display area.

## Solution

If all the nodes whose parentId is nonRelatedTableGroup node are hidden, the nonRelatedTableGroup node is also hidden.

https://github.com/user-attachments/assets/23ad41ab-738f-49a3-ba84-681223b2d792



