### PR TITLE
✨ Support on delete fk constraint in Prisma parser

### DIFF
--- a/.changeset/perfect-bottles-know.md
+++ b/.changeset/perfect-bottles-know.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+✨ Support on delete fk constraint in Prisma parser

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -1,8 +1,12 @@
 import type { DMMF } from '@prisma/generator-helper'
 import pkg from '@prisma/internals'
-import type { Columns, Relationship, Table } from '../../schema/index.js'
+import type {
+  Columns,
+  ForeignKeyConstraint,
+  Relationship,
+  Table,
+} from '../../schema/index.js'
 import type { ProcessResult, Processor } from '../types.js'
-
 // NOTE: Workaround for CommonJS module import issue with @prisma/internals
 // CommonJS module can not support all module.exports as named exports
 const { getDMMF } = pkg
@@ -57,7 +61,9 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
             foreignColumnName: field.relationFromFields[0] ?? '',
             cardinality: existingRelationship?.cardinality ?? 'ONE_TO_MANY',
             updateConstraint: 'NO_ACTION',
-            deleteConstraint: 'NO_ACTION',
+            deleteConstraint: normalizeConstraintName(
+              field.relationOnDelete ?? '',
+            ),
           } as const)
         : ({
             name: field.relationName,
@@ -95,6 +101,22 @@ function extractDefaultValue(field: DMMF.Field) {
     typeof defaultValue === 'boolean'
     ? defaultValue
     : null
+}
+
+function normalizeConstraintName(constraint: string): ForeignKeyConstraint {
+  // ref: https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/referential-actions
+  switch (constraint) {
+    case 'Cascade':
+      return 'CASCADE'
+    case 'Restrict':
+      return 'RESTRICT'
+    case 'SetNull':
+      return 'SET_NULL'
+    case 'SetDefault':
+      return 'SET_DEFAULT'
+    default:
+      return 'NO_ACTION'
+  }
 }
 
 export const processor: Processor = (str) => parsePrismaSchema(str)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Supported on delete fk constraint in Prisma parser.

Supported `relationOnDelete` only.
`relationOnUpdate` is not supported for now.
It was merged 10 days ago, and will be released `@prisma/generator-helper@6.3.0`.

- https://github.com/prisma/prisma/pull/26074
- https://github.com/prisma/prisma/milestone/144


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
