### PR TITLE
Improve `erd build` option description

### DIFF
--- a/frontend/packages/cli/src/cli/index.ts
+++ b/frontend/packages/cli/src/cli/index.ts
@@ -18,8 +18,8 @@ program.addCommand(erdCommand)
 erdCommand
   .command('build')
   .description('Build ERD html assets')
-  .option('--input <path>', 'Path to the .sql file')
-  .option('--format <format>', 'Format of the input file')
+  .option('--input <path|url>', 'Path or URL to the .sql file')
+  .option('--format <format>', 'Format of the input file (postgres|schemarb)')
   .action((options) => buildCommand(options.input, distDir, options.format))
 
 export { program }

--- a/frontend/packages/cli/src/cli/index.ts
+++ b/frontend/packages/cli/src/cli/index.ts
@@ -18,7 +18,7 @@ program.addCommand(erdCommand)
 erdCommand
   .command('build')
   .description('Build ERD html assets')
-  .option('--input <path|url>', 'Path or URL to the .sql file')
+  .option('--input <path|url>', 'Path or URL to the schema file')
   .option('--format <format>', 'Format of the input file (postgres|schemarb)')
   .action((options) => buildCommand(options.input, distDir, options.format))
 


### PR DESCRIPTION
This is without .changeset, I think that is ok.

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Improve `erd build` option description

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

```
[liam]$ cd frontend/packages/cli
```

```
[cli]$ node dist-cli/bin/cli.js erd build --help
(node:61123) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Usage: liam erd build [options]

Build ERD html assets

Options:
  --input <path|url>  Path or URL to the .sql file
  --format <format>   Format of the input file (postgres|schemarb)
  -h, --help          display help for command
```

## Other Information
<!-- Add any other relevant information for the reviewer. -->
