### PR TITLE
📝 docs: Add instructions for handling multiple Prisma schema files

### DIFF
--- a/frontend/apps/docs/content/docs/parser/supported-formats/prisma.mdx
+++ b/frontend/apps/docs/content/docs/parser/supported-formats/prisma.mdx
@@ -18,6 +18,18 @@ npx @liam-hq/cli erd build --format prisma --input prisma/schema.prisma
 
 If the above command runs without issue, you should see an ER diagram generated.
 
+### Handling Multiple Prisma Schema Files
+
+If you use the `prismaSchemaFolder` option in your Prisma configuration, you can still generate the ER diagram by specifying a glob pattern to include all `.prisma` files in the folder. 
+
+For example, if you have multiple `.prisma` files in the `prisma/schema/` directory, use the following command:
+
+```package-install
+npx @liam-hq/cli erd build --format prisma --input "prisma/schema/*.prisma"
+```
+
+This allows you to generate the ER diagram.
+
 ## Under the Hood
 
 Liam CLI analyzes the content of your `schema.prisma` file using a dedicated parser that relies on [`@prisma/internals`](https://www.npmjs.com/package/@prisma/internals) to build the ER diagram.

--- a/frontend/apps/docs/content/docs/parser/supported-formats/prisma.mdx
+++ b/frontend/apps/docs/content/docs/parser/supported-formats/prisma.mdx
@@ -20,7 +20,7 @@ If the above command runs without issue, you should see an ER diagram generated.
 
 ### Handling Multiple Prisma Schema Files
 
-If you use the `prismaSchemaFolder` option in your Prisma configuration, you can still generate the ER diagram by specifying a glob pattern to include all `.prisma` files in the folder. 
+If you use the [prismaSchemaFolder](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) option in your Prisma configuration, you can still generate the ER diagram by specifying a glob pattern to include all `.prisma` files in the folder. 
 
 For example, if you have multiple `.prisma` files in the `prisma/schema/` directory, use the following command:
 


### PR DESCRIPTION
## Summary
Added documentation for the CLI command to generate ER diagrams when using multiple Prisma schema files, as it was not previously specified.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
