### PR TITLE
🐛 Apply `window.requestAnimationFrame` to resolve conflicts between auto-layout and fitView operations

### DIFF
--- a/.changeset/nasty-taxis-agree.md
+++ b/.changeset/nasty-taxis-agree.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+🐛 Apply `window.requestAnimationFrame` to resolve conflicts between auto-layout and fitView operations

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/useAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/useAutoLayout.ts
@@ -39,10 +39,16 @@ export const useAutoLayout = () => {
       })
 
       setNodes([...hiddenNodes, ...newNodes])
+
+      // TODO: Investigate which approach works best. It's possible that both are needed.
+      // The use of `window.requestAnimationFrame` aligns with practices demonstrated in React Flow examples.
+      // ref: https://reactflow.dev/learn/layouting/layouting
       setTimeout(() => {
-        fitView(fitViewOptions)
-        setLoading(false)
-        setInitializeComplete(true)
+        window.requestAnimationFrame(() => {
+          fitView(fitViewOptions)
+          setLoading(false)
+          setInitializeComplete(true)
+        })
       }, 0)
     },
     [setNodes, fitView, setLoading, setInitializeComplete],


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

This update addresses auto-layout issues, particularly in the following scenarios:
- HTML generated by `liam erd build`
  - Mitigates a common problem observed in Safari
  - Likely does not fully prevent the issue yet 🙏 
- Problems in `apps/erd-web`
    - <details><summary>screenshot</summary>
        
        https://liam-erd-web.vercel.app/erd/p/raw.githubusercontent.com/mastodon/mastodon/refs/heads/main/db/schema.rb
        
        <img width="928" alt="スクリーンショット 2025-01-09 8 54 29" src="https://github.com/user-attachments/assets/b2ff82d6-8cd9-41c4-8196-2586f7c7f2a1" />
        
        
        </details>



The use of `window.requestAnimationFrame` aligns with practices demonstrated in React Flow examples.
Reference: https://reactflow.dev/learn/layouting/layouting


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->



#### Comparison: This PR vs. Main Branch

- **This PR**: [Preview](https://liam-erd-91eq87lg9-route-06-core.vercel.app/erd/p/raw.githubusercontent.com/mastodon/mastodon/refs/heads/main/db/schema.rb)
- **Main Branch**: [Preview](https://liam-erd-web.vercel.app/erd/p/raw.githubusercontent.com/mastodon/mastodon/refs/heads/main/db/schema.rb) (Main Branch) + Tidy Up + Zoom to Fit

Both versions produce the same rendering.



<details><summary></summary>

<img width="554" alt="スクリーンショット 2025-01-09 8 57 47" src="https://github.com/user-attachments/assets/f3f605af-0faa-43c3-b859-fe0595804d5e" />

</details>

## Other Information
<!-- Add any other relevant information for the reviewer. -->

This PR maybe mitigate a common problem observed in Safari . but likely does not fully prevent the issue yet 🙏 