### PR TITLE
💄 apps/docs: adjust banner styles for better responsiveness

### DIFF
--- a/frontend/apps/docs/components/Banner/Banner.tsx
+++ b/frontend/apps/docs/components/Banner/Banner.tsx
@@ -43,7 +43,7 @@ export const Banner: FC<Props> = ({
   }, [globalKey])
 
   const wrapperStyle = tv({
-    base: 'sticky top-0 z-40 flex h-[var(--fd-banner-height)] items-center justify-center px-4 bg-[url("/images/banner_bg.png")] bg-blend-overlay',
+    base: 'sticky top-0 z-40 flex h-[var(--fd-banner-height)] items-center justify-center px-8 bg-[url("/images/banner_bg.png")] bg-blend-overlay',
     variants: {
       variant: {
         light: 'bg-liam-green-300',
@@ -53,7 +53,7 @@ export const Banner: FC<Props> = ({
   })
 
   const textStyle = tv({
-    base: 'text-sm font-mono font-medium',
+    base: 'text-[10px] sm:text-sm font-mono font-medium overflow-hidden text-overflow-ellipsis line-clamp-2 leading-snug',
     variants: {
       variant: {
         light: 'text-base-black',
@@ -63,7 +63,7 @@ export const Banner: FC<Props> = ({
   })
 
   const linkStyle = tv({
-    base: 'py-0.5 px-2 text-base-black text-xs font-medium font-mono hover:underline',
+    base: 'py-0.5 px-2 text-base-black text-[10px] sm:text-sm font-medium font-mono whitespace-nowrap hover:underline',
     variants: {
       variant: {
         light: 'bg-base-white',
@@ -104,7 +104,7 @@ export const Banner: FC<Props> = ({
           />
         </>
       )}
-      <div className="flex items-center gap-6">
+      <div className="flex items-center gap-4">
         <div className="flex items-center gap-4">
           {match(variant)
             .with('light', () => <JackAnimationForLight />)

--- a/frontend/apps/docs/components/Banner/JackAnimationForDark.tsx
+++ b/frontend/apps/docs/components/Banner/JackAnimationForDark.tsx
@@ -19,7 +19,7 @@ const RiveComponent = () => {
 
 export const JackAnimationForDark: FC = () => {
   return (
-    <div className="w-[20px] h-[20px] sm:w-[1.875rem] sm:h-[1.875rem]">
+    <div className="w-[1.25rem] h-[1.25rem] sm:w-[1.875rem] sm:h-[1.875rem]">
       <RiveComponent />
     </div>
   )

--- a/frontend/apps/docs/components/Banner/JackAnimationForDark.tsx
+++ b/frontend/apps/docs/components/Banner/JackAnimationForDark.tsx
@@ -9,7 +9,7 @@ const RiveComponent = () => {
     src: `${baseUrl}/rivs/jack_animation_for_dark.riv`,
     stateMachines: 'State Machine 1',
     layout: new Layout({
-      fit: Fit.Cover,
+      fit: Fit.Contain,
     }),
     autoplay: true,
   })
@@ -19,7 +19,7 @@ const RiveComponent = () => {
 
 export const JackAnimationForDark: FC = () => {
   return (
-    <div className="w-[1.875rem] h-[1.875rem]">
+    <div className="w-[20px] h-[20px] sm:w-[1.875rem] sm:h-[1.875rem]">
       <RiveComponent />
     </div>
   )

--- a/frontend/apps/docs/components/Banner/JackAnimationForLight.tsx
+++ b/frontend/apps/docs/components/Banner/JackAnimationForLight.tsx
@@ -9,7 +9,7 @@ const RiveComponent = () => {
     src: `${baseUrl}/rivs/jack_animation_for_light.riv`,
     stateMachines: 'State Machine 1',
     layout: new Layout({
-      fit: Fit.Cover,
+      fit: Fit.Contain,
     }),
     autoplay: true,
   })
@@ -19,7 +19,7 @@ const RiveComponent = () => {
 
 export const JackAnimationForLight: FC = () => {
   return (
-    <div className="w-[1.875rem] h-[1.875rem]">
+    <div className="w-[20px] h-[20px] sm:w-[1.875rem] sm:h-[1.875rem]">
       <RiveComponent />
     </div>
   )

--- a/frontend/apps/docs/components/Banner/JackAnimationForLight.tsx
+++ b/frontend/apps/docs/components/Banner/JackAnimationForLight.tsx
@@ -19,7 +19,7 @@ const RiveComponent = () => {
 
 export const JackAnimationForLight: FC = () => {
   return (
-    <div className="w-[20px] h-[20px] sm:w-[1.875rem] sm:h-[1.875rem]">
+    <div className="w-[1.25rem] h-[1.25rem] sm:w-[1.875rem] sm:h-[1.875rem]">
       <RiveComponent />
     </div>
   )


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

preview: https://liam-docs-mwmo3vfzs-route-06-core.vercel.app/docs

💄 apps/docs: adjust banner styles for better responsiveness
    
- Increased padding (`px-4 → px-8`) for improved layout spacing.
- Adjusted font sizes (`text-sm → text-[10px] sm:text-sm`) for better readability on small screens.
- Changed `fit: Cover` to `fit: Contain` in `JackAnimationForLight` and `JackAnimationForDark` to ensure proper scaling.
- Adjusted minimum width and height (`w-[1.875rem] → w-[20px] sm:w-[1.875rem]`) for consistent display across screen sizes.
- Reduced spacing between elements (`gap-6 → gap-4`) for a more compact layout.


375px: 

| when text is short  | when text is long |
|--------|--------|
|  <img width="377" alt="スクリーンショット 2025-01-22 21 04 39" src="https://github.com/user-attachments/assets/5911283c-69be-4b29-ac9e-c4dd4c8355da" /> | <img width="376" alt="スクリーンショット 2025-01-22 21 04 03" src="https://github.com/user-attachments/assets/46a83b79-48aa-4e72-8549-7e3c241d5d8c" /> | 


1024px:

| when text is short  | when text is long |
|--------|--------|
|  <img width="1027" alt="スクリーンショット 2025-01-22 20 56 10" src="https://github.com/user-attachments/assets/4f0c2b71-569c-414f-b63a-f9ec30c449f3" /> |  <img width="1026" alt="スクリーンショット 2025-01-22 20 57 05" src="https://github.com/user-attachments/assets/2b203171-4c48-474c-aecd-1f4ed531c024" /> | 

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
