### PR TITLE
🐛 docs: fix link to supported formats documentation

### DIFF
--- a/frontend/apps/docs/content/docs/web.mdx
+++ b/frontend/apps/docs/content/docs/web.mdx
@@ -46,4 +46,4 @@ If the automatic detection does not match your desired format, you can specify i
 https://liambx.com/erd/p/public.example.net/path/to/file?format=schemarb
 ```
 
-For a full list of valid format identifiers, check [**/docs/supported-formats**](/docs/supported-formats).
+For a full list of valid format identifiers, check [**/docs/parser/supported-formats**](/docs/parser/supported-formats).


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I fixed the URL that leads to supported-formats.👍
✔️ https://liambx.com/docs/parser/supported-formats

Preview: https://liam-docs-5z3170sjv-route-06-core.vercel.app/docs/web


#### Before
![ss 2749](https://github.com/user-attachments/assets/d98e7a4a-bdbb-4e06-a3fc-690946895018)


#### After
![ss 2751](https://github.com/user-attachments/assets/ce46fedf-3ab2-45a8-8618-e524936b0433)


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
