### PR TITLE
🔧 Update Prisma column types to match PostgreSQL standards

### DIFF
--- a/.changeset/three-beds-wave.md
+++ b/.changeset/three-beds-wave.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+🔧 Update Prisma column types to match PostgreSQL standards

--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -12,7 +12,7 @@ describe(_processor, () => {
           columns: {
             id: aColumn({
               name: 'id',
-              type: 'Int',
+              type: 'integer',
               notNull: true,
               primary: true,
               unique: false,
@@ -58,7 +58,7 @@ describe(_processor, () => {
         columns: {
           name: aColumn({
             name: 'name',
-            type: 'String',
+            type: 'text',
             notNull: true,
           }),
         },
@@ -79,7 +79,7 @@ describe(_processor, () => {
         columns: {
           description: aColumn({
             name: 'description',
-            type: 'String',
+            type: 'text',
             notNull: false,
           }),
         },
@@ -100,7 +100,7 @@ describe(_processor, () => {
         columns: {
           description: aColumn({
             name: 'description',
-            type: 'String',
+            type: 'text',
             default: "user's description",
             notNull: true,
           }),
@@ -122,7 +122,7 @@ describe(_processor, () => {
         columns: {
           age: aColumn({
             name: 'age',
-            type: 'Int',
+            type: 'integer',
             default: 30,
             notNull: true,
           }),
@@ -144,7 +144,7 @@ describe(_processor, () => {
         columns: {
           active: aColumn({
             name: 'active',
-            type: 'Boolean',
+            type: 'boolean',
             default: true,
             notNull: true,
           }),
@@ -167,7 +167,7 @@ describe(_processor, () => {
         columns: {
           description: aColumn({
             name: 'description',
-            type: 'String',
+            type: 'text',
             comment: 'this is description',
           }),
         },
@@ -204,7 +204,7 @@ describe(_processor, () => {
         columns: {
           email: aColumn({
             name: 'email',
-            type: 'String',
+            type: 'text',
             notNull: true,
           }),
         },
@@ -233,7 +233,7 @@ describe(_processor, () => {
         columns: {
           email: aColumn({
             name: 'email',
-            type: 'String',
+            type: 'text',
             notNull: true,
           }),
         },
@@ -404,7 +404,7 @@ describe(_processor, () => {
         columns: {
           email: aColumn({
             name: 'email',
-            type: 'String',
+            type: 'text',
             notNull: true,
             unique: true,
           }),
@@ -433,7 +433,7 @@ describe(_processor, () => {
         columns: {
           email: aColumn({
             name: 'email',
-            type: 'String',
+            type: 'text',
             notNull: true,
             unique: false,
           }),

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -25,7 +25,7 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
       const defaultValue = extractDefaultValue(field)
       columns[field.name] = {
         name: field.name,
-        type: field.type,
+        type: convertToPostgresColumnType(field.type, dmmf.datamodel.enums),
         default: defaultValue,
         notNull: field.isRequired,
         unique: field.isUnique,
@@ -154,6 +154,40 @@ function normalizeConstraintName(constraint: string): ForeignKeyConstraint {
       return 'SET_DEFAULT'
     default:
       return 'NO_ACTION'
+  }
+}
+
+function convertToPostgresColumnType(
+  type: string,
+  enums: readonly DMMF.DatamodelEnum[],
+): string {
+  const enumNames = enums.map((e) => e.name)
+
+  if (enumNames.includes(type)) {
+    return 'enum'
+  }
+
+  switch (type) {
+    case 'String':
+      return 'text'
+    case 'Boolean':
+      return 'boolean'
+    case 'Int':
+      return 'integer'
+    case 'BigInt':
+      return 'bigint'
+    case 'Float':
+      return 'double precision'
+    case 'DateTime':
+      return 'timestamp'
+    case 'Json':
+      return 'jsonb'
+    case 'Decimal':
+      return 'decimal'
+    case 'Bytes':
+      return 'bytea'
+    default:
+      return ''
   }
 }
 

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -25,7 +25,7 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
       const defaultValue = extractDefaultValue(field)
       columns[field.name] = {
         name: field.name,
-        type: convertToPostgresColumnType(field.type, dmmf.datamodel.enums),
+        type: convertToPostgresColumnType(field.type),
         default: defaultValue,
         notNull: field.isRequired,
         unique: field.isUnique,
@@ -157,16 +157,7 @@ function normalizeConstraintName(constraint: string): ForeignKeyConstraint {
   }
 }
 
-function convertToPostgresColumnType(
-  type: string,
-  enums: readonly DMMF.DatamodelEnum[],
-): string {
-  const enumNames = enums.map((e) => e.name)
-
-  if (enumNames.includes(type)) {
-    return 'enum'
-  }
-
+function convertToPostgresColumnType(type: string): string {
   switch (type) {
     case 'String':
       return 'text'
@@ -187,7 +178,7 @@ function convertToPostgresColumnType(
     case 'Bytes':
       return 'bytea'
     default:
-      return ''
+      return type
   }
 }
 

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -157,6 +157,7 @@ function normalizeConstraintName(constraint: string): ForeignKeyConstraint {
   }
 }
 
+// ref: https://www.prisma.io/docs/orm/reference/prisma-schema-reference#model-field-scalar-types
 function convertToPostgresColumnType(type: string): string {
   switch (type) {
     case 'String':

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -171,11 +171,11 @@ function convertToPostgresColumnType(type: string): string {
     case 'Float':
       return 'double precision'
     case 'DateTime':
-      return 'timestamp'
+      return 'timestamp(3)'
     case 'Json':
       return 'jsonb'
     case 'Decimal':
-      return 'decimal'
+      return 'decimal(65,30)'
     case 'Bytes':
       return 'bytea'
     default:


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I updated LiamERD to display PostgreSQL data types by referring to https://www.prisma.io/docs/orm/reference/prisma-schema-reference.

I've made it so that enum values are returned as ``enum`` types.

| Before  | After |
| ------------- | ------------- |
| <img width=300 src="https://github.com/user-attachments/assets/aa0a5fca-4308-44f8-b679-929b255cb187">  | <img width=300 src="https://github.com/user-attachments/assets/ab920bae-2a56-4439-8eec-f53029194312">  |



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
