### PR TITLE
✨ Add Callout component

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2,7 +2,7 @@
 
 
 ## Summary
-* 990 MIT
+* 991 MIT
 * 77 Apache 2.0
 * 61 ISC
 * 27 Simplified BSD
@@ -11789,6 +11789,17 @@ Unknown manually approved
 
 <a name="tailwind-merge"></a>
 ### tailwind-merge v2.5.5
+#### 
+
+##### Paths
+* /home/runner/work/liam/liam
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
+<a name="tailwind-variants"></a>
+### tailwind-variants v0.3.0
 #### 
 
 ##### Paths

--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { Tab, Tabs } from '@/components'
+import { Callout, Tab, Tabs } from '@/components'
 import { source } from '@/lib/source'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import {
@@ -37,6 +37,7 @@ export default async function Page(props: {
             ...defaultMdxComponents,
             Tabs,
             Tab,
+            Callout,
           }}
         />
       </DocsBody>

--- a/frontend/apps/docs/app/global.css
+++ b/frontend/apps/docs/app/global.css
@@ -39,6 +39,11 @@
 
   /* Color Semantics */
   :root {
+    --primary-background: hsl(149 85% 52% / 0.05);
+    --warn: 37 95% 53%;
+    --danger: 2 92% 63%;
+
+    /* Overrides for Fumadocs */
     --fd-background: 0 0% 98%;
     --fd-foreground: var(--liam-gray-1000);
     --fd-muted: var(--liam-gray-5);
@@ -61,6 +66,10 @@
   }
 
   .dark {
+    --primary-background: hsl(149 85% 52% / 0.1);
+    --warn: 47 100% 64%;
+
+    /* Overrides for Fumadocs */
     --fd-background: var(--liam-gray-1100);
     --fd-foreground: var(--liam-gray-0);
     --fd-muted: var(--liam-gray-900);

--- a/frontend/apps/docs/components/Callout/Callout.tsx
+++ b/frontend/apps/docs/components/Callout/Callout.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { AlertTriangle, Info, XCircle } from '@liam-hq/ui'
+import type { FC, PropsWithChildren } from 'react'
+import { tv } from 'tailwind-variants'
+import { match } from 'ts-pattern'
+
+type Props = PropsWithChildren & {
+  type?: 'info' | 'warn' | 'error'
+  title: string
+}
+
+export const Callout: FC<Props> = ({ type = 'info', title, children }) => {
+  const icon = match(type)
+    .with('info', () => <Info className="w-5 h-5 text-fd-primary" />)
+    .with('warn', () => <AlertTriangle className="w-5 h-5 text-warn" />)
+    .with('error', () => <XCircle className="w-5 h-5 text-danger" />)
+    .exhaustive()
+
+  const wrapper = tv({
+    base: 'my-6 p-4 flex items-start gap-2 rounded-lg border',
+    variants: {
+      type: {
+        info: 'border-fd-primary/20 bg-primary-background',
+        warn: 'border-warn/20 bg-warn/10',
+        error: 'border-danger/20 bg-danger/10',
+      },
+    },
+  })
+
+  return (
+    <div className={wrapper({ type })}>
+      {icon}
+      <div className="grid gap-2">
+        <span className="text-fd-card-foreground text-sm font-medium leading-5">
+          {title}
+        </span>
+        <p className="text-fd-muted-foreground text-sm leading-5 m-0">
+          {children}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/docs/components/Callout/index.ts
+++ b/frontend/apps/docs/components/Callout/index.ts
@@ -1,0 +1,1 @@
+export * from './Callout'

--- a/frontend/apps/docs/components/index.ts
+++ b/frontend/apps/docs/components/index.ts
@@ -1,2 +1,3 @@
+export * from './Callout'
 export * from './LiamLogo'
 export * from './Tabs'

--- a/frontend/apps/docs/package.json
+++ b/frontend/apps/docs/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
+    "@liam-hq/ui": "workspace:*",
     "fumadocs-core": "14.5.4",
     "fumadocs-docgen": "1.3.2",
     "fumadocs-mdx": "11.1.2",
@@ -10,7 +11,9 @@
     "lucide-react": "0.451.0",
     "next": "15.1.2",
     "react": "18.3.1",
-    "react-dom": "18"
+    "react-dom": "18",
+    "tailwind-variants": "0.3.0",
+    "ts-pattern": "5.4.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.3",

--- a/frontend/apps/docs/tailwind.config.js
+++ b/frontend/apps/docs/tailwind.config.js
@@ -16,6 +16,11 @@ const config = {
   ],
   theme: {
     extend: {
+      colors: {
+        'primary-background': 'var(--primary-background)',
+        warn: 'hsl(var(--warn) / <alpha-value>)',
+        danger: 'hsl(var(--danger) / <alpha-value>)',
+      },
       typography: {
         DEFAULT: {
           css: {

--- a/frontend/packages/ui/src/icons/index.ts
+++ b/frontend/packages/ui/src/icons/index.ts
@@ -25,4 +25,11 @@ export * from './CardinalityZeroOrOneLeftIcon'
 export * from './Eye'
 export * from './EyeClosed'
 
-export { KeyRound, Hash, Link } from 'lucide-react'
+export {
+  KeyRound,
+  Hash,
+  Link,
+  AlertTriangle,
+  Info,
+  XCircle,
+} from 'lucide-react'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   frontend/apps/docs:
     dependencies:
+      '@liam-hq/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       fumadocs-core:
         specifier: 14.5.4
         version: 14.5.4(@types/react@18.3.12)(next@15.1.2(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -47,6 +50,12 @@ importers:
       react-dom:
         specifier: '18'
         version: 18.3.1(react@18.3.1)
+      tailwind-variants:
+        specifier: 0.3.0
+        version: 0.3.0(tailwindcss@3.4.15(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.2)))
+      ts-pattern:
+        specifier: 5.4.0
+        version: 5.4.0
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.3
@@ -6128,6 +6137,12 @@ packages:
 
   tailwind-merge@2.5.5:
     resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
+
+  tailwind-variants@0.3.0:
+    resolution: {integrity: sha512-ho2k5kn+LB1fT5XdNS3Clb96zieWxbStE9wNLK7D0AV64kdZMaYzAKo0fWl6fXLPY99ffF9oBJnIj5escEl/8A==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwindcss: '*'
 
   tailwindcss@3.4.15:
     resolution: {integrity: sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==}
@@ -13844,6 +13859,11 @@ snapshots:
       - typescript
 
   tailwind-merge@2.5.5: {}
+
+  tailwind-variants@0.3.0(tailwindcss@3.4.15(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.2))):
+    dependencies:
+      tailwind-merge: 2.5.5
+      tailwindcss: 3.4.15(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.2))
 
   tailwindcss@3.4.15(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.2)):
     dependencies:


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I added a Callout component for use in MDX documents.

<img width="483" alt="image" src="https://github.com/user-attachments/assets/92d509dc-cf69-4114-adea-f45a14eced85" />

## Changes
<!-- List the main changes made in this PR. -->

* [➕ add ts-pattern, tailwind-variants, @liam-hq/ui](https://github.com/liam-hq/liam/pull/483/commits/129673264f49f9fd22170a1cdbae0122550cfbfc)
  * I added the necessary dependencies to implement the Callout component.
* [💄 Enhance Tailwind CSS configuration with new color variables.](https://github.com/liam-hq/liam/pull/483/commits/8d7aa8a939e9438c893dcf3a332887c8ed54a417)
  * I added the necessary color definitions to implement the Callout component.
* [✨ Add Callout component](https://github.com/liam-hq/liam/pull/483/commits/4b280bfef1dc67d3e58ec6ea65c25157a18debf5)
  * I implemented the Callout component.
  * I made sure the component's props match those provided by the Fumadocs Callout component.

## References

- [Callout | Fumadocs](https://fumadocs.vercel.app/docs/ui/mdx/callout)