### PR TITLE
🐛 fix iframe detection to avoid window defined error

### DIFF
--- a/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
@@ -27,11 +27,11 @@ export default function ERDViewer({
   errorObjects,
   defaultSidebarOpen,
 }: ERDViewerProps) {
-  const [isIframe, setIsIframe] = useState(false)
+  const [isShowCookieConsent, setShowCookieConsent] = useState(false)
 
   useEffect(() => {
     initDBStructureStore(dbStructure)
-    setIsIframe(window !== window.parent)
+    setShowCookieConsent(window === window.parent)
   }, [dbStructure])
 
   const versionData = {
@@ -51,9 +51,8 @@ export default function ERDViewer({
           errorObjects={errorObjects}
         />
       </VersionProvider>
-      {process.env.NEXT_PUBLIC_ENV_NAME !== 'production' && !isIframe && (
-        <CookieConsent />
-      )}
+      {process.env.NEXT_PUBLIC_ENV_NAME !== 'production' &&
+        isShowCookieConsent && <CookieConsent />}
     </div>
   )
 }

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
@@ -8,7 +8,7 @@ import {
   initDBStructureStore,
   versionSchema,
 } from '@liam-hq/erd-core'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import * as v from 'valibot'
 
 type ErrorObject = {
@@ -27,8 +27,11 @@ export default function ERDViewer({
   errorObjects,
   defaultSidebarOpen,
 }: ERDViewerProps) {
+  const [isIframe, setIsIframe] = useState(false)
+
   useEffect(() => {
     initDBStructureStore(dbStructure)
+    setIsIframe(window !== window.parent)
   }, [dbStructure])
 
   const versionData = {
@@ -39,7 +42,6 @@ export default function ERDViewer({
     displayedOn: 'web',
   }
   const version = v.parse(versionSchema, versionData)
-  const isIframe = window !== window.parent
 
   return (
     <div style={{ height: '100vh' }}>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Fixed `ReferenceError: window is not defined`.

```ts
 ⨯ ReferenceError: window is not defined
    at window (app/erd/p/[...slug]/erdViewer.tsx:42:19)
  40 |   }
  41 |   const version = v.parse(versionSchema, versionData)
> 42 |   const isIframe = window !== window.parent
     |                   ^
  43 |
  44 |   return (
  45 |     <div style={{ height: '100vh' }}> {
  digest: '999588878'
}
```

I've confirmed no error on my local environment ✅

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
