### PR TITLE
📝 Update supported formats documentation with new support levels and workarounds

### DIFF
--- a/frontend/apps/docs/content/docs/parser/supported-formats/index.mdx
+++ b/frontend/apps/docs/content/docs/parser/supported-formats/index.mdx
@@ -5,21 +5,28 @@ title: Supported Formats
 **Legend**
 
 - ✅: Supported
+- ⚡: Supported via workaround
 - ⛔: Not in progress
 - ⌛️: In progress
 
 Below is a list of currently supported (or planned) formats and integrations.
 
+- **Web Support**: Support status for the web version.
+- **CLI Support**: Support status for the CLI version. ⚡ indicates support through workarounds (e.g., using pg_dump or tbls).
 - **Identifier**: Used for specifying the format in the CLI (via `--format=postgresql`) or as a web query parameter (e.g., `?format=schemarb`).
-- **Schema DSL Parsing**: If marked as **✅**, you can parse the schema DSL file both in the CLI and on the web version.
 
-| Technology                                              | Schema DSL Parsing | Support via Database URL (PostgreSQL) | Identifier   |
-| ------------------------------------------------------- | ------------------ | ------------------------------------- | ------------ |
-| [PostgreSQL](/docs/parser/supported-formats/postgresql) | ✅                 | ✅                                    | `postgresql` |
-| [Ruby on Rails](/docs/parser/supported-formats/rails)   | ✅                 | ✅                                    | `schemarb`   |
-| [Prisma](/docs/parser/supported-formats/prisma)         | ⌛                 | ✅                                    | `prisma`     |
-| [tbls](/docs/parser/supported-formats/tbls)             | ✅                 | ⛔                                    | `tbls`       |
-| [Drizzle](/docs/parser/supported-formats/drizzle)       | ⛔                 | ✅                                    | -            |
-| MySQL                                                   | ⛔                 | ⛔                                    | -            |
+| Technology                                              | Web Support | CLI Support | Identifier   |
+| ------------------------------------------------------- | ----------- | ----------- | ------------ |
+| [PostgreSQL](/docs/parser/supported-formats/postgresql) | ✅          | ✅          | `postgresql` |
+| [Ruby on Rails](/docs/parser/supported-formats/rails)   | ✅          | ✅          | `schemarb`   |
+| [Prisma](/docs/parser/supported-formats/prisma)         | ⌛          | ✅          | `prisma`     |
+| [tbls](/docs/parser/supported-formats/tbls)             | ✅          | ✅          | `tbls`       |
+| [Drizzle](/docs/parser/supported-formats/drizzle)       | ⛔          | ⚡          | -            |
+| MySQL                                                   | ⛔          | ⛔          | -            |
+
+For CLI support marked with ⚡, you can use the following workarounds:
+
+- Generate a PostgreSQL file using pg_dump ([see instructions](/docs/parser/supported-formats/postgresql#using-a-pg_dump-generated-sql-file)), then process it with the `postgresql` format
+- Generate a schema.json using tbls ([see instructions](/docs/parser/supported-formats/tbls#using-tbls-json-output)), then process it with the `tbls` format
 
 If there's another database schema or ORM you'd love to see supported, please let us know in the [GitHub Discussions](https://github.com/liam-hq/liam/discussions/364).


### PR DESCRIPTION
I've improved /docs/parser/supported-formats.

- `via database url` is not supported yet, so delete it.
- I thought it would be clearer to use the notation “web or CLI”, so I did.