### PR TITLE
🐛 Update `erd build` to exit with status 1 if there is at least one error

### DIFF
--- a/.changeset/fast-penguins-call.md
+++ b/.changeset/fast-penguins-call.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": patch
+---
+
+🐛 Update `erd build` to exit with status 1 if there is at least one error

--- a/frontend/packages/cli/src/cli/actionRunner.ts
+++ b/frontend/packages/cli/src/cli/actionRunner.ts
@@ -24,9 +24,10 @@ export function actionRunner<T>(fn: (args: T) => Promise<Error[]>) {
     if (errors.length > 0) {
       errors.forEach(actionErrorHandler)
       printTroubleshootingUrl()
-    }
 
-    if (errors.some((error) => error instanceof CriticalError)) {
+      // Currently, to align with the behavior of `buildCommand`, the process exits with status 1 if there is at least one error.
+      // In the future, we want to allow dist to be generated and the process to complete successfully with a warning message, even if there are minor errors.
+      // In that case, the process should exit with status 1 only if there is at least one `CriticalError`.
       process.exit(1)
     }
   }

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -20,6 +20,8 @@ export const buildCommand = async (
     format,
   )
   if (preprocessErrors.length > 0) {
+    // In the future, we want to allow dist to be generated and the process to complete successfully with a warning message, even if there are minor errors.
+    // see also: actionRunner.ts
     return preprocessErrors
   }
 


### PR DESCRIPTION
- Updated `actionRunner` to exit with status 1 if there is at least one error, matching the behavior of `buildCommand`.
- Added a comment explaining the future plan to allow successful execution with warnings for minor errors.
- Clarified that in the future, only `CriticalError` should trigger an exit with status 1.

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

#### before

```
[liam]$ npx @liam-hq/cli@latest erd build --input https://raw.githubusercontent.com/metabase/metabase/fe13ca685912aa3cde89a7a7e8c0d4698cf9d060/resources/migrations/initialization/metabase_mysql.sql --format postgres
Need to install the following packages:
@liam-hq/cli@0.0.24
Ok to proceed? (y) y

WARN: Error during parsing schema file: syntax error at or near "="
WARN: Error during parsing schema file: syntax error at or near "`"
[liam]$ echo $?
0
```

#### after

```
[cli]$ node dist-cli/bin/cli.js erd build --input https://raw.githubusercontent.com/metabase/metabase/fe13ca685912aa3cde89a7a7e8c0d4698cf9d060/resources/migrations/initialization/metabase_mysql.sql --format postgres
WARN: Error during parsing schema file: syntax error at or near "="
WARN: Error during parsing schema file: syntax error at or near "`"
For more information, see https://liambx.com/docs/parser/troubleshooting
[cli]$ echo $?
1
```


## Other Information
<!-- Add any other relevant information for the reviewer. -->
