### PR TITLE
🔧 Disable turbopack option from dev command for ERD Web

### DIFF
--- a/frontend/apps/erd-web/package.json
+++ b/frontend/apps/erd-web/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "next build",
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "fmt": "pnpm run '/^fmt:.*/'",
     "fmt:biome": "biome check --write --unsafe .",
     "lint": "pnpm run '/^lint:.*/'",


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Removed `--turbopack` flag from the dev script as it may bypass webpack configurations defined in `next.config.ts`, specifically our webpack alias settings for `@prisma/internals`. This ensures consistent behavior between development and production environments.

>Note: Production builds with next build are not yet supported.
https://turbo.build/pack/docs

## Related Issue
<!-- Mention the related issue number if applicable. -->

- https://github.com/liam-hq/liam/pull/454

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
