### PR TITLE
✨ Add static route to serve concatenated MDX content from docs directory

### DIFF
--- a/frontend/apps/docs/app/docs/llms-full.txt/route.ts
+++ b/frontend/apps/docs/app/docs/llms-full.txt/route.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { NextResponse } from 'next/server'
+
+// This is a static route, so it will be rendered at build time
+export const dynamic = 'force-static'
+
+const getRawContents = (dirPath: string): string[] => {
+  const results: string[] = []
+  let rootIndexContent: string | null = null
+
+  const list = fs.readdirSync(dirPath)
+  for (const file of list) {
+    const filePath = path.resolve(dirPath, file)
+    const stat = fs.statSync(filePath)
+
+    if (stat?.isDirectory()) {
+      results.push(...getRawContents(filePath))
+    } else {
+      const content = fs.readFileSync(filePath, 'utf8')
+      if (
+        filePath === path.resolve(dirPath, 'index.mdx') &&
+        dirPath === path.resolve(process.cwd(), 'content/docs')
+      ) {
+        rootIndexContent = content
+      } else {
+        results.push(content)
+      }
+    }
+  }
+
+  if (rootIndexContent) {
+    results.unshift(rootIndexContent)
+  }
+
+  return results
+}
+
+export function GET() {
+  const rawContents = getRawContents(
+    path.resolve(process.cwd(), 'content/docs'),
+  )
+
+  const content = `
+# Liam ERD
+
+${rawContents.join('\n\n')}
+`
+
+  return new NextResponse(content, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}


### PR DESCRIPTION
https://liam-docs-jpgj8xmww-route-06-core.vercel.app/docs/llms-full.txt

As `liambx.com/docs/llms-full.txt`, I have created an endpoint that returns the entire manual content in a single markdown plain/text format. Our objectives are twofold:

1. for use by the dev team in product development
    - 2. to pass all information in the manual to LLM and make it easier to discuss Liam ERD
    - ref: [started providing llms-full.txt on this site | Hirotaka Miyagi](https://www.mh4gf.dev/articles/llms-full-txt)
2. marketing purposes to be put on https://llmstxt.site/

