### PR TITLE
✨ Add a new galaxy page and implement a redirect from the ERD page

### DIFF
--- a/frontend/apps/erd-web/app/erd/galaxy/page.tsx
+++ b/frontend/apps/erd-web/app/erd/galaxy/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from 'next/navigation'
+import type { FC } from 'react'
+
+const Page: FC = () => {
+  if (process.env.NEXT_PUBLIC_ENV_NAME === 'production') return notFound()
+
+  return (
+    <div>
+      <p>Galaxy page</p>
+    </div>
+  )
+}
+
+export default Page

--- a/frontend/apps/erd-web/app/erd/page.tsx
+++ b/frontend/apps/erd-web/app/erd/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/erd/galaxy')
+}

--- a/frontend/apps/erd-web/app/page.tsx
+++ b/frontend/apps/erd-web/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/erd/galaxy')
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

a new page component has been added to handle the ``/erd/galaxy`` URL. The component includes logic to display the page only in non-production environments. 
If the environment is set to production, the page will return a 404 Not Found response.

As far as I understand...↓

URL | local | preview | production
-- | -- | -- | --
/ | redirect to /erd/galaxy | redirect to /erd/galaxy | access service-site
/erd | redirect to /erd/galaxy | redirect to /erd/galaxy | return 404
/erd/galaxy | access the /erd/galaxy | access the /erd/galaxy | return 404

If I'm mistaken, please let me know. 🙏


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
