### PR TITLE
🐛 Update TableCounter to count only table nodes

### DIFF
--- a/.changeset/two-bees-wash.md
+++ b/.changeset/two-bees-wash.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 Update TableCounter to count only table nodes

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableCounter/TableCounter.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableCounter/TableCounter.tsx
@@ -4,9 +4,10 @@ import type { FC } from 'react'
 import styles from './TableCounter.module.css'
 
 export const TableCounter: FC = () => {
-  const nodes = useNodes()
-  const allCount = nodes.length
-  const visibleCount = nodes.filter((node) => !node.hidden).length
+  const tableNodes = useNodes().filter((node) => node.type === 'table')
+
+  const allCount = tableNodes.length
+  const visibleCount = tableNodes.filter((node) => !node.hidden).length
 
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I've updated TableCounter to only count nodes that are strictly tables. Previously, ``non-related-table-group`` nodes were being included, leading to incorrect counts.

![ss 2676](https://github.com/user-attachments/assets/f97498a1-7272-4376-8030-3974b2747f59)


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
