### PR TITLE
♻️ Add createParserTestCases function and update parser tests

### DIFF
--- a/.changeset/nice-starfishes-collect.md
+++ b/.changeset/nice-starfishes-collect.md
@@ -1,6 +1,0 @@
----
-"@liam-hq/db-structure": patch
-"@liam-hq/cli": patch
----
-
-♻️ Add createParserTestCases function and update parser tests

--- a/.changeset/nice-starfishes-collect.md
+++ b/.changeset/nice-starfishes-collect.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+♻️ Add createParserTestCases function and update parser tests

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -1,35 +1,13 @@
 import {
   type Table,
   aColumn,
-  aDBStructure,
-  aTable,
+  type aDBStructure,
   anIndex,
 } from '../../schema/index.js'
 
-const userTable = (override?: Partial<Table>) =>
-  aDBStructure({
-    tables: {
-      users: aTable({
-        name: 'users',
-        columns: {
-          id: aColumn({
-            name: 'id',
-            type: 'bigserial',
-            notNull: true,
-            primary: true,
-            unique: true,
-          }),
-          ...override?.columns,
-        },
-        indices: {
-          ...override?.indices,
-        },
-        comment: override?.comment ?? null,
-      }),
-    },
-  })
-
-export const parserTestCases = {
+export const createParserTestCases = (
+  userTable: (override?: Partial<Table>) => ReturnType<typeof aDBStructure>,
+) => ({
   'table comment': userTable({
     comment: 'store our users.',
   }),
@@ -96,20 +74,21 @@ export const parserTestCases = {
       }),
     },
   }),
-  'index (unique: false)': userTable({
-    columns: {
-      email: aColumn({
-        name: 'email',
-      }),
-    },
-    indices: {
-      index_users_on_id_and_email: anIndex({
-        name: 'index_users_on_id_and_email',
-        unique: false,
-        columns: ['id', 'email'],
-      }),
-    },
-  }),
+  'index (unique: false)': (indexName: string) =>
+    userTable({
+      columns: {
+        email: aColumn({
+          name: 'email',
+        }),
+      },
+      indices: {
+        [indexName]: anIndex({
+          name: indexName,
+          unique: false,
+          columns: ['id', 'email'],
+        }),
+      },
+    }),
   'index (unique: true)': userTable({
     columns: {
       email: aColumn({
@@ -136,9 +115,9 @@ export const parserTestCases = {
       deleteConstraint: 'NO_ACTION',
     },
   }),
-  'foreign key (one-to-one)': {
-    users_id_to_posts_user_id: {
-      name: 'users_id_to_posts_user_id',
+  'foreign key (one-to-one)': (name: string) => ({
+    [name]: {
+      name,
       primaryTableName: 'users',
       primaryColumnName: 'id',
       foreignTableName: 'posts',
@@ -147,7 +126,7 @@ export const parserTestCases = {
       updateConstraint: 'NO_ACTION',
       deleteConstraint: 'NO_ACTION',
     },
-  },
+  }),
   'foreign key with action': {
     fk_posts_user_id: {
       name: 'fk_posts_user_id',
@@ -160,4 +139,4 @@ export const parserTestCases = {
       deleteConstraint: 'CASCADE',
     },
   },
-}
+})

--- a/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
+++ b/frontend/packages/db-structure/src/parser/__tests__/testcase.ts
@@ -1,12 +1,12 @@
 import {
+  type DBStructure,
   type Table,
   aColumn,
-  type aDBStructure,
   anIndex,
 } from '../../schema/index.js'
 
 export const createParserTestCases = (
-  userTable: (override?: Partial<Table>) => ReturnType<typeof aDBStructure>,
+  userTable: (override?: Partial<Table>) => DBStructure,
 ) => ({
   'table comment': userTable({
     comment: 'store our users.',

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -34,7 +34,7 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
         ),
         default: defaultValue,
         notNull: field.isRequired,
-        unique: field.isUnique,
+        unique: field.isId || field.isUnique,
         primary: field.isId,
         comment: field.documentation ?? null,
         check: null,

--- a/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/index.test.ts
@@ -3,7 +3,7 @@ import type { Table } from '../../schema/index.js'
 import { aColumn, aDBStructure, aTable } from '../../schema/index.js'
 import { UnsupportedTokenError, processor } from './index.js'
 
-import { parserTestCases } from '../__tests__/index.js'
+import { createParserTestCases } from '../__tests__/index.js'
 
 describe(processor, () => {
   const userTable = (override?: Partial<Table>) =>
@@ -28,6 +28,7 @@ describe(processor, () => {
         }),
       },
     })
+  const parserTestCases = createParserTestCases(userTable)
 
   describe('should parse create_table correctly', () => {
     it('table comment', async () => {
@@ -188,6 +189,7 @@ describe(processor, () => {
     })
 
     it('index (unique: false)', async () => {
+      const indexName = 'index_users_on_id_and_email'
       const { value } = await processor(/* Ruby */ `
         create_table "users" do |t|
           t.string "email"
@@ -195,7 +197,7 @@ describe(processor, () => {
         end
       `)
 
-      expect(value).toEqual(parserTestCases['index (unique: false)'])
+      expect(value).toEqual(parserTestCases['index (unique: false)'](indexName))
     })
 
     it('index (unique: true)', async () => {
@@ -244,6 +246,7 @@ describe(processor, () => {
     })
 
     it('foreign key (one-to-one)', async () => {
+      const keyName = 'users_id_to_posts_user_id'
       const { value } = await processor(/* Ruby */ `
         create_table "posts" do |t|
           t.bigint "user_id", unique: true
@@ -253,7 +256,7 @@ describe(processor, () => {
       `)
 
       expect(value.relationships).toEqual(
-        parserTestCases['foreign key (one-to-one)'],
+        parserTestCases['foreign key (one-to-one)'](keyName),
       )
     })
 

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from 'vitest'
-import { parserTestCases } from '../../__tests__/index.js'
+import type { Table } from '../../../schema/index.js'
+import { aColumn, aDBStructure, aTable } from '../../../schema/index.js'
+import { createParserTestCases } from '../../__tests__/index.js'
 import { UnexpectedTokenWarningError } from '../../errors.js'
 import { processor } from './index.js'
 
 describe(processor, () => {
+  const userTable = (override?: Partial<Table>) =>
+    aDBStructure({
+      tables: {
+        users: aTable({
+          name: 'users',
+          columns: {
+            id: aColumn({
+              name: 'id',
+              type: 'bigserial',
+              notNull: true,
+              primary: true,
+              unique: true,
+            }),
+            ...override?.columns,
+          },
+          indices: {
+            ...override?.indices,
+          },
+          comment: override?.comment ?? null,
+        }),
+      },
+    })
+  const parserTestCases = createParserTestCases(userTable)
+
   describe('should parse CREATE TABLE statement correctly', () => {
     it('table comment', async () => {
       const { value } = await processor(/* sql */ `
@@ -95,6 +121,7 @@ describe(processor, () => {
     })
 
     it('index (unique: false)', async () => {
+      const indexName = 'index_users_on_id_and_email'
       const { value } = await processor(/* sql */ `
         CREATE TABLE users (
           id BIGSERIAL PRIMARY KEY,
@@ -104,7 +131,7 @@ describe(processor, () => {
         CREATE INDEX index_users_on_id_and_email ON public.users USING btree (id, email);
       `)
 
-      expect(value).toEqual(parserTestCases['index (unique: false)'])
+      expect(value).toEqual(parserTestCases['index (unique: false)'](indexName))
     })
 
     it('index (unique: true)', async () => {
@@ -152,6 +179,7 @@ describe(processor, () => {
     })
 
     it('foreign key (one-to-one)', async () => {
+      const keyName = 'users_id_to_posts_user_id'
       const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
           id BIGSERIAL PRIMARY KEY,
@@ -160,7 +188,7 @@ describe(processor, () => {
       `)
 
       expect(value.relationships).toEqual(
-        parserTestCases['foreign key (one-to-one)'],
+        parserTestCases['foreign key (one-to-one)'](keyName),
       )
     })
   })
@@ -179,6 +207,7 @@ describe(processor, () => {
     })
 
     it('foreign key (one-to-one)', async () => {
+      const keyName = 'users_id_to_posts_user_id'
       const { value } = await processor(/* sql */ `
         CREATE TABLE posts (
             id SERIAL PRIMARY KEY,
@@ -190,7 +219,7 @@ describe(processor, () => {
       `)
 
       expect(value.relationships).toEqual(
-        parserTestCases['foreign key (one-to-one)'],
+        parserTestCases['foreign key (one-to-one)'](keyName),
       )
     })
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

To improve consistency, I've standardized the tests using a single test case. However, variations in parser behavior, like ``index names`` and ``default values``, necessitate the redefinition of ``userTable`` for each parser.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
