### PR TITLE
✨ Introduce Heading component

### DIFF
--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { Callout, Tab, Tabs } from '@/components'
+import { Callout, Heading, Tab, Tabs } from '@/components'
 import { source } from '@/lib/source'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import {
@@ -38,6 +38,12 @@ export default async function Page(props: {
             Tabs,
             Tab,
             Callout,
+            h1: (props) => <Heading as="h1" {...props} />,
+            h2: (props) => <Heading as="h2" {...props} />,
+            h3: (props) => <Heading as="h3" {...props} />,
+            h4: (props) => <Heading as="h4" {...props} />,
+            h5: (props) => <Heading as="h5" {...props} />,
+            h6: (props) => <Heading as="h6" {...props} />,
           }}
         />
       </DocsBody>

--- a/frontend/apps/docs/biome.jsonc
+++ b/frontend/apps/docs/biome.jsonc
@@ -6,7 +6,9 @@
         "noRestrictedImports": {
           "options": {
             "paths": {
-              "fumadocs-ui/components/tabs": "Use '@/components' instead."
+              "fumadocs-ui/components/tabs": "Use '@/components' instead.",
+              "fumadocs-ui/components/callout": "Use '@/components' instead.",
+              "fumadocs-ui/components/heading": "Use '@/components' instead."
             }
           }
         }

--- a/frontend/apps/docs/components/Heading/Heading.tsx
+++ b/frontend/apps/docs/components/Heading/Heading.tsx
@@ -1,0 +1,23 @@
+// biome-ignore lint/nursery/noRestrictedImports: Make original Heading component
+import { Heading as FumadocsHeading } from 'fumadocs-ui/components/heading'
+import type { ComponentProps, FC } from 'react'
+import { tv } from 'tailwind-variants'
+
+type Props = ComponentProps<typeof FumadocsHeading>
+
+export const Heading: FC<Props> = ({ as, ...props }) => {
+  const wrapper = tv({
+    variants: {
+      as: {
+        h1: 'text-3xl',
+        h2: 'text-2xl',
+        h3: 'text-xl',
+        h4: 'text-base',
+        h5: 'text-sm',
+        h6: 'text-xs',
+      },
+    },
+  })
+
+  return <FumadocsHeading {...props} as={as} className={wrapper({ as })} />
+}

--- a/frontend/apps/docs/components/Heading/index.ts
+++ b/frontend/apps/docs/components/Heading/index.ts
@@ -1,0 +1,1 @@
+export * from './Heading'

--- a/frontend/apps/docs/components/index.ts
+++ b/frontend/apps/docs/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Callout'
+export * from './Heading'
 export * from './LiamLogo'
 export * from './Tabs'

--- a/frontend/apps/docs/content/docs/debug.mdx
+++ b/frontend/apps/docs/content/docs/debug.mdx
@@ -8,13 +8,18 @@ import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Tab, Tabs } from "@/components";
 import { TypeTable } from "fumadocs-ui/components/type-table";
 
-# Heading
+# Heading 1
 
-## Heading
+## Heading 2
 
-### Heading
+### Heading 3
 
-#### Heading
+#### Heading 4
+
+##### Heading 5
+
+###### Heading 6
+
 
 Hello World, **Bold**, _Italic_, ~~Hidden~~
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I created an original Heading component with adjustable font sizes from the Heading provided by Fumadocs.

| light | dark |
|--------|--------|
| <img width="604" alt="スクリーンショット 2025-01-17 14 42 43" src="https://github.com/user-attachments/assets/315d585e-25b2-4b2c-a4d7-2e2257c0ceae" /> | <img width="602" alt="スクリーンショット 2025-01-17 14 42 51" src="https://github.com/user-attachments/assets/7dc84d37-52cb-458c-91e1-6430feb0bf00" /> | 

## Other Information
<!-- Add any other relevant information for the reviewer. -->

- [Heading | Fumadocs](https://fumadocs.vercel.app/docs/ui/mdx/heading)