### PR TITLE
fix a broken link to docs/packages-license.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 Liam is licensed under the [Apache License Version 2.0](LICENSE).
 
-Licenses for third-party packages can be found in [frontend/docs/packages-license.md](frontend/docs/packages-license.md).
+Licenses for third-party packages can be found in [docs/packages-license.md](docs/packages-license.md).


### PR DESCRIPTION
## Summary
I fixed a broken link to docs/packages-license.md in README.md.

## Related Issue
none

## Changes
fix a broken link 

## Testing
check the link in [README.md](https://github.com/liam-hq/liam/blob/7c08f949596cc294133ccfb68cd110b52bf9b550/README.md)

## Other Information
<!-- Add any other relevant information for the reviewer. -->
