### PR TITLE
Adjust `assetPrefix` configuration for non-production environments

### DIFF
--- a/frontend/apps/erd-web/next.config.ts
+++ b/frontend/apps/erd-web/next.config.ts
@@ -13,6 +13,8 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_GIT_HASH: gitCommitHash,
     NEXT_PUBLIC_RELEASE_DATE: releaseDate,
   },
+  // TODO: consider using .env.preview or the Preview environment variable setting in Vercel
+  // https://github.com/liam-hq/liam/pull/422#discussion_r1906531394
   assetPrefix:
     process.env.NEXT_PUBLIC_ENV_NAME === 'production'
       ? process.env.ASSET_PREFIX

--- a/frontend/apps/erd-web/next.config.ts
+++ b/frontend/apps/erd-web/next.config.ts
@@ -13,7 +13,10 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_GIT_HASH: gitCommitHash,
     NEXT_PUBLIC_RELEASE_DATE: releaseDate,
   },
-  assetPrefix: process.env.ASSET_PREFIX,
+  assetPrefix:
+    process.env.NEXT_PUBLIC_ENV_NAME === 'production'
+      ? process.env.ASSET_PREFIX
+      : undefined,
 }
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Adjust `assetPrefix` configuration for non-production environments

- Set `assetPrefix` to `undefined` when `NEXT_PUBLIC_ENV_NAME` is not 'production'.


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->


- The path `/erd/p/raw.githubusercontent.com/{owner_name/repo_name}/refs/heads/main/db/structure.sql`  is worked **in vercel preview environment(note: that is private for liam-dev)**.
    - check https://liam-erd-fze3tb8u5-route-06-core.vercel.app/

## Other Information
<!-- Add any other relevant information for the reviewer. -->

No Changeset setting. Intentionally.