### PR TITLE
Refactor workflows to include `erd-web` deployment

### DIFF
--- a/.github/workflows/vercel-deploy-erd.yml
+++ b/.github/workflows/vercel-deploy-erd.yml
@@ -1,4 +1,4 @@
-# This workflow specifically deploys the `apps/erd-sample` app.
+# This workflow specifically deploys the `apps/erd-sample` and `apps/erd-web` app.
 # For deployments of other `apps/*` apps, see `.github/workflows/vercel-deploy.yml`.
 name: Vercel Deployment erd-sample
 
@@ -31,8 +31,9 @@ jobs:
         with:
           filters: |
             src:
-              - './.github/workflows/vercel-deploy-erd-sample.yml'
+              - './.github/workflows/vercel-deploy-erd.yml'
               - './frontend/apps/erd-sample/**'
+              - './frontend/apps/erd-web/**'
               - './frontend/packages/cli/**'
               - './frontend/packages/db-structure/**'
               - './frontend/packages/erd-core/**'
@@ -49,6 +50,8 @@ jobs:
         apps:
           - name: "@liam-hq/erd-sample"
             vercel-project-id-key: VERCEL_PROJECT_ID_ERD_SAMPLE
+          - name: erd-web
+            vercel-project-id-key: VERCEL_PROJECT_ID_ERD_WEB
     environment:
       name: "${{ needs.setup-deployment.outputs.environment }} - ${{ matrix.apps.name }}"
       url: ${{ steps.deployment.outputs.deployment-url }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,5 +1,5 @@
-# This workflow deploys all `apps/*` apps.
-# For the `apps/erd-sample` app, see `.github/workflows/vercel-deploy-erd-sample.yml`.
+# This workflow deploys some `apps/*` apps.
+# For the `apps/erd-sample` and `apps/erd-web` app, see `.github/workflows/vercel-deploy-erd.yml`.
 name: Vercel Deployment
 
 on:
@@ -33,7 +33,6 @@ jobs:
             src:
               - './.github/workflows/vercel-deploy.yml'
               - './frontend/apps/docs/**'
-              - './frontend/apps/erd-web/**'
 
   deploy:
     name: Deploy
@@ -46,8 +45,6 @@ jobs:
         apps:
           - name: docs
             vercel-project-id-key: VERCEL_PROJECT_ID_DOCS
-          - name: erd-web
-            vercel-project-id-key: VERCEL_PROJECT_ID_ERD_WEB
     environment:
       name: "${{ needs.setup-deployment.outputs.environment }} - ${{ matrix.apps.name }}"
       url: ${{ steps.deployment.outputs.deployment-url }}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Enabled `apps/erd-web` to deploy to the preview environment even when a PR contains changes only under `packages/`.

- Renamed `.github/workflows/vercel-deploy-erd-sample.yml` to `.github/workflows/vercel-deploy-erd.yml` to encompass both `erd-sample` and `erd-web` deployments.
- Updated filters in `vercel-deploy-erd.yml` to include `erd-web` sources.
- Added `erd-web` configuration to the deployment job in `vercel-deploy-erd.yml`.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

GitHub Actions in this PR are worked

- apps/docs
- apps/erd-web
- apps/erd-sample

## Other Information
<!-- Add any other relevant information for the reviewer. -->

No changeset added intentionally.






