### PR TITLE
💄 Add an override for the Fumadocs `package installation` component.

### DIFF
--- a/frontend/apps/docs/app/global.css
+++ b/frontend/apps/docs/app/global.css
@@ -86,4 +86,13 @@
     --fd-accent: var(--liam-gray-800);
     --fd-accent-foreground: var(--liam-gray-30);
   }
+
+  /* Overrides for Fumadocs package-install component */
+  div[role='tabpanel'] figure {
+    background-color: var(--fd-secondary) !important;
+  }
+
+  div[role='tablist'] {
+    background-color: hsl(var(--fd-muted)) !important;
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
The background color of the areas using the Fumadocs package-install component was inconsistent with the design. I've corrected it to match the design.


### Before
![ss 2763](https://github.com/user-attachments/assets/05ae2243-cc65-4ad8-a9c2-b0e6b7d6ec1d)


### Design
![ss 2764](https://github.com/user-attachments/assets/f3231ae2-3ab8-4ec3-82ab-ede7aad5efe6)


### After

![ss 2766](https://github.com/user-attachments/assets/f702140d-7a46-4ca9-a366-79b2c1a34938)



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
