### PR TITLE
🚸 delete unnecessary margin on mobile

### DIFF
--- a/.changeset/hip-poems-trade.md
+++ b/.changeset/hip-poems-trade.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🚸 delete unnecessary margin on mobile

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.module.css
@@ -55,5 +55,7 @@
   :global([data-state='expanded']) + .main .toolbarWrapper {
     opacity: 0;
     visibility: hidden;
+    width: 0;
+    margin: 0;
   }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

A minor fix. The **small margin on the right and bottom** of the LeftPane on mobile devices, caused by the Toolbar, has been removed.

preview: https://liam-erd-sample-r58kkhgx5-route-06-core.vercel.app/

![ss 2630](https://github.com/user-attachments/assets/a6cb62c2-6caa-437a-b24c-908990b03b13)

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
