### PR TITLE
✨ Add FooterNavi component for original style

### DIFF
--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -37,7 +37,7 @@ export default async function Page(props: {
       }}
       breadcrumb={{
         enabled: true,
-        component: <Breadcrumb tree={source.pageTree} />,
+        component: <Breadcrumb />,
       }}
       footer={{
         enabled: true,

--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,11 @@
-import { Breadcrumb, Callout, Heading, Tab, Tabs } from '@/components'
+import {
+  Breadcrumb,
+  Callout,
+  FooterNavi,
+  Heading,
+  Tab,
+  Tabs,
+} from '@/components'
 import { source } from '@/lib/source'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import {
@@ -31,6 +38,10 @@ export default async function Page(props: {
       breadcrumb={{
         enabled: true,
         component: <Breadcrumb tree={source.pageTree} />,
+      }}
+      footer={{
+        enabled: true,
+        component: <FooterNavi />,
       }}
     >
       <DocsTitle>{page.data.title}</DocsTitle>

--- a/frontend/apps/docs/components/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/apps/docs/components/Breadcrumb/Breadcrumb.tsx
@@ -1,16 +1,16 @@
 'use client'
 
+import { source } from '@/lib/source'
 import { useBreadcrumb } from 'fumadocs-core/breadcrumb'
-import type { PageTree } from 'fumadocs-core/server'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { type FC, Fragment } from 'react'
 import { tv } from 'tailwind-variants'
 
-export const Breadcrumb: FC<{ tree: PageTree.Root }> = ({ tree }) => {
+export const Breadcrumb: FC = () => {
   const pathname = usePathname()
-  const items = useBreadcrumb(pathname, tree)
+  const items = useBreadcrumb(pathname, source.pageTree)
 
   const textStyle = tv({
     base: 'truncate text-base text-fd-muted-foreground font-normal',

--- a/frontend/apps/docs/components/FooterNavi/FooterNavi.tsx
+++ b/frontend/apps/docs/components/FooterNavi/FooterNavi.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { source } from '@/lib/source'
+import { findNeighbour } from 'fumadocs-core/server'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { FC } from 'react'
+import { tv } from 'tailwind-variants'
+
+export const FooterNavi: FC = () => {
+  const pathname = usePathname()
+  const neighbours = findNeighbour(source.pageTree, pathname)
+
+  const linkStyle = tv({
+    base: 'flex w-full flex-col gap-2 rounded-lg border bg-fd-card p-4 text-sm transition-colors hover:text-fd-primary hover:bg-transparent hover:border-fd-primary',
+    variants: {
+      direction: {
+        previous: '',
+        next: 'col-start-2 text-end',
+      },
+    },
+  })
+
+  const itemLabelStyle = tv({
+    base: 'inline-flex items-center gap-0.5 text-fd-muted-foreground',
+    variants: {
+      direction: {
+        previous: '',
+        next: 'flex-row-reverse',
+      },
+    },
+  })
+
+  return (
+    <div className="grid grid-cols-2 gap-4 pb-6">
+      {neighbours.previous && (
+        <Link href={neighbours.previous.url} className={linkStyle()}>
+          <div className={itemLabelStyle()}>
+            <ChevronLeft className="-ms-1 size-4 shrink-0 rtl:rotate-180" />
+            <p>Previous</p>
+          </div>
+          <p>{neighbours.previous.name}</p>
+        </Link>
+      )}
+      {neighbours.next && (
+        <Link
+          href={neighbours.next.url}
+          className={linkStyle({ direction: 'next' })}
+        >
+          <div className={itemLabelStyle({ direction: 'next' })}>
+            <ChevronRight className="-me-1 size-4 shrink-0 rtl:rotate-180" />
+            <p>Next</p>
+          </div>
+          <p>{neighbours.next.name}</p>
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/frontend/apps/docs/components/FooterNavi/index.ts
+++ b/frontend/apps/docs/components/FooterNavi/index.ts
@@ -1,0 +1,1 @@
+export * from './FooterNavi'

--- a/frontend/apps/docs/components/index.ts
+++ b/frontend/apps/docs/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Breadcrumb'
 export * from './Callout'
 export * from './Heading'
+export * from './FooterNavi'
 export * from './LiamLogo'
 export * from './Tabs'


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I created an original FooterNavi component with adjusted hover colors, and replaced the default footer used within Fumadocs with it.

| light | dark |
|--------|--------|
| <img width="863" alt="スクリーンショット 2025-01-17 15 34 53" src="https://github.com/user-attachments/assets/67e210e5-71c7-4d0d-8714-e7031971105a" /> | <img width="864" alt="スクリーンショット 2025-01-17 15 34 37" src="https://github.com/user-attachments/assets/776c2a92-aaeb-4b48-bd60-a34237475cef" /> | 


## Other Information
<!-- Add any other relevant information for the reviewer. -->

- [Page#Footer | Fumadocs](https://fumadocs.vercel.app/docs/ui/layouts/page#footer)
