### PR TITLE
✨ Add support for table comments in Prisma schema

### DIFF
--- a/.changeset/yellow-rocks-run.md
+++ b/.changeset/yellow-rocks-run.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+✨ Add support for table comments in Prisma schema

--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -92,6 +92,21 @@ describe(processor, () => {
       expect(value).toEqual(expected)
     })
 
+    it('table comment', async () => {
+      const { value } = await processor(`
+        /// store our users.
+        model users {
+          id   Int    @id @default(autoincrement())
+        }
+      `)
+
+      const expected = userTable({
+        comment: 'store our users.',
+      })
+
+      expect(value).toEqual(expected)
+    })
+
     it('relationship', async () => {
       const { value } = await processor(`
         model users {

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -30,7 +30,7 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
     tables[model.name] = {
       name: model.name,
       columns,
-      comment: null,
+      comment: model.documentation ?? null,
       indices: {},
     }
   }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Add support for table comments in Prisma schema.

> [!NOTE]
>Prisma does not yet support table and column comments.
> - https://github.com/prisma/prisma/issues/8703
>I mean, Prisma comment feature is only attached within the AST and is not applied to user database.
> ```js
> /// This comment will get attached to the `User` node in the AST
> model User {
>   /// This comment will get attached to the `id` node in the AST
>   id     Int   @default(autoincrement())
>   // This comment is just for you
>   weight Float /// This comment gets attached to the `weight` node
> }
> ```
> https://www.prisma.io/docs/orm/prisma-schema/overview#comments

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
