### PR TITLE
Toggle function for sections within the ``TableDetailDrawer``

### DIFF
--- a/.changeset/clean-owls-approve.md
+++ b/.changeset/clean-owls-approve.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/ui": patch
+"@liam-hq/cli": patch
+---
+
+✨ Implement collapsible columns in ERD table detail view

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -9,6 +9,7 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  cursor: pointer;
 }
 
 .iconTitleContainer {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -21,9 +21,9 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-2);
+  font-size: var(--font-size-3);
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   line-height: normal;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -28,5 +28,12 @@
 }
 
 .itemWrapper {
+  max-height: 0;
+  transition: max-height 0.2s var(--default-timing-function);
+  overflow: hidden;
+}
+
+.itemWrapper.visible {
+  max-height: 100vh;
   border-bottom: 1px solid var(--global-border);
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -30,7 +30,7 @@
 
 .itemWrapper {
   max-height: 0;
-  transition: max-height 0.2s var(--default-timing-function);
+  transition: max-height 0.1s var(--default-timing-function);
   overflow: hidden;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -22,9 +22,8 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-3);
+  font-size: var(--font-size-2);
   font-style: normal;
-  font-weight: 400;
   line-height: normal;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
@@ -1,6 +1,12 @@
 import type { Columns as ColumnsType } from '@liam-hq/db-structure'
-import { Rows3 as Rows3Icon } from '@liam-hq/ui'
-import type { FC } from 'react'
+import {
+  ChevronDown,
+  ChevronUp,
+  IconButton,
+  Rows3 as Rows3Icon,
+} from '@liam-hq/ui'
+import clsx from 'clsx'
+import { type FC, useState } from 'react'
 import styles from './Columns.module.css'
 import { ColumnsItem } from './ColumnsItem'
 
@@ -9,6 +15,10 @@ type Props = {
 }
 
 export const Columns: FC<Props> = ({ columns }) => {
+  const [isClosed, setIsClosed] = useState(false)
+  const handleClose = () => {
+    setIsClosed(!isClosed)
+  }
   return (
     <div className={styles.wrapper}>
       <div className={styles.header}>
@@ -16,9 +26,17 @@ export const Columns: FC<Props> = ({ columns }) => {
           <Rows3Icon width={12} />
           <h2 className={styles.heading}>Columns</h2>
         </div>
+        <IconButton
+          icon={isClosed ? <ChevronDown /> : <ChevronUp />}
+          tooltipContent={isClosed ? 'Open' : 'Close'}
+          onClick={handleClose}
+        />
       </div>
       {Object.entries(columns).map(([key, column]) => (
-        <div className={styles.itemWrapper} key={key}>
+        <div
+          className={clsx(!isClosed && styles.visible, styles.itemWrapper)}
+          key={key}
+        >
           <ColumnsItem column={column} />
         </div>
       ))}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
@@ -19,9 +19,22 @@ export const Columns: FC<Props> = ({ columns }) => {
   const handleClose = () => {
     setIsClosed(!isClosed)
   }
+  const handleKeyDown = (event: { key: string }) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      handleClose()
+    }
+  }
+
   return (
     <div className={styles.wrapper}>
-      <div className={styles.header}>
+      <div
+        className={styles.header}
+        // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
+        role="button"
+        tabIndex={0}
+        onClick={handleClose}
+        onKeyDown={handleKeyDown}
+      >
         <div className={styles.iconTitleContainer}>
           <Rows3Icon width={12} />
           <h2 className={styles.heading}>Columns</h2>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
@@ -6,7 +6,7 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-3);
+  font-size: var(--font-size-2);
   font-style: normal;
   font-weight: 400;
   line-height: normal;
@@ -16,7 +16,6 @@
   color: var(--color-white-alpha-70);
   font-size: var(--font-size-2);
   font-style: normal;
-  font-weight: 400;
   line-height: 150%;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
@@ -21,15 +21,14 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-3);
+  font-size: var(--font-size-2);
   font-style: normal;
-  font-weight: 400;
   line-height: normal;
 }
 
 .list {
   list-style: inside;
-  padding: var(--spacing-2);
+  padding: var(--spacing-3);
 }
 
 .listItem {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
@@ -1,14 +1,25 @@
 .wrapper {
-  display: grid;
-  gap: var(--spacing-2);
-  padding: var(--spacing-4);
   border-bottom: 1px solid var(--global-border);
 }
 
-.heading {
-  display: inline-flex;
+.header {
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2);
+  border-bottom: 1px solid var(--global-border);
+}
+
+.iconTitleContainer {
+  display: grid;
+  grid-auto-flow: column;
   gap: var(--spacing-1);
+  align-items: center;
+  color: var(--overlay-70);
+}
+
+.heading {
   color: var(--global-foreground);
   font-size: var(--font-size-3);
   font-style: normal;
@@ -16,14 +27,9 @@
   line-height: normal;
 }
 
-.icon {
-  width: 0.75rem;
-  height: 0.75rem;
-  color: var(--overlay-70);
-}
-
 .list {
   list-style: inside;
+  padding: var(--spacing-2);
 }
 
 .listItem {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.tsx
@@ -10,17 +10,21 @@ type Props = {
 export const Indices: FC<Props> = ({ indices }) => {
   return (
     <div className={styles.wrapper}>
-      <h2 className={styles.heading}>
-        <Hash className={styles.icon} />
-        <span>Indexes</span>
-      </h2>
-      <ul className={styles.list}>
-        {Object.entries(indices).map(([key, index]) => (
-          <li key={key} className={styles.listItem}>
-            {index.name}
-          </li>
-        ))}
-      </ul>
+      <div className={styles.header}>
+        <div className={styles.iconTitleContainer}>
+          <Hash width={12} />
+          <h2 className={styles.heading}>Indexes</h2>
+        </div>
+      </div>
+      {Object.keys(indices).length !== 0 && (
+        <ul className={styles.list}>
+          {Object.entries(indices).map(([key, index]) => (
+            <li key={key} className={styles.listItem}>
+              {index.name}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.module.css
@@ -1,14 +1,10 @@
-.wrapper {
-  display: grid;
-  gap: var(--spacing-4);
-  padding: var(--spacing-4);
-}
-
 .header {
   display: grid;
   grid-auto-flow: column;
   align-items: center;
   justify-content: space-between;
+  padding: var(--spacing-2);
+  border-bottom: 1px solid var(--global-border);
 }
 
 .iconTitleContainer {
@@ -25,6 +21,10 @@
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+}
+
+.outerWrapper {
+  padding: var(--spacing-3);
 }
 
 .contentWrapper {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.module.css
@@ -17,9 +17,8 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-3);
+  font-size: var(--font-size-2);
   font-style: normal;
-  font-weight: 400;
   line-height: normal;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
@@ -46,7 +46,7 @@ export const RelatedTables: FC<Props> = ({ table }) => {
   }, [nodes, getNodes, table.name, version])
 
   return (
-    <div className={styles.wrapper}>
+    <div>
       <div className={styles.header}>
         <div className={styles.iconTitleContainer}>
           <WaypointsIcon width={12} />
@@ -58,17 +58,19 @@ export const RelatedTables: FC<Props> = ({ table }) => {
           onClick={handleClick}
         />
       </div>
-      <div className={styles.contentWrapper}>
-        <ReactFlowProvider>
-          <ERDContent
-            nodes={nodes}
-            edges={edges}
-            enabledFeatures={{
-              fitViewWhenActiveTableChange: false,
-              initialFitViewToActiveTable: false,
-            }}
-          />
-        </ReactFlowProvider>
+      <div className={styles.outerWrapper}>
+        <div className={styles.contentWrapper}>
+          <ReactFlowProvider>
+            <ERDContent
+              nodes={nodes}
+              edges={edges}
+              enabledFeatures={{
+                fitViewWhenActiveTableChange: false,
+                initialFitViewToActiveTable: false,
+              }}
+            />
+          </ReactFlowProvider>
+        </div>
       </div>
     </div>
   )

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
@@ -30,9 +30,9 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-2);
+  font-size: var(--font-size-3);
   font-style: normal;
-  font-weight: 500;
+  font-weight: 400;
   line-height: normal;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
@@ -30,9 +30,8 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-3);
+  font-size: var(--font-size-2);
   font-style: normal;
-  font-weight: 400;
   line-height: normal;
 }
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
@@ -21,15 +21,14 @@
 
 .heading {
   color: var(--global-foreground);
-  font-size: var(--font-size-3);
+  font-size: var(--font-size-2);
   font-style: normal;
-  font-weight: 400;
   line-height: normal;
 }
 
 .list {
   list-style: inside;
-  padding: var(--spacing-2);
+  padding: var(--spacing-3);
 }
 
 .listItem {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
@@ -1,14 +1,25 @@
 .wrapper {
-  display: grid;
-  gap: var(--spacing-2);
-  padding: var(--spacing-4);
   border-bottom: 1px solid var(--global-border);
 }
 
-.heading {
-  display: inline-flex;
+.header {
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2);
+  border-bottom: 1px solid var(--global-border);
+}
+
+.iconTitleContainer {
+  display: grid;
+  grid-auto-flow: column;
   gap: var(--spacing-1);
+  align-items: center;
+  color: var(--overlay-70);
+}
+
+.heading {
   color: var(--global-foreground);
   font-size: var(--font-size-3);
   font-style: normal;
@@ -16,14 +27,9 @@
   line-height: normal;
 }
 
-.icon {
-  width: 0.75rem;
-  height: 0.75rem;
-  color: var(--overlay-70);
-}
-
 .list {
   list-style: inside;
+  padding: var(--spacing-2);
 }
 
 .listItem {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx
@@ -10,10 +10,12 @@ type Props = {
 export const Unique: FC<Props> = ({ columns }) => {
   return (
     <div className={styles.wrapper}>
-      <h2 className={styles.heading}>
-        <Fingerprint className={styles.icon} />
-        <span>Unique</span>
-      </h2>
+      <div className={styles.header}>
+        <div className={styles.iconTitleContainer}>
+          <Fingerprint width={12} />
+          <h2 className={styles.heading}>Unique</h2>
+        </div>
+      </div>
       <ul className={styles.list}>
         {Object.entries(columns).map(([key, column]) => {
           if (!column.unique) return null

--- a/frontend/packages/ui/src/icons/ChevronUp.tsx
+++ b/frontend/packages/ui/src/icons/ChevronUp.tsx
@@ -1,0 +1,8 @@
+import { ChevronUp as PrimitiveChevronUp } from 'lucide-react'
+import type { ComponentPropsWithoutRef, FC } from 'react'
+
+type Props = ComponentPropsWithoutRef<typeof PrimitiveChevronUp>
+
+export const ChevronUp: FC<Props> = (props) => (
+  <PrimitiveChevronUp strokeWidth={1.5} {...props} />
+)

--- a/frontend/packages/ui/src/icons/index.ts
+++ b/frontend/packages/ui/src/icons/index.ts
@@ -1,6 +1,7 @@
 export * from './BookText'
 export * from './Check'
 export * from './ChevronDown'
+export * from './ChevronUp'
 export * from './CircleHelp'
 export * from './InfoIcon'
 export * from './FacebookIcon'


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

I've added a toggle feature to each section of the ``TableDetailDrawer``. For now, I've implemented it only for the ``Columns`` section.（So that I can apply it to other sections after the review.）


Preview: https://liam-erd-sample-b9tglfoys-route-06-core.vercel.app/?active=announcements

https://github.com/user-attachments/assets/f97763a9-fadb-4073-b4d6-b959274fe3eb

In the future,

<img width="367" alt="ss 2783" src="https://github.com/user-attachments/assets/bd0db60a-d4e8-47b3-bb41-53aeb613bb16" />



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

https://github.com/liam-hq/liam/pull/607/commits/aecb91a55e2b2b9516a70c6834f7be6d936ac6fe : ✨ Implement collapsible columns in ERD table detail view
https://github.com/liam-hq/liam/pull/607/commits/1a656aa24093125ca30be4d3fc11a0b4b4998c92 : ♻️ Unify the structure and style of each section within the TableDetailDrawer.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
I'd like you to check out the animation part!