### PR TITLE
💄 Move react flow attribution from bottom-right to bottom-left

### DIFF
--- a/.changeset/tender-seas-cover.md
+++ b/.changeset/tender-seas-cover.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+💄 Move react flow attribution from bottom-right to bottom-left

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -159,6 +159,7 @@ export const ERDContentInner: FC<Props> = ({
         panOnDrag={panOnDrag}
         selectionOnDrag
         deleteKeyCode={null} // Turn off because it does not want to be deleted
+        attributionPosition="bottom-left"
       >
         <Background
           color="var(--color-gray-600)"


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->


Move react flow attribution from bottom-right to bottom-left.

|before|after|
|--|--|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/a418576e-84d5-4781-83f9-2f2a5b1f2afa" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/ca8682d6-c6f6-49df-80a8-e72c8d5fab76" />|

Reason:
When embedding an ER diagram in an iframe in LP, we would like to display a link to go to the path of the ER diagram on bottom-right, but it overlaps with the React Flow logo (attribution).

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
