### PR TITLE
✨ Add support for default in `tbls` parser

### DIFF
--- a/.changeset/nice-kiwis-begin.md
+++ b/.changeset/nice-kiwis-begin.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/cli": patch
+---
+
+✨ Add support for default values in tbls parser and tests

--- a/frontend/packages/db-structure/src/parser/tbls/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/tbls/index.test.ts
@@ -167,6 +167,133 @@ describe(processor, () => {
       expect(value).toEqual(expected)
     })
 
+    it('default value as string', async () => {
+      const { value } = await processor(
+        JSON.stringify({
+          name: 'testdb',
+          tables: [
+            {
+              name: 'users',
+              type: 'TABLE',
+              columns: [
+                {
+                  name: 'id',
+                  type: 'int',
+                  nullable: false,
+                  default: "nextval('users_id_seq'::regclass)",
+                },
+              ],
+            },
+          ],
+        }),
+      )
+
+      const expected = userTable({
+        columns: {
+          id: aColumn({
+            name: 'id',
+            type: 'int',
+            notNull: true,
+            default: "nextval('users_id_seq'::regclass)",
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
+
+    it('default value as integer', async () => {
+      const { value } = await processor(
+        JSON.stringify({
+          name: 'testdb',
+          tables: [
+            {
+              name: 'users',
+              type: 'TABLE',
+              columns: [
+                {
+                  name: 'id',
+                  type: 'int',
+                  nullable: false,
+                },
+                {
+                  name: 'age',
+                  type: 'int',
+                  nullable: false,
+                  // NOTE: tblsColumn.default is of type string | null | undefined
+                  default: '30',
+                },
+              ],
+            },
+          ],
+        }),
+      )
+
+      const expected = userTable({
+        columns: {
+          id: aColumn({
+            name: 'id',
+            type: 'int',
+            notNull: true,
+          }),
+          age: aColumn({
+            name: 'age',
+            type: 'int',
+            notNull: true,
+            default: 30,
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
+
+    it('default value as boolean', async () => {
+      const { value } = await processor(
+        JSON.stringify({
+          name: 'testdb',
+          tables: [
+            {
+              name: 'users',
+              type: 'TABLE',
+              columns: [
+                {
+                  name: 'id',
+                  type: 'int',
+                  nullable: false,
+                },
+                {
+                  name: 'active',
+                  type: 'bool',
+                  nullable: false,
+                  // NOTE: tblsColumn.default is of type string | null | undefined
+                  default: 'true',
+                },
+              ],
+            },
+          ],
+        }),
+      )
+
+      const expected = userTable({
+        columns: {
+          id: aColumn({
+            name: 'id',
+            type: 'int',
+            notNull: true,
+          }),
+          active: aColumn({
+            name: 'active',
+            type: 'bool',
+            notNull: true,
+            default: true,
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
+
     describe('relationship', () => {
       const relationshipCases = [
         ['exactly_one', 'zero_or_one', 'ONE_TO_ONE'],

--- a/frontend/packages/db-structure/src/parser/tbls/parser.ts
+++ b/frontend/packages/db-structure/src/parser/tbls/parser.ts
@@ -55,11 +55,13 @@ async function parseTblsSchema(schemaString: string): Promise<ProcessResult> {
     )
 
     for (const tblsColumn of tblsTable.columns) {
+      const defaultValue = extractDefaultValue(tblsColumn.default)
+
       columns[tblsColumn.name] = aColumn({
         name: tblsColumn.name,
         type: tblsColumn.type,
         notNull: !tblsColumn.nullable,
-        default: tblsColumn.default ?? null,
+        default: defaultValue,
         comment: tblsColumn.comment ?? null,
         unique: uniqueColumnNames.has(tblsColumn.name),
       })
@@ -116,6 +118,29 @@ async function parseTblsSchema(schemaString: string): Promise<ProcessResult> {
     },
     errors,
   }
+}
+
+function extractDefaultValue(
+  value: string | null | undefined,
+): Columns[string]['default'] {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  // Convert string to number if it represents a number
+  if (!Number.isNaN(Number(value))) {
+    return Number(value)
+  }
+
+  // Convert string to boolean if it represents a boolean
+  if (value.toLowerCase() === 'true') {
+    return true
+  }
+  if (value.toLowerCase() === 'false') {
+    return false
+  }
+
+  return value
 }
 
 export const processor: Processor = (str) => parseTblsSchema(str)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Added support for default values in the tbls parser.
Since ``tblsColumn.default`` in tbls's ``schema.json`` provides values like booleans and numbers as strings (e.g., ``'1'`` or ``'true'``), we have added processing to appropriately convert them to numbers or booleans before returning.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
