### PR TITLE
🐛 Update cli/README: Remove outdated `preview` sub-command

### DIFF
--- a/frontend/packages/cli/README.md
+++ b/frontend/packages/cli/README.md
@@ -2,21 +2,9 @@
 
 Command-line tool designed to generate a web application that displays ER diagrams.
 
-```bash
-$ liam erd build --input {your .sql} --format postgres
-# Outputs the web application to the ./public and ./dist directories
-```
+## How To Use
 
-```bash
-# Or use a `db/schema.rb` file (from your Ruby on Rails app).
-$ liam erd build --input {your schema.rb} --format schemarb
-# Outputs the web application to the `./dist` directory
-```
-
-```bash
-$ liam erd preview
-# Launches the web application for preview
-```
+See https://liambx.com/docs/cli
 
 ## Test
 


### PR DESCRIPTION


## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

- Removed the old `preview` sub-command from `frontend/packages/cli/README.md`
- This change affects the documentation displayed on https://www.npmjs.com/package/@liam-hq/cli

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
