### PR TITLE
Support glob pattern as input paths

### DIFF
--- a/.changeset/chilled-dancers-search.md
+++ b/.changeset/chilled-dancers-search.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": minor
+---
+
+✨ Support glob pattern as input paths

--- a/frontend/packages/cli/package.json
+++ b/frontend/packages/cli/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@prisma/internals": "6.2.1",
     "commander": "12.1.0",
+    "glob": "^11.0.1",
     "inquirer": "12.3.2",
     "react": "18.3.1",
     "react-dom": "18",
@@ -25,6 +26,7 @@
     "@liam-hq/erd-core": "workspace:*",
     "@rollup/plugin-node-resolve": "15.3.0",
     "@rollup/plugin-typescript": "12.1.1",
+    "@types/glob": "^8.1.0",
     "@types/node": "22.9.0",
     "@types/react": "18",
     "@types/react-dom": "18",

--- a/frontend/packages/cli/package.json
+++ b/frontend/packages/cli/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@prisma/internals": "6.2.1",
     "commander": "12.1.0",
-    "glob": "^11.0.1",
+    "glob": "11.0.1",
     "inquirer": "12.3.2",
     "react": "18.3.1",
     "react-dom": "18",
@@ -26,7 +26,7 @@
     "@liam-hq/erd-core": "workspace:*",
     "@rollup/plugin-node-resolve": "15.3.0",
     "@rollup/plugin-typescript": "12.1.1",
-    "@types/glob": "^8.1.0",
+    "@types/glob": "8.1.0",
     "@types/node": "22.9.0",
     "@types/react": "18",
     "@types/react-dom": "18",

--- a/frontend/packages/cli/rollup.config.js
+++ b/frontend/packages/cli/rollup.config.js
@@ -21,5 +21,5 @@ export default {
     }),
     execute('chmod +x dist-cli/bin/cli.js'),
   ],
-  external: ['commander', 'inquirer', '@prisma/internals'],
+  external: ['commander', 'inquirer', '@prisma/internals', 'glob'],
 }

--- a/frontend/packages/cli/src/cli/erdCommand/getInputContent.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/getInputContent.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
-import { afterEach, describe, expect, it, vi } from 'vitest'
 import { glob } from 'glob'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getInputContent } from './getInputContent.js'
 
 vi.mock('node:fs')
@@ -93,14 +93,8 @@ describe('getInputContent', () => {
   })
 
   it('should read and combine multiple files when given a glob pattern', async () => {
-    const mockFiles = [
-      '/path/to/file1.sql',
-      '/path/to/file2.sql',
-    ]
-    const mockContents = [
-      'Content of file 1',
-      'Content of file 2',
-    ]
+    const mockFiles = ['/path/to/file1.sql', '/path/to/file2.sql']
+    const mockContents = ['Content of file 1', 'Content of file 2']
 
     vi.mocked(glob).mockImplementation(async (pattern) => {
       if (pattern === '/path/to/*.sql') {

--- a/frontend/packages/cli/src/cli/erdCommand/getInputContent.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/getInputContent.test.ts
@@ -135,4 +135,12 @@ describe('getInputContent', () => {
       'File not found: /path/to/nonexistent.sql',
     )
   })
+
+  it('should throw an error if no files match the glob pattern', async () => {
+    vi.mocked(glob).mockImplementation(async () => [])
+
+    await expect(getInputContent('*.nonexistent')).rejects.toThrow(
+      'No files found matching the pattern. Please provide valid file(s).',
+    )
+  })
 })

--- a/frontend/packages/cli/src/cli/erdCommand/getInputContent.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/getInputContent.test.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { glob } from 'glob'
 import { getInputContent } from './getInputContent.js'
 
 vi.mock('node:fs')
 vi.mock('node:https')
+vi.mock('glob')
 
 describe('getInputContent', () => {
   afterEach(() => {
@@ -14,6 +16,12 @@ describe('getInputContent', () => {
     const mockFilePath = '/path/to/local/file.txt'
     const mockFileContent = 'Local file content'
 
+    vi.mocked(glob).mockImplementation(async (pattern) => {
+      if (pattern === mockFilePath) {
+        return [mockFilePath]
+      }
+      return []
+    })
     vi.spyOn(fs, 'existsSync').mockReturnValue(true)
     vi.spyOn(fs, 'readFileSync').mockReturnValue(mockFileContent)
 
@@ -25,10 +33,16 @@ describe('getInputContent', () => {
   it('should throw an error if the local file path is invalid', async () => {
     const mockFilePath = '/invalid/path/to/file.txt'
 
+    vi.mocked(glob).mockImplementation(async (pattern) => {
+      if (pattern === mockFilePath) {
+        return [mockFilePath]
+      }
+      return []
+    })
     vi.spyOn(fs, 'existsSync').mockReturnValue(false)
 
     await expect(getInputContent(mockFilePath)).rejects.toThrow(
-      'Invalid input path. Please provide a valid file.',
+      'File not found: /invalid/path/to/file.txt',
     )
   })
 
@@ -75,6 +89,50 @@ describe('getInputContent', () => {
 
     await expect(getInputContent(mockUrl)).rejects.toThrow(
       'Failed to download file: Not Found',
+    )
+  })
+
+  it('should read and combine multiple files when given a glob pattern', async () => {
+    const mockFiles = [
+      '/path/to/file1.sql',
+      '/path/to/file2.sql',
+    ]
+    const mockContents = [
+      'Content of file 1',
+      'Content of file 2',
+    ]
+
+    vi.mocked(glob).mockImplementation(async (pattern) => {
+      if (pattern === '/path/to/*.sql') {
+        return mockFiles
+      }
+      return []
+    })
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    vi.spyOn(fs, 'readFileSync')
+      .mockReturnValueOnce(mockContents[0])
+      .mockReturnValueOnce(mockContents[1])
+
+    const content = await getInputContent('/path/to/*.sql')
+
+    expect(content).toBe(mockContents.join('\n'))
+    expect(glob).toHaveBeenCalledWith('/path/to/*.sql')
+  })
+
+  it('should throw an error if any matched file does not exist', async () => {
+    const mockFiles = ['/path/to/file1.sql', '/path/to/nonexistent.sql']
+    vi.mocked(glob).mockImplementation(async (pattern) => {
+      if (pattern === '*.sql') {
+        return mockFiles
+      }
+      return []
+    })
+    vi.spyOn(fs, 'existsSync')
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+
+    await expect(getInputContent('*.sql')).rejects.toThrow(
+      'File not found: /path/to/nonexistent.sql',
     )
   })
 })

--- a/frontend/packages/cli/src/cli/erdCommand/getInputContent.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/getInputContent.ts
@@ -19,7 +19,9 @@ function isGitHubFileUrl(url: string): boolean {
 async function readLocalFiles(pattern: string): Promise<string> {
   const files = await glob(pattern)
   if (files.length === 0) {
-    throw new Error('No files found matching the pattern. Please provide valid file(s).')
+    throw new Error(
+      'No files found matching the pattern. Please provide valid file(s).',
+    )
   }
 
   const contents = await Promise.all(

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -11,7 +11,10 @@ const erdCommand = new Command('erd').description('ERD commands')
 erdCommand
   .command('build')
   .description('Build ERD html assets')
-  .option('--input <path|url>', 'Path (supports glob patterns) or URL to the schema file(s)')
+  .option(
+    '--input <path|url>',
+    'Path (supports glob patterns) or URL to the schema file(s)',
+  )
   .option(
     '--format <format>',
     `Format of the input file (${supportedFormatSchema.options.join('|')})`,

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -11,7 +11,7 @@ const erdCommand = new Command('erd').description('ERD commands')
 erdCommand
   .command('build')
   .description('Build ERD html assets')
-  .option('--input <path|url>', 'Path or URL to the schema file')
+  .option('--input <path|url>', 'Path (supports glob patterns) or URL to the schema file(s)')
   .option(
     '--format <format>',
     `Format of the input file (${supportedFormatSchema.options.join('|')})`,

--- a/frontend/packages/cli/src/cli/index.test.ts
+++ b/frontend/packages/cli/src/cli/index.test.ts
@@ -58,6 +58,8 @@ describe('program', () => {
   it('should have an "init" command with subcommands', () => {
     const initCommand = program.commands.find((cmd) => cmd.name() === 'init')
     expect(initCommand).toBeDefined()
-    expect(initCommand?.description()).toBe('guide you interactively through the setup')
+    expect(initCommand?.description()).toBe(
+      'guide you interactively through the setup',
+    )
   })
 })

--- a/frontend/packages/cli/src/cli/index.test.ts
+++ b/frontend/packages/cli/src/cli/index.test.ts
@@ -41,7 +41,9 @@ describe('program', () => {
     )
     expect(inputOption).toBeDefined()
     expect(inputOption?.flags).toBe('--input <path|url>')
-    expect(inputOption?.description).toBe('Path or URL to the schema file')
+    expect(inputOption?.description).toBe(
+      'Path (supports glob patterns) or URL to the schema file(s)',
+    )
 
     const formatOption = buildSubCommand?.options.find(
       (option) => option.name() === 'format',
@@ -56,8 +58,6 @@ describe('program', () => {
   it('should have an "init" command with subcommands', () => {
     const initCommand = program.commands.find((cmd) => cmd.name() === 'init')
     expect(initCommand).toBeDefined()
-    expect(initCommand?.description()).toBe(
-      'guide you interactively through the setup',
-    )
+    expect(initCommand?.description()).toBe('guide you interactively through the setup')
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       commander:
         specifier: 12.1.0
         version: 12.1.0
+      glob:
+        specifier: ^11.0.1
+        version: 11.0.1
       inquirer:
         specifier: 12.3.2
         version: 12.3.2(@types/node@22.9.0)
@@ -185,6 +188,9 @@ importers:
       '@rollup/plugin-typescript':
         specifier: 12.1.1
         version: 12.1.1(rollup@4.27.3)(tslib@2.8.1)(typescript@5.6.2)
+      '@types/glob':
+        specifier: ^8.1.0
+        version: 8.1.0
       '@types/node':
         specifier: 22.9.0
         version: 22.9.0
@@ -2548,6 +2554,9 @@ packages:
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
+  '@types/glob@8.1.0':
+    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -4132,6 +4141,11 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  glob@11.0.1:
+    resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -4601,6 +4615,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.0.2:
+    resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
+    engines: {node: 20 || >=22}
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -4766,6 +4784,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.0.2:
+    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -5004,6 +5026,10 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -5350,6 +5376,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
@@ -9359,6 +9389,11 @@ snapshots:
       '@types/minimatch': 5.1.2
       '@types/node': 22.9.0
 
+  '@types/glob@8.1.0':
+    dependencies:
+      '@types/minimatch': 5.1.2
+      '@types/node': 22.9.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -10767,7 +10802,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.3.0
@@ -10780,7 +10815,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10802,7 +10837,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.16.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -11360,6 +11395,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.0.1:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 4.0.2
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -11902,6 +11946,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.0.2:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 22.9.0
@@ -12047,6 +12095,8 @@ snapshots:
   lower-case@1.1.4: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.0.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -12543,6 +12593,10 @@ snapshots:
   min-indent@1.0.1:
     optional: true
 
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -12932,6 +12986,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.0.2
       minipass: 7.1.2
 
   path-to-regexp@0.1.10: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         specifier: 12.1.0
         version: 12.1.0
       glob:
-        specifier: ^11.0.1
+        specifier: 11.0.1
         version: 11.0.1
       inquirer:
         specifier: 12.3.2
@@ -189,7 +189,7 @@ importers:
         specifier: 12.1.1
         version: 12.1.1(rollup@4.27.3)(tslib@2.8.1)(typescript@5.6.2)
       '@types/glob':
-        specifier: ^8.1.0
+        specifier: 8.1.0
         version: 8.1.0
       '@types/node':
         specifier: 22.9.0


### PR DESCRIPTION
## Summary
Add glob pattern support for the `--input` option in `erd build` command, allowing users to specify multiple schema files using glob patterns.

## Related Issue
N/A

## Changes
- Modified `getInputContent.ts` to support glob patterns for file path resolution
- Updated the `--input` option description to indicate glob pattern support
- Added glob package as a dependency
- Added comprehensive test cases for glob pattern functionality:
  - Multiple file matching and content combination
  - Error handling for non-existent files
  - Error handling for patterns with no matches

## Testing

  ```bash
  # Single file (existing behavior)
  liam erd build --input schema.sql --format postgresql

  # Multiple files using glob
  liam erd build --input "db/migrate/*.sql" --format postgresql

  # Multiple directories
  liam erd build --input "{db1,db2}/*.sql" --format postgresql
  ```

## Other Information
- The implementation maintains backward compatibility with existing file path and URL support
- All changes are generated by Cursor Composer (wow!)