### PR TITLE
✨ Create original Tabs/Tab component for docs

### DIFF
--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,5 +1,5 @@
+import { Tab, Tabs } from '@/components'
 import { source } from '@/lib/source'
-import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import {
   DocsBody,
@@ -32,7 +32,13 @@ export default async function Page(props: {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Tab, Tabs }} />
+        <MDX
+          components={{
+            ...defaultMdxComponents,
+            Tabs,
+            Tab,
+          }}
+        />
       </DocsBody>
     </DocsPage>
   )

--- a/frontend/apps/docs/biome.jsonc
+++ b/frontend/apps/docs/biome.jsonc
@@ -1,3 +1,16 @@
 {
-  "extends": ["../../packages/configs/biome.jsonc"]
+  "extends": ["../../packages/configs/biome.jsonc"],
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noRestrictedImports": {
+          "options": {
+            "paths": {
+              "fumadocs-ui/components/tabs": "Use '@/components' instead."
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/frontend/apps/docs/components/Tabs/Tabs.tsx
+++ b/frontend/apps/docs/components/Tabs/Tabs.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import {
+  type TabsProps as FumadocsTabsProps,
+  Primitive,
+  // biome-ignore lint/nursery/noRestrictedImports: Make original Tabs/Tab component
+} from 'fumadocs-ui/components/tabs'
+import type { ComponentProps, PropsWithChildren } from 'react'
+
+type TabsProps = PropsWithChildren<FumadocsTabsProps>
+
+export const Tabs = ({ children, ...props }: TabsProps) => {
+  return (
+    <Primitive.Tabs {...props} defaultValue={props.items?.[0]}>
+      <Primitive.TabsList className="bg-fd-muted">
+        {props.items?.map((item) => (
+          <Primitive.TabsTrigger key={item} value={item}>
+            {item}
+          </Primitive.TabsTrigger>
+        ))}
+      </Primitive.TabsList>
+      {children}
+    </Primitive.Tabs>
+  )
+}
+
+type TabProps = PropsWithChildren<ComponentProps<typeof Primitive.TabsContent>>
+
+export const Tab = ({ children, ...props }: TabProps) => {
+  return <Primitive.TabsContent {...props}>{children}</Primitive.TabsContent>
+}

--- a/frontend/apps/docs/components/Tabs/index.ts
+++ b/frontend/apps/docs/components/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './Tabs'

--- a/frontend/apps/docs/components/index.ts
+++ b/frontend/apps/docs/components/index.ts
@@ -1,1 +1,2 @@
 export * from './LiamLogo'
+export * from './Tabs'

--- a/frontend/apps/docs/content/docs/debug.mdx
+++ b/frontend/apps/docs/content/docs/debug.mdx
@@ -5,7 +5,7 @@ title: (debug) All components
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { File, Folder, Files } from "fumadocs-ui/components/files";
 import { Step, Steps } from "fumadocs-ui/components/steps";
-import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Tab, Tabs } from "@/components";
 import { TypeTable } from "fumadocs-ui/components/type-table";
 
 # Heading


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

To change the background color of TabsList, I used original Tabs/Tab components instead of the ones from fumadocs-ui/components/tabs.


| Before | After |
|--------|--------|
| ![スクリーンショット 2025-01-16 18 17 23](https://github.com/user-attachments/assets/f5370529-2a1d-4f42-982c-ade47d7c1a53) | ![スクリーンショット 2025-01-16 18 17 05](https://github.com/user-attachments/assets/8f0d4893-dde5-4ef8-8c97-ae1e06856d23) | 

## Other Information
<!-- Add any other relevant information for the reviewer. -->

- [Tabs - Fumadocs](https://fumadocs.vercel.app/docs/ui/components/tabs#advanced)