### PR TITLE
✨ Implement show mode handling in URL parameters and state management

### DIFF
--- a/.changeset/olive-spoons-notice.md
+++ b/.changeset/olive-spoons-notice.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+✨ Implement show mode handling in URL parameters and state management

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -1,5 +1,10 @@
 import type { QueryParam } from '@/schemas/queryParam'
-import { addHiddenNodeIds, updateActiveTableName } from '@/stores'
+import type { ShowMode } from '@/schemas/showMode'
+import {
+  addHiddenNodeIds,
+  updateActiveTableName,
+  updateShowMode,
+} from '@/stores'
 import { decompressFromEncodedURIComponent } from '@/utils'
 import { type Node, useReactFlow } from '@xyflow/react'
 import { useEffect, useMemo } from 'react'
@@ -24,6 +29,14 @@ const getHiddenNodeIdsFromUrl = async (): Promise<string[]> => {
     : undefined
 
   return hiddenNodeIds ? hiddenNodeIds.split(',') : []
+}
+
+const getShowModeFromUrl = (): string | undefined => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const showModeQueryParam: QueryParam = 'showMode'
+  const showMode = urlParams.get(showModeQueryParam)
+
+  return showMode || 'TABLE_NAME'
 }
 
 export const useInitialAutoLayout = (
@@ -66,6 +79,9 @@ export const useInitialAutoLayout = (
         shouldFitViewToActiveTable && activeTableName
           ? { maxZoom: 1, duration: 300, nodes: [{ id: activeTableName }] }
           : undefined
+
+      const showMode = getShowModeFromUrl()
+      updateShowMode(showMode as ShowMode)
 
       if (tableNodesInitialized) {
         handleLayout(updatedNodes, updatedEdges, fitViewOptions)

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -37,10 +37,6 @@ const getShowModeFromUrl = (): ShowMode => {
   const showModeQueryParam: QueryParam = 'showMode'
   const showMode = urlParams.get(showModeQueryParam)
 
-  if (!showMode) {
-    return 'TABLE_NAME'
-  }
-
   const result = v.safeParse(showModeSchema, showMode)
   if (result.success && result.output) {
     return result.output

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
@@ -1,4 +1,9 @@
-import { updateActiveTableName, updateIsPopstateInProgress } from '@/stores'
+import type { ShowMode } from '@/schemas/showMode'
+import {
+  updateActiveTableName,
+  updateIsPopstateInProgress,
+  updateShowMode,
+} from '@/stores'
 import { useEffect } from 'react'
 
 export const usePopStateListener = () => {
@@ -6,9 +11,12 @@ export const usePopStateListener = () => {
     const handlePopState = async () => {
       const url = new URL(window.location.href)
       const tableName = url.searchParams.get('active')
+      const showMode = url.searchParams.get('showMode')
 
       updateIsPopstateInProgress(true)
       updateActiveTableName(tableName ?? undefined)
+
+      updateShowMode(showMode as ShowMode)
 
       setTimeout(() => {
         updateIsPopstateInProgress(false)

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
@@ -17,20 +17,11 @@ export const usePopStateListener = () => {
       updateIsPopstateInProgress(true)
       updateActiveTableName(tableName ?? undefined)
 
-      if (!showMode) {
-        updateShowMode('TABLE_NAME')
-        setTimeout(() => {
-          updateIsPopstateInProgress(false)
-        }, 0)
-        return
-      }
-
       const result = v.safeParse(showModeSchema, showMode)
       if (result.success && result.output) {
         updateShowMode(result.output)
       }
 
-      updateShowMode('TABLE_NAME')
       setTimeout(() => {
         updateIsPopstateInProgress(false)
       }, 0)

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/usePopStateListener.ts
@@ -1,10 +1,11 @@
-import type { ShowMode } from '@/schemas/showMode'
+import { showModeSchema } from '@/schemas/showMode'
 import {
   updateActiveTableName,
   updateIsPopstateInProgress,
   updateShowMode,
 } from '@/stores'
 import { useEffect } from 'react'
+import * as v from 'valibot'
 
 export const usePopStateListener = () => {
   useEffect(() => {
@@ -16,8 +17,20 @@ export const usePopStateListener = () => {
       updateIsPopstateInProgress(true)
       updateActiveTableName(tableName ?? undefined)
 
-      updateShowMode(showMode as ShowMode)
+      if (!showMode) {
+        updateShowMode('TABLE_NAME')
+        setTimeout(() => {
+          updateIsPopstateInProgress(false)
+        }, 0)
+        return
+      }
 
+      const result = v.safeParse(showModeSchema, showMode)
+      if (result.success && result.output) {
+        updateShowMode(result.output)
+      }
+
+      updateShowMode('TABLE_NAME')
       setTimeout(() => {
         updateIsPopstateInProgress(false)
       }, 0)

--- a/frontend/packages/erd-core/src/schemas/queryParam/schemas.ts
+++ b/frontend/packages/erd-core/src/schemas/queryParam/schemas.ts
@@ -1,3 +1,3 @@
 import { picklist } from 'valibot'
 
-export const queryParamSchema = picklist(['active', 'hidden'])
+export const queryParamSchema = picklist(['active', 'hidden', 'showMode'])

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -52,3 +52,18 @@ subscribe(userEditingStore.hiddenNodeIds, async () => {
 
   window.history.pushState({}, '', url)
 })
+
+let previousShowMode = userEditingStore.showMode
+subscribe(userEditingStore, () => {
+  const newShowMode = userEditingStore.showMode
+  if (newShowMode !== previousShowMode) {
+    previousShowMode = newShowMode
+    const url = new URL(window.location.href)
+    const showModeQueryParam: QueryParam = 'showMode'
+
+    if (newShowMode) {
+      url.searchParams.set(showModeQueryParam, newShowMode)
+      window.history.pushState({}, '', url)
+    }
+  }
+})

--- a/frontend/packages/erd-core/src/stores/userEditing/store.ts
+++ b/frontend/packages/erd-core/src/stores/userEditing/store.ts
@@ -2,7 +2,7 @@ import type { QueryParam } from '@/schemas/queryParam'
 import type { ShowMode } from '@/schemas/showMode'
 import { compressToEncodedURIComponent } from '@/utils'
 import { proxy, subscribe } from 'valtio'
-import { proxySet } from 'valtio/utils'
+import { proxySet, subscribeKey } from 'valtio/utils'
 
 type UserEditingStore = {
   active: {
@@ -53,17 +53,12 @@ subscribe(userEditingStore.hiddenNodeIds, async () => {
   window.history.pushState({}, '', url)
 })
 
-let previousShowMode = userEditingStore.showMode
-subscribe(userEditingStore, () => {
-  const newShowMode = userEditingStore.showMode
-  if (newShowMode !== previousShowMode) {
-    previousShowMode = newShowMode
-    const url = new URL(window.location.href)
-    const showModeQueryParam: QueryParam = 'showMode'
+subscribeKey(userEditingStore, 'showMode', (newShowMode) => {
+  const url = new URL(window.location.href)
+  const showModeQueryParam: QueryParam = 'showMode'
 
-    if (newShowMode) {
-      url.searchParams.set(showModeQueryParam, newShowMode)
-      window.history.pushState({}, '', url)
-    }
+  if (newShowMode) {
+    url.searchParams.set(showModeQueryParam, newShowMode)
+    window.history.pushState({}, '', url)
   }
 })


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

In thisPR, the code has been updated to manage the ``showMode`` state and synchronize it with the URL query parameters.

Preview: https://liam-erd-sample-ggnkr3clv-route-06-core.vercel.app/?showMode=TABLE_NAME&active=status_edits

## Related Issue
<!-- Mention the related issue number if applicable. -->

close: https://github.com/liam-hq/liam/issues/337

## Changes
<!-- List the main changes made in this PR. -->

####  1. Managing showMode State:

The  ``showMode`` state is now monitored, and any changes to it are reflected in the URL query parameters.
A  ``previousShowMode`` variable is used to track the previous state and detect changes.


####  2. Synchronizing showMode with URL:

When  ``showMode`` changes, the URL query parameter  ``showMode`` is updated accordingly.
If showMode is set, it is added to the URL; otherwise, it is removed.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
