### PR TITLE
🚸 Add ErrorDisplay component for handling and displaying errors in ERDViewer (first step)

### DIFF
--- a/.changeset/afraid-apes-add.md
+++ b/.changeset/afraid-apes-add.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/erd-core": patch
+---
+
+🚸 Add ErrorDisplay component for handling and displaying errors in ERDViewer

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { DBStructure } from '@liam-hq/db-structure'
+import type { DBStructure, ProcessError } from '@liam-hq/db-structure'
 import {
   ERDRenderer,
   VersionProvider,
@@ -12,11 +12,13 @@ import * as v from 'valibot'
 
 type ERDViewerProps = {
   dbStructure: DBStructure
+  errors: ProcessError[]
   defaultSidebarOpen: boolean
 }
 
 export default function ERDViewer({
   dbStructure,
+  errors,
   defaultSidebarOpen,
 }: ERDViewerProps) {
   useEffect(() => {
@@ -33,7 +35,7 @@ export default function ERDViewer({
   return (
     <div style={{ height: '100vh' }}>
       <VersionProvider version={version}>
-        <ERDRenderer defaultSidebarOpen={defaultSidebarOpen} />
+        <ERDRenderer defaultSidebarOpen={defaultSidebarOpen} errors={errors} />
       </VersionProvider>
     </div>
   )

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/correctness/noNodejsModules: Required for the server component to read the wasm file
 import path from 'node:path'
 import type { PageProps } from '@/app/types'
 import {
@@ -117,11 +116,9 @@ export default async function Page({
   }
 
   const { value: dbStructure, errors } = await parse(input, format)
-  // TODO: Show error message in the UI
   if (errors.length > 0) {
     for (const error of errors) {
       Sentry.captureException(error)
-      console.error(error)
     }
   }
 
@@ -132,6 +129,7 @@ export default async function Page({
     <ERDViewer
       dbStructure={dbStructure}
       defaultSidebarOpen={defaultSidebarOpen}
+      errors={errors}
     />
   )
 }

--- a/frontend/packages/db-structure/src/index.ts
+++ b/frontend/packages/db-structure/src/index.ts
@@ -13,3 +13,5 @@ export {
   aColumn,
   aRelationship,
 } from './schema/index.js'
+
+export { type ProcessError } from './parser.js'

--- a/frontend/packages/db-structure/src/parser.ts
+++ b/frontend/packages/db-structure/src/parser.ts
@@ -4,4 +4,5 @@ export {
   supportedFormatSchema,
   detectFormat,
   setPrismWasmUrl,
+  ProcessError,
 } from './parser/index.js'

--- a/frontend/packages/db-structure/src/parser/index.ts
+++ b/frontend/packages/db-structure/src/parser/index.ts
@@ -3,6 +3,7 @@ import { processor as postgresqlProcessor } from './sql/index.js'
 import type { SupportedFormat } from './supportedFormat/index.js'
 import type { ProcessResult } from './types.js'
 
+export { ProcessError } from './errors.js'
 export { setPrismWasmUrl } from './schemarb/index.js'
 export {
   supportedFormatSchema,

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -1,4 +1,5 @@
 import '@xyflow/react/dist/style.css'
+import type { ProcessError } from '@liam-hq/db-structure'
 import { SidebarProvider, SidebarTrigger, ToastProvider } from '@liam-hq/ui'
 import { ReactFlowProvider } from '@xyflow/react'
 import { type FC, useCallback, useState } from 'react'
@@ -13,15 +14,20 @@ import { useDBStructureStore, useUserEditingStore } from '@/stores'
 import { CardinalityMarkers } from './CardinalityMarkers'
 // biome-ignore lint/nursery/useImportRestrictions: Fixed in the next PR.
 import { Toolbar } from './ERDContent/Toolbar'
+import { ErrorDisplay } from './ErrorDisplay'
 import { RelationshipEdgeParticleMarker } from './RelationshipEdgeParticleMarker'
 import { TableDetailDrawer, TableDetailDrawerRoot } from './TableDetailDrawer'
 import { convertDBStructureToNodes } from './convertDBStructureToNodes'
 
 type Props = {
   defaultSidebarOpen?: boolean | undefined
+  errors: ProcessError[]
 }
 
-export const ERDRenderer: FC<Props> = ({ defaultSidebarOpen = false }) => {
+export const ERDRenderer: FC<Props> = ({
+  defaultSidebarOpen = false,
+  errors,
+}) => {
   const [open, setOpen] = useState(defaultSidebarOpen)
 
   const { showMode } = useUserEditingStore()
@@ -61,15 +67,20 @@ export const ERDRenderer: FC<Props> = ({ defaultSidebarOpen = false }) => {
                   <SidebarTrigger />
                 </div>
                 <TableDetailDrawerRoot>
-                  <ERDContent
-                    key={`${nodes.length}-${showMode}`}
-                    nodes={nodes}
-                    edges={edges}
-                  />
-                  <div className={styles.toolbarWrapper}>
-                    <Toolbar />
-                  </div>
-                  <TableDetailDrawer />
+                  {errors.length > 0 && <ErrorDisplay errors={errors} />}
+                  {errors.length > 0 || (
+                    <>
+                      <ERDContent
+                        key={`${nodes.length}-${showMode}`}
+                        nodes={nodes}
+                        edges={edges}
+                      />
+                      <div className={styles.toolbarWrapper}>
+                        <Toolbar />
+                      </div>
+                      <TableDetailDrawer />
+                    </>
+                  )}
                 </TableDetailDrawerRoot>
               </main>
             </div>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay.module.css
@@ -1,0 +1,8 @@
+/* TODO: styling */
+.wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: var(--global-background);
+  color: blanchedalmond;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay.tsx
@@ -1,0 +1,24 @@
+import type { ProcessError } from '@liam-hq/db-structure'
+import type { FC } from 'react'
+import styles from './ErrorDisplay.module.css'
+
+type Props = {
+  errors: ProcessError[]
+}
+
+export const ErrorDisplay: FC<Props> = ({ errors }) => {
+  // TODO: styling
+  return (
+    <div className={styles.wrapper}>
+      <div>something went wrong</div>
+      <ul>
+        {errors.map((error) => (
+          // NOTE: error.stack is not available in the browser now.
+          <li key={error.message}>
+            {error.name}: {error.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Component for erd-web app.

- Introduced the `ErrorDisplay` component to provide a visual representation of errors in the ERD renderer.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

display: 

https://liam-erd-ajtacqg7o-route-06-core.vercel.app/erd/p/raw.githubusercontent.com/metabase/metabase/fe13ca685912aa3cde89a7a7e8c0d4698cf9d060/resources/migrations/initialization/metabase_mysql.sql

<img width="1351" alt="スクリーンショット 2025-01-09 20 14 13" src="https://github.com/user-attachments/assets/854a42b4-9a98-46eb-814f-78dbc79820f8" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->


