### PR TITLE
♻️ Refactor usePopStateListener

### DIFF
--- a/.changeset/large-waves-hug.md
+++ b/.changeset/large-waves-hug.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+♻️ refactor usePopStateListener

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
@@ -1,4 +1,4 @@
-import { updateActiveTableName } from '@/stores'
+import { updateActiveTableName, updateIsPopstateInProgress } from '@/stores'
 import { useEffect } from 'react'
 
 export const usePopStateListener = () => {
@@ -7,7 +7,12 @@ export const usePopStateListener = () => {
       const url = new URL(window.location.href)
       const tableName = url.searchParams.get('active')
 
+      updateIsPopstateInProgress(true)
       updateActiveTableName(tableName ?? undefined)
+
+      setTimeout(() => {
+        updateIsPopstateInProgress(false)
+      }, 0)
     }
 
     window.addEventListener('popstate', handlePopState)

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
@@ -7,7 +7,7 @@ export const usePopStateListener = () => {
       const url = new URL(window.location.href)
       const tableName = url.searchParams.get('active')
 
-      updateActiveTableName(tableName ?? undefined, true)
+      updateActiveTableName(tableName ?? undefined)
     }
 
     window.addEventListener('popstate', handlePopState)

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -1,6 +1,10 @@
 import type { ShowMode } from '@/schemas/showMode'
 import { userEditingStore } from './store'
 
+export const updateIsPopstateInProgress = (isPopstateInProgress: boolean) => {
+  userEditingStore.isPopstateInProgress = isPopstateInProgress
+}
+
 export const updateActiveTableName = (tableName: string | undefined) => {
   userEditingStore.active.tableName = tableName
 }

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -1,12 +1,8 @@
 import type { ShowMode } from '@/schemas/showMode'
 import { userEditingStore } from './store'
 
-export const updateActiveTableName = (
-  tableName: string | undefined,
-  isPopstateInProgress?: boolean,
-) => {
+export const updateActiveTableName = (tableName: string | undefined) => {
   userEditingStore.active.tableName = tableName
-  userEditingStore.isPopstateInProgress = isPopstateInProgress ?? false
 }
 
 export const updateShowMode = (showMode: ShowMode) => {

--- a/frontend/packages/erd-core/src/stores/userEditing/actions.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/actions.ts
@@ -3,10 +3,10 @@ import { userEditingStore } from './store'
 
 export const updateActiveTableName = (
   tableName: string | undefined,
-  isPopstateNavigation?: boolean,
+  isPopstateInProgress?: boolean,
 ) => {
   userEditingStore.active.tableName = tableName
-  userEditingStore.isPopstateNavigation = isPopstateNavigation ?? false
+  userEditingStore.isPopstateInProgress = isPopstateInProgress ?? false
 }
 
 export const updateShowMode = (showMode: ShowMode) => {

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -10,7 +10,7 @@ type UserEditingStore = {
   }
   showMode: ShowMode
   hiddenNodeIds: Set<string>
-  isPopstateNavigation: boolean
+  isPopstateInProgress: boolean
 }
 
 export const userEditingStore = proxy<UserEditingStore>({
@@ -19,12 +19,12 @@ export const userEditingStore = proxy<UserEditingStore>({
   },
   showMode: 'TABLE_NAME',
   hiddenNodeIds: proxySet<string>(),
-  isPopstateNavigation: false,
+  isPopstateInProgress: false,
 })
 
 subscribe(userEditingStore.active, () => {
   const newTableName = userEditingStore.active.tableName
-  const isPopstateNavigation = userEditingStore.isPopstateNavigation
+  const isPopstateInProgress = userEditingStore.isPopstateInProgress
   const url = new URL(window.location.href)
   const activeQueryParam: QueryParam = 'active'
 
@@ -34,7 +34,7 @@ subscribe(userEditingStore.active, () => {
     url.searchParams.delete(activeQueryParam)
   }
 
-  if (!isPopstateNavigation) {
+  if (!isPopstateInProgress) {
     window.history.pushState({}, '', url)
   }
 })


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

* [♻️ refactor: Rename isPopstateNavigation to isPopstateInProgress](https://github.com/liam-hq/liam/commit/b57ada9a29f9d69f5aff39ff0d562409e96a9264)
  * Navigation is not very clear meaning, so it makes clear that the popstate operation is in progress.
* [♻️ refactor: Delete argument form updateActiveTableName](https://github.com/liam-hq/liam/commit/e04b84a2777980de14d002322c4bd1bc6edbea13)
  * If each update actions accept args (`isPopstateInProgress`), e.g. `replaceHiddenNodeIds `, the amount of code increases and becomes complex.
* [♻️ refactor: Manage state in usePopStateListener](https://github.com/liam-hq/liam/commit/6a377154260466abb3c67c4ff43afad552c3b9d2)
  * Prevent adobe problem by having an action to update `isPopstateInProgress`.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
