### PR TITLE
🐛 Fix CSS import issue and improve font handling in `erd-web`

### DIFF
--- a/.changeset/beige-clocks-deliver.md
+++ b/.changeset/beige-clocks-deliver.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+🐛 Fix CSS import issue and improve font handling in `erd-web`

--- a/frontend/apps/erd-web/app/globals.css
+++ b/frontend/apps/erd-web/app/globals.css
@@ -1,0 +1,1 @@
+@import '@/styles/fonts.css';

--- a/frontend/apps/erd-web/tsconfig.json
+++ b/frontend/apps/erd-web/tsconfig.json
@@ -22,7 +22,8 @@
       "@/*": [
         "./*",
         "../../packages/erd-core/src/*",
-        "../../packages/db-structure/src/*"
+        "../../packages/db-structure/src/*",
+        "../../packages/ui/src/*"
       ]
     }
   },

--- a/frontend/packages/ui/src/styles/fonts.css
+++ b/frontend/packages/ui/src/styles/fonts.css
@@ -1,0 +1,3 @@
+/* https://fonts.google.com/specimen/IBM+Plex+Mono */
+/* https://fonts.google.com/specimen/Inter */
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');

--- a/frontend/packages/ui/src/styles/globals.css
+++ b/frontend/packages/ui/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import './fonts.css';
 @import url('destyle.css');
 @import './Dark/variables.css';
 @import './Mode 1/variables.css';

--- a/frontend/packages/ui/src/styles/variables.css
+++ b/frontend/packages/ui/src/styles/variables.css
@@ -1,7 +1,3 @@
-/* https://fonts.google.com/specimen/IBM+Plex+Mono */
-/* https://fonts.google.com/specimen/Inter */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
-
 :root {
   --default-timing-function: ease-out;
   --default-animation-duration: 300ms;


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

- Moved `@import` rule for Google Fonts to resolve an error in Chrome.
- Addressed an issue in Safari where the font incorrectly appeared as serif.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

- **erd-sample**
    - Visit https://liam-erd-sample-t04r56gms-route-06-core.vercel.app/  by Safari
- **erd-web**
    - Visit https://liam-erd-eyqd2fas5-route-06-core.vercel.app/erd/p/raw.githubusercontent.com/mastodon/mastodon/refs/heads/main/db/schema.rb by Safari

## Other Information
<!-- Add any other relevant information for the reviewer. -->
