### PR TITLE
✨ Add Banner component to layout for Liam ERD launch announcement

### DIFF
--- a/frontend/apps/docs/app/layout.tsx
+++ b/frontend/apps/docs/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Banner } from '@/components'
 import './global.css'
 import { RootProvider } from 'fumadocs-ui/provider'
 import { Inter } from 'next/font/google'
@@ -18,6 +19,13 @@ export default function Layout({ children }: { children: ReactNode }) {
             },
           }}
         >
+          <Banner
+            id="liam-erd-introduction"
+            variant="dark"
+            link="https://liambx.com/blog/liam-erd-introduction"
+          >
+            {"We're launched Liam ERD!"}
+          </Banner>
           {children}
         </RootProvider>
       </body>


### PR DESCRIPTION
- related: https://github.com/liam-hq/liam/pull/500

Add Banner with blog link 👾

<img width="1825" alt="スクリーンショット 2025-01-21 12 00 18" src="https://github.com/user-attachments/assets/9eaa8814-f093-43e0-9b7d-bd0d804d4214" />


ref: https://liam-docs-7bl6utmtf-route-06-core.vercel.app/docs