### PR TITLE
🔧: add GitHub Actions workflow to send discussion comments to Slack

### DIFF
--- a/.github/workflows/discussion-comment-to-slack.yml
+++ b/.github/workflows/discussion-comment-to-slack.yml
@@ -1,0 +1,10 @@
+on:
+  discussion_comment:
+    types: [created]
+
+jobs:
+  discussion_commented:
+    if: github.event.discussion && github.event.comment
+    uses: route06/actions/.github/workflows/gh_discussion_comment_to_slack.yml@v2
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_GHD_WEBHOOK_URL }}


### PR DESCRIPTION
Notify for development team.