### PR TITLE
🔧 prisma: Supports column data types more accurately

### DIFF
--- a/.changeset/funny-squids-yawn.md
+++ b/.changeset/funny-squids-yawn.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+🔧 Implement convertToPostgresColumnType function for PostgreSQL type conversion and update parser to utilize it

--- a/frontend/packages/db-structure/src/parser/prisma/convertToPostgresColumnType.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/convertToPostgresColumnType.ts
@@ -1,0 +1,84 @@
+import type { DMMF } from '@prisma/generator-helper'
+
+// ref: https://www.prisma.io/docs/orm/reference/prisma-schema-reference#model-field-scalar-types
+export function convertToPostgresColumnType(
+  type: string,
+  nativeType: DMMF.Field['nativeType'],
+  defaultValue: DMMF.Field['default'] | null,
+): string {
+  if (nativeType) {
+    const [nativeTypeName, nativeTypeArgs] = nativeType
+
+    // If the default value includes 'autoincrement()', return the appropriate serial type
+    if (
+      typeof defaultValue === 'string' &&
+      defaultValue.includes('autoincrement()')
+    ) {
+      switch (nativeTypeName) {
+        case 'Int':
+          return 'serial'
+        case 'SmallInt':
+          return 'smallserial'
+        case 'BigInt':
+          return 'bigserial'
+        default:
+          return nativeTypeName.toLowerCase()
+      }
+    }
+
+    // If nativeType has arguments, format it as 'type(args)'
+    // For example, when `price Decimal @db.Decimal(10, 2)`, type should be Decimal(10, 2)
+    if (nativeTypeArgs.length > 0) {
+      return `${nativeTypeName.toLowerCase()}(${nativeTypeArgs.join(',')})`
+    }
+
+    // Special case for 'DoublePrecision' to return 'double precision' with a space
+    if (nativeTypeName === 'DoublePrecision') {
+      return 'double precision'
+    }
+    return nativeTypeName.toLowerCase()
+  }
+
+  // If nativeType is not provided, use the Prisma field type to determine the PostgreSQL column type
+  if (
+    typeof defaultValue === 'string' &&
+    defaultValue.includes('autoincrement()')
+  ) {
+    switch (type) {
+      case 'Int':
+        return 'serial'
+      case 'BigInt':
+        return 'bigserial'
+      default:
+        return type.toLowerCase()
+    }
+  }
+
+  // Special case for 'uuid' default value
+  if (typeof defaultValue === 'string' && defaultValue.includes('uuid')) {
+    return 'uuid'
+  }
+
+  switch (type) {
+    case 'String':
+      return 'text'
+    case 'Boolean':
+      return 'boolean'
+    case 'Int':
+      return 'integer'
+    case 'BigInt':
+      return 'bigint'
+    case 'Float':
+      return 'double precision'
+    case 'DateTime':
+      return 'timestamp(3)'
+    case 'Json':
+      return 'jsonb'
+    case 'Decimal':
+      return 'decimal(65,30)'
+    case 'Bytes':
+      return 'bytea'
+    default:
+      return type
+  }
+}

--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -12,7 +12,8 @@ describe(_processor, () => {
           columns: {
             id: aColumn({
               name: 'id',
-              type: 'integer',
+              type: 'serial',
+              default: 'autoincrement()',
               notNull: true,
               primary: true,
               unique: false,

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -136,10 +136,11 @@ function extractIndex(index: DMMF.Index): Index | null {
 function extractDefaultValue(field: DMMF.Field) {
   const value = field.default?.valueOf()
   const defaultValue = value === undefined ? null : value
-  // NOTE: For example, when `@default(autoincrement())` is specified, `defaultValue`
-  // becomes an object like `{"name":"autoincrement","args":[]}` (DMMF.FieldDefault).
-  // This function now supports both primitive types (DMMF.FieldDefaultScalar as `string | number | boolean`)
-  // and object types. For object types, it returns a string representation like `name(args)`.
+  // NOTE: When `@default(autoincrement())` is specified, `defaultValue` becomes an object
+  // like `{"name":"autoincrement","args":[]}` (DMMF.FieldDefault).
+  // This function handles both primitive types (`string | number | boolean`) and objects,
+  // returning a string like `name(args)` for objects.
+  // Note: `FieldDefaultScalar[]` is not supported.
   if (typeof defaultValue === 'object' && defaultValue !== null) {
     if ('name' in defaultValue && 'args' in defaultValue) {
       return `${defaultValue.name}(${defaultValue.args})`

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -8,6 +8,8 @@ import type {
   Table,
 } from '../../schema/index.js'
 import type { ProcessResult, Processor } from '../types.js'
+import { convertToPostgresColumnType } from './convertToPostgresColumnType.js'
+
 // NOTE: Workaround for CommonJS module import issue with @prisma/internals
 // CommonJS module can not support all module.exports as named exports
 const { getDMMF } = pkg
@@ -25,7 +27,11 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
       const defaultValue = extractDefaultValue(field)
       columns[field.name] = {
         name: field.name,
-        type: convertToPostgresColumnType(field.type),
+        type: convertToPostgresColumnType(
+          field.type,
+          field.nativeType,
+          defaultValue,
+        ),
         default: defaultValue,
         notNull: field.isRequired,
         unique: field.isUnique,
@@ -132,8 +138,13 @@ function extractDefaultValue(field: DMMF.Field) {
   const defaultValue = value === undefined ? null : value
   // NOTE: For example, when `@default(autoincrement())` is specified, `defaultValue`
   // becomes an object like `{"name":"autoincrement","args":[]}` (DMMF.FieldDefault).
-  // Currently, to maintain consistency with other parsers, only primitive types
-  // (DMMF.FieldDefaultScalar as `string | number | boolean`) are accepted.
+  // This function now supports both primitive types (DMMF.FieldDefaultScalar as `string | number | boolean`)
+  // and object types. For object types, it returns a string representation like `name(args)`.
+  if (typeof defaultValue === 'object' && defaultValue !== null) {
+    if ('name' in defaultValue && 'args' in defaultValue) {
+      return `${defaultValue.name}(${defaultValue.args})`
+    }
+  }
   return typeof defaultValue === 'string' ||
     typeof defaultValue === 'number' ||
     typeof defaultValue === 'boolean'
@@ -154,32 +165,6 @@ function normalizeConstraintName(constraint: string): ForeignKeyConstraint {
       return 'SET_DEFAULT'
     default:
       return 'NO_ACTION'
-  }
-}
-
-// ref: https://www.prisma.io/docs/orm/reference/prisma-schema-reference#model-field-scalar-types
-function convertToPostgresColumnType(type: string): string {
-  switch (type) {
-    case 'String':
-      return 'text'
-    case 'Boolean':
-      return 'boolean'
-    case 'Int':
-      return 'integer'
-    case 'BigInt':
-      return 'bigint'
-    case 'Float':
-      return 'double precision'
-    case 'DateTime':
-      return 'timestamp(3)'
-    case 'Json':
-      return 'jsonb'
-    case 'Decimal':
-      return 'decimal(65,30)'
-    case 'Bytes':
-      return 'bytea'
-    default:
-      return type
   }
 }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

While our PR for #572 previously supported only the following columns, we've enhanced it to provide more accurate support. For example, we now support columns like ``serial``, ``uuid``, and ``time``

![ss 2769](https://github.com/user-attachments/assets/62816b92-0d87-42eb-9dfd-72998af1fedb)

Support for added columns: 
```
char
varchar
bit
varbit
uuid
xml
inet
citext
smallint
smallserial
serial
oid
bigserial
real
money
timestamptz
date
time
timetz
json
```

You can find the UUID and serial number within the ``cal.com`` data schema.
Preview: https://liam-erd-ncg6vs35h-route-06-core.vercel.app/erd/p/github.com/calcom/cal.com/blob/main/packages/prisma/schema.prisma?showMode=ALL_FIELDS&active=EventType

![ss 2772](https://github.com/user-attachments/assets/b9dd50cb-26f9-4c51-a7a6-0a9b8ecc71b8)



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
