### PR TITLE
✨️  Support parsing default values in Prisma schema 

### DIFF
--- a/.changeset/proud-cycles-train.md
+++ b/.changeset/proud-cycles-train.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+✨️ feat(db-structure): support parsing default values in Prisma schema

--- a/frontend/packages/db-structure/package.json
+++ b/frontend/packages/db-structure/package.json
@@ -18,6 +18,7 @@
     "@biomejs/biome": "1.9.3",
     "@liam-hq/configs": "workspace:*",
     "@pgsql/types": "15.0.2",
+    "@prisma/generator-helper": "6.2.1",
     "typescript": "5",
     "vitest": "2.1.4"
   },

--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -70,6 +70,72 @@ describe(processor, () => {
       expect(value).toEqual(expected)
     })
 
+    it('default value as string', async () => {
+      const { value } = await processor(`
+        model users {
+          id   Int    @id @default(autoincrement())
+          description String @default("user's description")
+        }
+      `)
+
+      const expected = userTable({
+        columns: {
+          description: aColumn({
+            name: 'description',
+            type: 'String',
+            default: "user's description",
+            notNull: true,
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
+
+    it('default value as integer', async () => {
+      const { value } = await processor(`
+        model users {
+          id   Int    @id @default(autoincrement())
+          age  Int    @default(30)
+        }
+      `)
+
+      const expected = userTable({
+        columns: {
+          age: aColumn({
+            name: 'age',
+            type: 'Int',
+            default: 30,
+            notNull: true,
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
+
+    it('default value as boolean', async () => {
+      const { value } = await processor(`
+        model users {
+          id     Int     @id @default(autoincrement())
+          active Boolean @default(true)
+        }
+      `)
+
+      const expected = userTable({
+        columns: {
+          active: aColumn({
+            name: 'active',
+            type: 'Boolean',
+            default: true,
+            notNull: true,
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
+
     it('relationship', async () => {
       const { value } = await processor(`
         model users {

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -73,12 +73,15 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
 function extractDefaultValue(field: DMMF.Field) {
   const value = field.default?.valueOf()
   const defaultValue = value === undefined ? null : value
-  // NOTE: When `@default(autoincrement())` is specified, defaultValue becomes
-  // an object in the form of `{"name":"autoincrement","args":[]}`.
-  // For now, to align with other parsers, return null if the value is an object.
-  return typeof defaultValue === 'object' && defaultValue !== null
-    ? null
-    : defaultValue
+  // NOTE: For example, when `@default(autoincrement())` is specified, `defaultValue`
+  // becomes an object like `{"name":"autoincrement","args":[]}` (DMMF.FieldDefault).
+  // Currently, to maintain consistency with other parsers, only primitive types
+  // (DMMF.FieldDefaultScalar as `string | number | boolean`) are accepted.
+  return typeof defaultValue === 'string' ||
+    typeof defaultValue === 'number' ||
+    typeof defaultValue === 'boolean'
+    ? defaultValue
+    : null
 }
 
 export const processor: Processor = (str) => parsePrismaSchema(str)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       '@pgsql/types':
         specifier: 15.0.2
         version: 15.0.2
+      '@prisma/generator-helper':
+        specifier: 6.2.1
+        version: 6.2.1
       typescript:
         specifier: '5'
         version: 5.6.2


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->


Support parsing default values in Prisma schema
- Added `@prisma/generator-helper` as a dependency.
    - for  `extractDefaultValue` return-type 
- Implemented `extractDefaultValue` function to correctly parse default values in Prisma models.
- Added test cases for parsing default values of type `String`, `Int`, and `Boolean`.


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

- erd-web works 
     - preview: https://liam-erd-8a8524u0h-route-06-core.vercel.app/erd/p/github.com/langfuse/langfuse/blob/cf29c6b7e447cf1aec7a8d50ae6a877c3844b7cd/packages/shared/prisma/schema.prisma

## Other Information
<!-- Add any other relevant information for the reviewer. -->
