### PR TITLE
🐛 fix: exclude model type from columns in Prisma parser 

### DIFF
--- a/.changeset/curvy-bottles-obey.md
+++ b/.changeset/curvy-bottles-obey.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+🐛 fix: exclude model type from columns in Prisma parser

--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -245,5 +245,40 @@ describe(_processor, () => {
 
       expect(value.relationships).toEqual(expected)
     })
+
+    it('columns do not include model type', async () => {
+      const { value } = await processor(`
+        model users {
+          id   Int    @id @default(autoincrement())
+          posts posts[]
+        }
+
+        model posts {
+          id   Int    @id @default(autoincrement())
+          user users @relation(fields: [user_id], references: [id])
+          user_id Int
+        }
+      `)
+
+      // biome-ignore lint/complexity/useLiteralKeys: for readability and simplicity
+      const usersTable = value.tables['users']
+      // biome-ignore lint/complexity/useLiteralKeys: for readability and simplicity
+      const postsTable = value.tables['posts']
+
+      if (!usersTable || !usersTable.columns) {
+        throw new Error('Users table or columns are undefined')
+      }
+      if (!postsTable || !postsTable.columns) {
+        throw new Error('Posts table or columns are undefined')
+      }
+
+      const usersColumnNames = Object.keys(usersTable.columns)
+      const postsColumnNames = Object.keys(postsTable.columns)
+
+      expect(usersColumnNames).toEqual(['id'])
+      expect(usersColumnNames).not.toContain('posts')
+      expect(postsColumnNames).toEqual(['id', 'user_id'])
+      expect(postsColumnNames).not.toContain('user')
+    })
   })
 })

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -13,9 +13,11 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
   const relationships: Record<string, Relationship> = {}
   const errors: Error[] = []
 
+  const modelNames = dmmf.datamodel.models.map((model) => model.name)
   for (const model of dmmf.datamodel.models) {
     const columns: Columns = {}
     for (const field of model.fields) {
+      if (modelNames.includes(field.type)) continue
       const defaultValue = extractDefaultValue(field)
       columns[field.name] = {
         name: field.name,

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -13,11 +13,10 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
   const relationships: Record<string, Relationship> = {}
   const errors: Error[] = []
 
-  const modelNames = dmmf.datamodel.models.map((model) => model.name)
   for (const model of dmmf.datamodel.models) {
     const columns: Columns = {}
     for (const field of model.fields) {
-      if (modelNames.includes(field.type)) continue
+      if (field.relationName) continue
       const defaultValue = extractDefaultValue(field)
       columns[field.name] = {
         name: field.name,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Exclude model type from columns

| before | after |
|--------|--------|
| <img width="635" alt="before" src="https://github.com/user-attachments/assets/b3b78581-449d-4a8b-bce1-513cfd203c2e" />  | <img width="510" alt="after" src="https://github.com/user-attachments/assets/b8b30e49-b944-4a0e-9840-01de2d15aba8" /> |




## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

see preview https://liam-erd-o43orap6s-route-06-core.vercel.app/erd/p/github.com/langfuse/langfuse/blob/cf29c6b7e447cf1aec7a8d50ae6a877c3844b7cd/packages/shared/prisma/schema.prisma


## Other Information
<!-- Add any other relevant information for the reviewer. -->
