### PR TITLE
📝 Add prisma schema header to tests for improved parsing validation

### DIFF
--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -27,9 +27,22 @@ describe(processor, () => {
       },
     })
 
+  const prismaSchemaHeader = `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "postgresql"
+      url = env("DATABASE_URL")
+    }
+  `
+
   describe('should parse prisma schema correctly', () => {
     it('not null', async () => {
       const { value } = await processor(`
+        ${prismaSchemaHeader}
+
         model users {
           id   Int    @id @default(autoincrement())
           name String
@@ -51,6 +64,8 @@ describe(processor, () => {
 
     it('nullable', async () => {
       const { value } = await processor(`
+        ${prismaSchemaHeader}
+
         model users {
           id   Int    @id @default(autoincrement())
           description String?
@@ -72,6 +87,8 @@ describe(processor, () => {
 
     it('column comment', async () => {
       const { value } = await processor(`
+        ${prismaSchemaHeader}
+
         model users {
           id   Int    @id @default(autoincrement())
           /// this is description
@@ -94,6 +111,8 @@ describe(processor, () => {
 
     it('table comment', async () => {
       const { value } = await processor(`
+        ${prismaSchemaHeader}
+
         /// store our users.
         model users {
           id   Int    @id @default(autoincrement())
@@ -109,6 +128,8 @@ describe(processor, () => {
 
     it('relationship (one-to-many)', async () => {
       const { value } = await processor(`
+        ${prismaSchemaHeader}
+
         model users {
           id   Int    @id @default(autoincrement())
           posts posts[]
@@ -139,6 +160,8 @@ describe(processor, () => {
 
     it('relationship (one-to-one)', async () => {
       const { value } = await processor(`
+        ${prismaSchemaHeader}
+
         model users {
           id   Int    @id @default(autoincrement())
           post posts?


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

There are several type attributes supported by specific db engine such as `@db.BigInt`.
ref: https://www.prisma.io/docs/orm/reference/prisma-schema-reference#model-field-scalar-types

If we use default connector, these attributes will raise validation error:

```ts
GetDmmfError: Prisma schema validation - (get-dmmf wasm)
Error code: P1012
error: Native type BigInt is not supported for Default connector.
  -->  schema.prisma:6
   | 
 5 |         model users {
 6 |           id   BigInt    @id @db.BigInt @default(autoincrement())
   | 
```

So I've added the postgresql provider on each test cases.
ref: https://www.prisma.io/docs/orm/overview/databases/postgresql

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
