### PR TITLE
Add permissions to the GitHub Actions workflows

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,6 +12,9 @@ jobs:
   setup-job:
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has-changes: ${{ steps.changes.outputs.has-changes }}
     steps:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -23,6 +23,8 @@ jobs:
     timeout-minutes: 10
     env:
       LICENSE_REPORT: docs/packages-license.md
+    permissions:
+      contents: write
     steps:
       - name: Check if running in a fork
         id: fork-check

--- a/.github/workflows/vercel-deploy-erd.yml
+++ b/.github/workflows/vercel-deploy-erd.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   setup-deployment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       environment: ${{ steps.environment.outputs.environment }}
       has-changes: ${{ steps.changes.outputs.src }}
@@ -55,6 +58,9 @@ jobs:
     environment:
       name: "${{ needs.setup-deployment.outputs.environment }} - ${{ matrix.apps.name }}"
       url: ${{ steps.deployment.outputs.deployment-url }}
+    permissions:
+      contents: read
+      deployments: write
     outputs:
       app-name: ${{ matrix.apps.name }}
       url: ${{ steps.deployment.outputs.deployment-url }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   setup-deployment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       environment: ${{ steps.environment.outputs.environment }}
       has-changes: ${{ steps.changes.outputs.src }}
@@ -48,6 +51,9 @@ jobs:
     environment:
       name: "${{ needs.setup-deployment.outputs.environment }} - ${{ matrix.apps.name }}"
       url: ${{ steps.deployment.outputs.deployment-url }}
+    permissions:
+      contents: read
+      deployments: write
     outputs:
       app-name: ${{ matrix.apps.name }}
       url: ${{ steps.deployment.outputs.deployment-url }}


### PR DESCRIPTION
I have already changed the `GITHUB_TOKEN` permissions to read-only at the organizational level. This follows the [Principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).

In this pull request, I will make changes to workflows that should clearly be granted permissions.

Since all the tests in this pull request have passed, I think it is ok. If permissions-related problems occur in the future, we can deal with them on a case-by-case basis.
