### PR TITLE
🐛 Change the Rive src attribute to an absolute path.

### DIFF
--- a/frontend/apps/docs/components/Banner/JackAnimationForDark.tsx
+++ b/frontend/apps/docs/components/Banner/JackAnimationForDark.tsx
@@ -4,8 +4,9 @@ import { Fit, Layout, useRive } from '@rive-app/react-canvas'
 import type { FC } from 'react'
 
 const RiveComponent = () => {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3002'
   const { RiveComponent } = useRive({
-    src: '/rivs/jack_animation_for_dark.riv',
+    src: `${baseUrl}/rivs/jack_animation_for_dark.riv`,
     stateMachines: 'State Machine 1',
     layout: new Layout({
       fit: Fit.Cover,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

We're encountering an issue where Mr. Jack is not showing up on https://liambx.com/docs. 

![ss 2731](https://github.com/user-attachments/assets/dec933f6-3712-47f8-89b3-5e518b686cfb)


The problem lies in the riv file, which is currently referencing ``https://liambx.com/rivs`` instead of the correct path ``https://liam-docs-sigma.vercel.app/rivs``. To fix this, I've updated the source to use an absolute path. While I can't verify this until after deployment, I expect that this change will resolve the display issue.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
