### PR TITLE
✨ Add Breadcrumb component for original style

### DIFF
--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { Callout, Heading, Tab, Tabs } from '@/components'
+import { Breadcrumb, Callout, Heading, Tab, Tabs } from '@/components'
 import { source } from '@/lib/source'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import {
@@ -27,6 +27,10 @@ export default async function Page(props: {
         repo: 'liam',
         sha: 'main',
         path: `frontend/apps/docs/content/docs/${page.file.path}`,
+      }}
+      breadcrumb={{
+        enabled: true,
+        component: <Breadcrumb tree={source.pageTree} />,
       }}
     >
       <DocsTitle>{page.data.title}</DocsTitle>

--- a/frontend/apps/docs/components/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/apps/docs/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useBreadcrumb } from 'fumadocs-core/breadcrumb'
+import type { PageTree } from 'fumadocs-core/server'
+import { ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { type FC, Fragment } from 'react'
+import { tv } from 'tailwind-variants'
+
+export const Breadcrumb: FC<{ tree: PageTree.Root }> = ({ tree }) => {
+  const pathname = usePathname()
+  const items = useBreadcrumb(pathname, tree)
+
+  const textStyle = tv({
+    base: 'truncate text-base text-fd-muted-foreground font-normal',
+  })
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="-mb-3 flex flex-row items-center gap-1 text-sm font-medium text-fd-muted-foreground">
+      {items.map((item, i) => (
+        <Fragment key={item.url}>
+          {i !== 0 && (
+            <ChevronRight className="size-4 shrink-0 rtl:rotate-180" />
+          )}
+          {item.url ? (
+            <Link href={item.url} className={textStyle()}>
+              {item.name}
+            </Link>
+          ) : (
+            <span className={textStyle()}>{item.name}</span>
+          )}
+        </Fragment>
+      ))}
+    </div>
+  )
+}

--- a/frontend/apps/docs/components/Breadcrumb/index.ts
+++ b/frontend/apps/docs/components/Breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumb'

--- a/frontend/apps/docs/components/index.ts
+++ b/frontend/apps/docs/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Breadcrumb'
 export * from './Callout'
 export * from './Heading'
 export * from './LiamLogo'


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I created an original Breadcrumb component with adjustable font size, weights and color, and replaced the default breadcrumb used within Fumadocs with it.

| light | dark |
|--------|--------|
| <img width="603" alt="スクリーンショット 2025-01-17 14 50 01" src="https://github.com/user-attachments/assets/66e3d3ee-0087-42f6-84e1-3cf028466846" /> | <img width="601" alt="スクリーンショット 2025-01-17 14 49 54" src="https://github.com/user-attachments/assets/1dc36288-3d8b-4b8d-84a3-d639dcc69d7d" /> | 


## Other Information
<!-- Add any other relevant information for the reviewer. -->

- [Page#Breadcrumb | Fumadocs](https://fumadocs.vercel.app/docs/ui/layouts/page#breadcrumb)
