### PR TITLE
💄 Add custom color theme settings

### DIFF
--- a/frontend/apps/docs/app/global.css
+++ b/frontend/apps/docs/app/global.css
@@ -1,3 +1,80 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  /* Color Primitive */
+  :root {
+    --liam-gray-0: 0 0% 100%;
+    --liam-gray-5: 0 0% 97%;
+    --liam-gray-10: 0 0% 94%;
+    --liam-gray-30: 220 7% 91%;
+    --liam-gray-40: 210 3% 87%;
+    --liam-gray-50: 210 2% 82%;
+    --liam-gray-100: 220 2% 75%;
+    --liam-gray-400: 206 4% 39%;
+    --liam-gray-500: 200 2% 27%;
+    --liam-gray-600: 200 3% 23%;
+    --liam-gray-700: 200 3% 23%;
+    --liam-gray-800: 200 3% 19%;
+    --liam-gray-900: 200 4% 14%;
+    --liam-gray-1000: 180 5% 8%;
+    --liam-gray-1100: 180 5% 6%;
+
+    --liam-green-10: 135 67% 99%;
+    --liam-green-50: 145 100% 97%;
+    --liam-green-80: 135 100% 94%;
+    --liam-green-100: 136 100% 89%;
+    --liam-green-200: 148 97% 85%;
+    --liam-green-300: 149 86% 62%;
+    --liam-green-400: 149 85% 52%;
+    --liam-green-500: 145 56% 49%;
+    --liam-green-600: 150 100% 26%;
+    --liam-green-700: 143 49% 18%;
+    --liam-green-950: 152 100% 10%;
+
+    --base-black: 0 0% 0%;
+    --base-white: 0 0% 100%;
+  }
+
+  /* Color Semantics */
+  :root {
+    --fd-background: 0 0% 98%;
+    --fd-foreground: var(--liam-gray-1000);
+    --fd-muted: var(--liam-gray-5);
+    --fd-muted-foreground: var(--liam-gray-600);
+    --fd-popover: var(--base-white);
+    --fd-popover-foreground: var(--liam-gray-800);
+    --fd-card: var(--base-white);
+    --fd-card-foreground: var(--liam-gray-1000);
+    --fd-border: var(--liam-gray-30);
+    --fd-primary: var(--liam-green-600);
+    --fd-primary-foreground: var(--base-black);
+    --fd-secondary: var(--liam-gray-10);
+    --fd-secondary-foreground: var(--liam-gray-500);
+    --fd-accent: var(--liam-gray-50);
+    --fd-accent-foreground: var(--liam-gray-500);
+
+    --fd-ring: 221 83% 53%;
+
+    --fd-sidebar-width: 16.25rem;
+  }
+
+  .dark {
+    --fd-background: var(--liam-gray-1100);
+    --fd-foreground: var(--liam-gray-0);
+    --fd-muted: var(--liam-gray-900);
+    --fd-muted-foreground: var(--liam-gray-100);
+    --fd-popover: var(--liam-gray-1000);
+    --fd-popover-foreground: var(--liam-gray-0);
+    --fd-card: var(--liam-gray-1000);
+    --fd-card-foreground: var(--liam-gray-0);
+    --fd-border: var(--liam-gray-800);
+    --fd-primary: var(--liam-green-400);
+    --fd-primary-foreground: var(--base-black);
+    --fd-secondary: var(--liam-gray-600);
+    --fd-secondary-foreground: var(--liam-gray-10);
+    --fd-accent: var(--liam-gray-800);
+    --fd-accent-foreground: var(--liam-gray-30);
+  }
+}

--- a/frontend/apps/docs/tailwind.config.js
+++ b/frontend/apps/docs/tailwind.config.js
@@ -1,7 +1,7 @@
 import { createPreset } from 'fumadocs-ui/tailwind-plugin'
 
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   content: [
     './components/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
@@ -9,5 +9,37 @@ export default {
     './mdx-components.{ts,tsx}',
     './node_modules/fumadocs-ui/dist/**/*.js',
   ],
-  presets: [createPreset()],
+  presets: [
+    createPreset({
+      cssPrefix: 'fd',
+    }),
+  ],
+  theme: {
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': 'hsl(var(--fd-foreground) / 0.9)',
+            '--tw-prose-headings': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-lead': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-links': 'hsl(var(--fd-primary) / 1)',
+            '--tw-prose-bold': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-counters': 'hsl(var(--fd-muted-foreground) / 1)',
+            '--tw-prose-bullets': 'hsl(var(--fd-muted-foreground) / 1)',
+            '--tw-prose-hr': 'hsl(var(--fd-border) / 1)',
+            '--tw-prose-quotes': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-quote-borders': 'hsl(var(--fd-border) / 1)',
+            '--tw-prose-captions': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-code': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-th-borders': 'hsl(var(--fd-border) / 1)',
+            '--tw-prose-td-borders': 'hsl(var(--fd-border) / 1)',
+            '--tw-prose-kbd': 'hsl(var(--fd-foreground) / 1)',
+            '--tw-prose-kbd-shadows': 'hsl(var(--fd-primary) / 0.5)',
+          },
+        },
+      },
+    },
+  },
 }
+
+export default config


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I added fumadocs color themes and Tailwind color themes to match the design of the docs site.

| light | dark |
|--------|--------|
| ![スクリーンショット 2025-01-15 17 58 42](https://github.com/user-attachments/assets/9997c337-1839-43bc-8f69-5268383ad175) | ![スクリーンショット 2025-01-15 17 58 32](https://github.com/user-attachments/assets/ad4c7a6d-847d-4254-bc11-56068e02e545) | 
