### PR TITLE
🔧 Update Next.js configuration to exclude '@prisma/internals'

### DIFF
--- a/frontend/apps/erd-web/next.config.ts
+++ b/frontend/apps/erd-web/next.config.ts
@@ -35,6 +35,17 @@ const nextConfig: NextConfig = {
       config.externals['@prisma/schema-files-loader'] =
         '@prisma/schema-files-loader'
     }
+    config.plugins.push({
+      // biome-ignore lint/suspicious/noExplicitAny: webpack types are incomplete so we need to use any here
+      apply: (compiler: any) => {
+        compiler.hooks.afterEmit.tap('InstallPrismaInternals', () => {
+          execSync('node scripts/install-prisma-internals.mjs', {
+            stdio: 'inherit',
+            cwd: __dirname,
+          })
+        })
+      },
+    })
 
     return config
   },

--- a/frontend/apps/erd-web/next.config.ts
+++ b/frontend/apps/erd-web/next.config.ts
@@ -6,13 +6,36 @@ const gitCommitHash = execSync('git rev-parse --short HEAD').toString().trim()
 const releaseDate = new Date().toISOString().split('T')[0]
 
 const nextConfig: NextConfig = {
-  // NOTE: Exclude '@prisma/internals' from the client-side bundle
-  // This module is server-side only and should not be included in the client build
+  // NOTE: Exclude Prisma-related packages from the bundle
+  // These packages are installed separately in the node_modules/@prisma directory
+  // Excluding them prevents `Error: Cannot find module 'fs'` errors in the build process
   webpack: (config) => {
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      '@prisma/internals': false,
+    if (Array.isArray(config.externals)) {
+      config.externals.push(
+        '@prisma/debug',
+        '@prisma/engines',
+        '@prisma/engines-version',
+        '@prisma/fetch-engine',
+        '@prisma/generator-helper',
+        '@prisma/get-platform',
+        '@prisma/internals',
+        '@prisma/prisma-schema-wasm',
+        '@prisma/schema-files-loader',
+      )
+    } else {
+      config.externals['@prisma/debug'] = '@prisma/debug'
+      config.externals['@prisma/engines'] = '@prisma/engines'
+      config.externals['@prisma/engines-version'] = '@prisma/engines-version'
+      config.externals['@prisma/fetch-engine'] = '@prisma/fetch-engine'
+      config.externals['@prisma/generator-helper'] = '@prisma/generator-helper'
+      config.externals['@prisma/get-platform'] = '@prisma/get-platform'
+      config.externals['@prisma/internals'] = '@prisma/internals'
+      config.externals['@prisma/prisma-schema-wasm'] =
+        '@prisma/prisma-schema-wasm'
+      config.externals['@prisma/schema-files-loader'] =
+        '@prisma/schema-files-loader'
     }
+
     return config
   },
   outputFileTracingIncludes: {

--- a/frontend/apps/erd-web/scripts/install-prisma-internals.mjs
+++ b/frontend/apps/erd-web/scripts/install-prisma-internals.mjs
@@ -1,0 +1,34 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const main = () => {
+  const dotNextPath = path.resolve(__dirname, '../.next')
+  const nodeModulesPath = path.join(dotNextPath, 'node_modules')
+
+  if (!fs.existsSync(dotNextPath)) {
+    fs.mkdirSync(dotNextPath, { recursive: true })
+  }
+  if (!fs.existsSync(nodeModulesPath)) {
+    fs.mkdirSync(nodeModulesPath, { recursive: true })
+  }
+
+  process.chdir(nodeModulesPath)
+
+  execSync('npm install @prisma/internals', { stdio: 'inherit' })
+
+  const packageJsonPath = path.join(nodeModulesPath, 'package.json')
+  const packageLockJsonPath = path.join(nodeModulesPath, '.package-lock.json')
+  if (fs.existsSync(packageJsonPath)) {
+    fs.unlinkSync(packageJsonPath)
+  }
+  if (fs.existsSync(packageLockJsonPath)) {
+    fs.unlinkSync(packageLockJsonPath)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Exclude `@prisma/internals` from the bundle
to prevent `Error: Cannot find module 'fs'` errors in the build process.

✅ schema.rb
https://liam-erd-2e02911f4-route-06-core.vercel.app/erd/p/github.com/mastodon/mastodon/blob/main/db/schema.rb

✅ sql
https://liam-erd-2e02911f4-route-06-core.vercel.app/erd/p/github.com/ekylibre/ekylibre/blob/main/db/structure.sql

✅ Prisma 🎉
https://liam-erd-2e02911f4-route-06-core.vercel.app/erd/p/github.com/langfuse/langfuse/blob/main/packages/shared/prisma/schema.prisma

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
