### PR TITLE
:sparkle: Improved error output

### DIFF
--- a/.changeset/clever-pens-invite.md
+++ b/.changeset/clever-pens-invite.md
@@ -1,0 +1,8 @@
+---
+"@liam-hq/cli": patch
+---
+
+:sparkle: Improved error output
+
+- Output logs are now prefixed with `ERROR:` and `WARN:` and output in color.
+- In case of `ERROR` exit 1.

--- a/frontend/packages/cli/src/cli/actionRunner.ts
+++ b/frontend/packages/cli/src/cli/actionRunner.ts
@@ -1,0 +1,27 @@
+import { red, yellow } from 'yoctocolors'
+import { CriticalError, WarningError } from './errors.js'
+
+function actionErrorHandler(error: Error) {
+  if (error instanceof CriticalError) {
+    console.error(red(`ERROR: ${error.message}`))
+    return
+  }
+
+  if (error instanceof WarningError) {
+    console.warn(yellow(`WARN: ${error.message}`))
+    return
+  }
+}
+
+export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {
+  return async (args: T) => {
+    const errors = await fn(args)
+    if (errors.length > 0) {
+      errors.forEach(actionErrorHandler)
+    }
+
+    if (errors.some((error) => error instanceof CriticalError)) {
+      process.exit(1)
+    }
+  }
+}

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -4,13 +4,14 @@ import { dirname } from 'node:path'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { SupportedFormat } from '@liam-hq/db-structure/parser'
+import type { CliError } from '../../errors.js'
 import { runPreprocess } from '../runPreprocess.js'
 
 export const buildCommand = async (
   inputPath: string,
   outDir: string,
   format: SupportedFormat,
-) => {
+): Promise<CliError[]> => {
   // generate schema.json
   runPreprocess(inputPath, outDir, format)
 
@@ -22,7 +23,7 @@ export const buildCommand = async (
   // Check if the source directory exists
   if (!existsSync(cliHtmlPath)) {
     console.error(`The directory '${cliHtmlPath}' does not exist.`)
-    return
+    return []
   }
 
   // Ensure the output directory exists
@@ -42,4 +43,6 @@ export const buildCommand = async (
       },
     )
   })
+
+  return []
 }

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -13,7 +13,14 @@ export const buildCommand = async (
   format: SupportedFormat,
 ): Promise<CliError[]> => {
   // generate schema.json
-  runPreprocess(inputPath, outDir, format)
+  const { errors: preprocessErrors } = await runPreprocess(
+    inputPath,
+    outDir,
+    format,
+  )
+  if (preprocessErrors.length > 0) {
+    return preprocessErrors
+  }
 
   // generate index.html
   const __filename = fileURLToPath(import.meta.url)

--- a/frontend/packages/cli/src/cli/erdCommand/index.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.test.ts
@@ -5,7 +5,7 @@ import { buildCommand } from './buildCommand/index.js'
 // Function to set up mocks
 function setupMocks() {
   vi.mock('./buildCommand', () => ({
-    buildCommand: vi.fn(),
+    buildCommand: vi.fn().mockImplementation(() => Promise.resolve([])),
   }))
 }
 

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -1,37 +1,11 @@
 import path from 'node:path'
 import { Command } from 'commander'
-import { red, yellow } from 'yoctocolors'
-import { CriticalError, WarningError } from '../errors.js'
+import { actionRunner } from '../actionRunner.js'
 import { buildCommand } from './buildCommand/index.js'
 
 const distDir = path.join(process.cwd(), 'dist')
 
 const erdCommand = new Command('erd').description('ERD commands')
-
-function actionErrorHandler(error: Error) {
-  if (error instanceof CriticalError) {
-    console.error(red(`ERROR: ${error.message}`))
-    return
-  }
-
-  if (error instanceof WarningError) {
-    console.warn(yellow(`WARN: ${error.message}`))
-    return
-  }
-}
-
-export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {
-  return async (args: T) => {
-    const errors = await fn(args)
-    if (errors.length > 0) {
-      errors.forEach(actionErrorHandler)
-    }
-
-    if (errors.some((error) => error instanceof CriticalError)) {
-      process.exit(1)
-    }
-  }
-}
 
 erdCommand
   .command('build')

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -6,11 +6,28 @@ const distDir = path.join(process.cwd(), 'dist')
 
 const erdCommand = new Command('erd').description('ERD commands')
 
+function actionErrorHandler(error: Error) {
+  console.error(error.message)
+}
+
+export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {
+  return async (args: T) => {
+    const errors = await fn(args)
+    if (errors.length > 0) {
+      errors.forEach(actionErrorHandler)
+    }
+  }
+}
+
 erdCommand
   .command('build')
   .description('Build ERD html assets')
   .option('--input <path|url>', 'Path or URL to the schema file')
   .option('--format <format>', 'Format of the input file (postgres|schemarb)')
-  .action((options) => buildCommand(options.input, distDir, options.format))
+  .action(
+    actionRunner((options) =>
+      buildCommand(options.input, distDir, options.format),
+    ),
+  )
 
 export { erdCommand }

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { Command } from 'commander'
+import { red } from 'yoctocolors'
 import { buildCommand } from './buildCommand/index.js'
 
 const distDir = path.join(process.cwd(), 'dist')
@@ -7,7 +8,7 @@ const distDir = path.join(process.cwd(), 'dist')
 const erdCommand = new Command('erd').description('ERD commands')
 
 function actionErrorHandler(error: Error) {
-  console.error(error.message)
+  console.error(red(`ERROR: ${error.message}`))
 }
 
 export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { Command } from 'commander'
 import { red } from 'yoctocolors'
+import { CriticalError } from '../errors.js'
 import { buildCommand } from './buildCommand/index.js'
 
 const distDir = path.join(process.cwd(), 'dist')
@@ -16,6 +17,10 @@ export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {
     const errors = await fn(args)
     if (errors.length > 0) {
       errors.forEach(actionErrorHandler)
+    }
+
+    if (errors.some((error) => error instanceof CriticalError)) {
+      process.exit(1)
     }
   }
 }

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { Command } from 'commander'
-import { red } from 'yoctocolors'
-import { CriticalError } from '../errors.js'
+import { red, yellow } from 'yoctocolors'
+import { CriticalError, WarningError } from '../errors.js'
 import { buildCommand } from './buildCommand/index.js'
 
 const distDir = path.join(process.cwd(), 'dist')
@@ -9,7 +9,15 @@ const distDir = path.join(process.cwd(), 'dist')
 const erdCommand = new Command('erd').description('ERD commands')
 
 function actionErrorHandler(error: Error) {
-  console.error(red(`ERROR: ${error.message}`))
+  if (error instanceof CriticalError) {
+    console.error(red(`ERROR: ${error.message}`))
+    return
+  }
+
+  if (error instanceof WarningError) {
+    console.warn(yellow(`WARN: ${error.message}`))
+    return
+  }
 }
 
 export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {

--- a/frontend/packages/cli/src/cli/erdCommand/runPreprocess.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/runPreprocess.test.ts
@@ -22,7 +22,7 @@ describe('runPreprocess', () => {
         end
       `,
     },
-  ]
+  ] as const
 
   it.each(testCases)(
     'should create schema.json with the content in $format format',
@@ -32,11 +32,7 @@ describe('runPreprocess', () => {
 
       fs.writeFileSync(inputPath, content, 'utf8')
 
-      const outputFilePath = await runPreprocess(
-        inputPath,
-        tmpDir,
-        format as SupportedFormat,
-      )
+      const outputFilePath = await runPreprocess(inputPath, tmpDir, format)
       if (!outputFilePath) throw new Error('Failed to run preprocess')
 
       expect(fs.existsSync(outputFilePath)).toBe(true)

--- a/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
@@ -6,7 +6,12 @@ import {
   supportedFormatSchema,
 } from '@liam-hq/db-structure/parser'
 import * as v from 'valibot'
-import { ArgumentError, type CliError, FileSystemError } from '../errors.js'
+import {
+  ArgumentError,
+  type CliError,
+  FileSystemError,
+  WarningProcessingError,
+} from '../errors.js'
 import { getInputContent } from './getInputContent.js'
 
 type Output = {
@@ -34,8 +39,14 @@ export async function runPreprocess(
 
   const { value: json, errors } = await parse(input, format)
   if (errors.length > 0) {
-    for (const error of errors) {
-      console.error(error)
+    return {
+      outputFilePath: null,
+      errors: errors.map(
+        (err) =>
+          new WarningProcessingError(
+            `Error during parcing schema file: ${err.message}`,
+          ),
+      ),
     }
   }
 

--- a/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
@@ -6,19 +6,30 @@ import {
   supportedFormatSchema,
 } from '@liam-hq/db-structure/parser'
 import * as v from 'valibot'
+import { ArgumentError, type CliError, FileSystemError } from '../errors.js'
 import { getInputContent } from './getInputContent.js'
+
+type Output = {
+  outputFilePath: string | null
+  errors: CliError[]
+}
 
 export async function runPreprocess(
   inputPath: string,
   outputDir: string,
   format: SupportedFormat,
-) {
+): Promise<Output> {
   const input = await getInputContent(inputPath)
 
   if (!v.safeParse(supportedFormatSchema, format).success) {
-    throw new Error(
-      '--format is missing, invalid, or specifies an unsupported format. Please provide a valid format (e.g., "schemarb" or "postgres").',
-    )
+    return {
+      outputFilePath: null,
+      errors: [
+        new ArgumentError(
+          '--format is missing, invalid, or specifies an unsupported format. Please provide a valid format (e.g., "schemarb" or "postgres").',
+        ),
+      ],
+    }
   }
 
   const { value: json, errors } = await parse(input, format)
@@ -37,11 +48,15 @@ export async function runPreprocess(
   try {
     const jsonContent = JSON.stringify(json, null, 2)
     fs.writeFileSync(filePath, jsonContent, 'utf8')
-    return filePath
+    return { outputFilePath: filePath, errors: [] }
   } catch (error) {
-    console.error(
-      `Error during preprocessing: ${error instanceof Error ? error.message : 'Unknown error'}`,
-    )
-    return null
+    return {
+      outputFilePath: null,
+      errors: [
+        new FileSystemError(
+          `Error during preprocessing: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        ),
+      ],
+    }
   }
 }

--- a/frontend/packages/cli/src/cli/errors.ts
+++ b/frontend/packages/cli/src/cli/errors.ts
@@ -18,3 +18,10 @@ export class FileSystemError extends CriticalError {
     this.name = 'FileSystemError'
   }
 }
+
+export class ArgumentError extends CriticalError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ArgumentError'
+  }
+}

--- a/frontend/packages/cli/src/cli/errors.ts
+++ b/frontend/packages/cli/src/cli/errors.ts
@@ -11,3 +11,10 @@ export class CriticalError extends CliError {
     this.name = 'CriticalError'
   }
 }
+
+export class FileSystemError extends CriticalError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FileSystemError'
+  }
+}

--- a/frontend/packages/cli/src/cli/errors.ts
+++ b/frontend/packages/cli/src/cli/errors.ts
@@ -25,3 +25,17 @@ export class ArgumentError extends CriticalError {
     this.name = 'ArgumentError'
   }
 }
+
+export class WarningError extends CliError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WarningError'
+  }
+}
+
+export class WarningProcessingError extends WarningError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WarningProcessingError'
+  }
+}

--- a/frontend/packages/cli/src/cli/errors.ts
+++ b/frontend/packages/cli/src/cli/errors.ts
@@ -4,3 +4,10 @@ export class CliError extends Error {
     this.name = 'CliError'
   }
 }
+
+export class CriticalError extends CliError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CriticalError'
+  }
+}

--- a/frontend/packages/cli/src/cli/errors.ts
+++ b/frontend/packages/cli/src/cli/errors.ts
@@ -1,0 +1,6 @@
+export class CliError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CliError'
+  }
+}


### PR DESCRIPTION
- Output logs are now prefixed with `ERROR:` and `WARN:` and output in color.
- In case of `ERROR` exit 1.

## Testing

```sh
node dist-cli/bin/cli.js erd build --format postgres --input https://raw.githubusercontent.com/metabase/metabase/fe13ca685912aa3cde89a7a7e8c0d4698cf9d060/resources/migrations/initialization/metabase_mysql.sql
```

output
<img width="932" alt="スクリーンショット 2025-01-03 19 54 00" src="https://github.com/user-attachments/assets/0498ee5a-bfbf-450c-a3a5-70ce7a202e23" />
