### PR TITLE
🐛 Change the Rive src attribute to an absolute path.(light ver)

### DIFF
--- a/frontend/apps/docs/components/Banner/JackAnimationForLight.tsx
+++ b/frontend/apps/docs/components/Banner/JackAnimationForLight.tsx
@@ -4,8 +4,9 @@ import { Fit, Layout, useRive } from '@rive-app/react-canvas'
 import type { FC } from 'react'
 
 const RiveComponent = () => {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3002'
   const { RiveComponent } = useRive({
-    src: '/rivs/jack_animation_for_light.riv',
+    src: `${baseUrl}/rivs/jack_animation_for_light.riv`,
     stateMachines: 'State Machine 1',
     layout: new Layout({
       fit: Fit.Cover,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

We previously encountered an issue where Mr. Jack was not being displayed. This was resolved in pull request #528.
While that PR only addressed **JackAnimationForDark**, we've now made the same fix for **JackAnimationForLight** as well.
（As **JackAnimationForLight** is not currently in use, we are unable to verify its functionality at this time.）

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
