### PR TITLE
✨ Support index for Prisma parser

### DIFF
--- a/.changeset/bright-shoes-look.md
+++ b/.changeset/bright-shoes-look.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+✨ Support index for Prisma parser


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Support index for Prisma parser.
https://www.prisma.io/docs/orm/prisma-schema/data-model/indexes

I've checked the actual properties from prisma index/unique attributes.

### single column index (not unique)

```ts
model dogs {
  id   Int    @id @default(autoincrement())
  name String
  @@index([name])
}
```

```sql
-- CreateIndex
CREATE INDEX "dogs_name_idx" ON "dogs"("name");
```

### single column index (unique)

```ts
model posts {
  id      Int    @id @default(autoincrement())
  user    users  @relation(fields: [user_id], references: [id])
  user_id Int    @unique
  count   Int    @unique // added
}
```

```sql
-- CreateIndex
CREATE UNIQUE INDEX "posts_count_key" ON "posts"("count");
```

### multi column index (not unique)

```ts
model Company {
  id        BigInt  @id @db.BigInt @default(autoincrement())
  number    BigInt
  @@index([id, number])
}
```

```sql
-- CreateIndex
CREATE INDEX "Company_id_number_idx" ON "Company"("id", "number");
```

### multi column index (unique)


```ts
model birds {
  id   Int    @id @default(autoincrement())
  name String
  @@unique([id, name])
}
```

```sql
-- CreateIndex
CREATE UNIQUE INDEX "birds_id_name_key" ON "birds"("id", "name");
```

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
