### PR TITLE
🚸 Make node width variable to accommodate table/column name and type

### DIFF
--- a/.changeset/heavy-badgers-laugh.md
+++ b/.changeset/heavy-badgers-laugh.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+💄 Add elk.alignment property to node conversion for centralized layout

--- a/.changeset/olive-jars-press.md
+++ b/.changeset/olive-jars-press.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🚸 Make node width variable to accommodate table/column name and type

--- a/.changeset/wild-rabbits-itch.md
+++ b/.changeset/wild-rabbits-itch.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🚧 Prevent omission of TableColumn

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.module.css
@@ -33,12 +33,7 @@
   display: inline-flex;
   justify-content: space-between;
   align-items: center;
-}
-
-.columnName {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  gap: var(--spacing-3);
 }
 
 .columnType {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
@@ -60,7 +60,7 @@ export const TableColumn: FC<TableColumnProps> = ({
       ) : null}
 
       <span className={styles.columnNameWrapper}>
-        <span className={styles.columnName}>{column.name}</span>
+        <span>{column.name}</span>
         <span className={styles.columnType}>{column.type}</span>
       </span>
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableNode.module.css
@@ -1,7 +1,8 @@
 .wrapper {
   border-radius: var(--border-radius-md);
   border: 1px solid var(--overlay-20);
-  width: 172px;
+  min-width: 172px;
+  width: auto;
   transition: border-color 300ms var(--default-timing-function), border-width
     300ms var(--default-timing-function);
   opacity: 1;

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/convertNodesToElkNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useAutoLayout/convertNodesToElkNodes.ts
@@ -18,6 +18,7 @@ export function convertNodesToElkNodes(nodes: Node[]): ElkNode[] {
          */
         'elk.aspectRatio':
           node.type === 'nonRelatedTableGroup' ? '0.5625' : '1.6f',
+        'elk.alignment': 'LEFT',
       },
     }
     nodeMap[node.id] = elkNode


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I fixed an issue where long column names and type names would overlap and become unreadable.

I took the approach of expanding the width of the TableNode until all column names and type names are fully displayed.

| Before | After |
|--------|--------|
| ![スクリーンショット 2025-01-23 20 48 33](https://github.com/user-attachments/assets/9c79b301-3e98-4388-b1ab-614f1bda8652) | ![スクリーンショット 2025-01-23 20 48 45](https://github.com/user-attachments/assets/91348f5d-4f15-4f7a-bb06-d2415d790d57) |


## Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

## Changes
<!-- List the main changes made in this PR. -->

* [🚸 Make node width variable to accommodate table/column name and type](https://github.com/liam-hq/liam/pull/548/commits/76bc7be04c3c9945dc9c0e0d21f005c5ed2cd3a8)
  * I set the width of TableNode to "auto".
* [🚧 Prevent omission of TableColumn](https://github.com/liam-hq/liam/pull/548/commits/18e75a33134cbbfb98ef55e84419b2e7a93dc15a)
  * I prevented column names from being truncated even if they are long.
* [💄 Add elk.alignment property to node conversion for centralized layout](https://github.com/liam-hq/liam/pull/548/commits/2137216c927d1c728fbfa961c6077e065b7ad1dc)
  * I aligned each TableNode to the left.