### PR TITLE
🚸 Conditionally render CookieConsent based on iframe context

### DIFF
--- a/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
@@ -39,6 +39,7 @@ export default function ERDViewer({
     displayedOn: 'web',
   }
   const version = v.parse(versionSchema, versionData)
+  const isIframe = window !== window.parent
 
   return (
     <div style={{ height: '100vh' }}>
@@ -48,7 +49,9 @@ export default function ERDViewer({
           errorObjects={errorObjects}
         />
       </VersionProvider>
-      {process.env.NEXT_PUBLIC_ENV_NAME !== 'production' && <CookieConsent />}
+      {process.env.NEXT_PUBLIC_ENV_NAME !== 'production' && !isIframe && (
+        <CookieConsent />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Added condition to check if ERD is rendered on iframe.
If on iframe, cookie consent component is not appeared.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

Checked by manually:

|before|after|
|--|--|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/d4300050-7aa1-4cfb-8c58-25232469b6f0" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/8d028eb5-7d71-4e56-b340-4452865701ad" />|


```html
<!DOCTYPE html>
<html lang="ja">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>ERD Viewer Embed Example</title>
    <style>
      iframe {
        width: 100%;
        height: 100vh;
        border: none;
      }
      body {
        margin: 0;
        padding: 0;
      }
    </style>
  </head>
  <body>
    <iframe
      src="http://localhost:3001/erd/p/github.com/langfuse/langfuse/blob/cf29c6b7e447cf1aec7a8d50ae6a877c3844b7cd/packages/shared/prisma/schema.prisma"
      allowfullscreen
    >
    </iframe>
  </body>
</html>

```

## Other Information
<!-- Add any other relevant information for the reviewer. -->
