### PR TITLE
♻︎ Simplify tbls schema.json generation instructions

### DIFF
--- a/.changeset/dry-insects-help.md
+++ b/.changeset/dry-insects-help.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": patch
+---
+
+♻︎ Simplify tbls schema.json generation instructions

--- a/frontend/packages/cli/src/cli/initCommand/index.ts
+++ b/frontend/packages/cli/src/cli/initCommand/index.ts
@@ -74,7 +74,6 @@ Now, let’s get started with setting up your Liam ERD project.
   //
   let inputFilePath = ''
   let cannotSupportNow = false
-  const tblsInstruction = '   $ tbls out -t json -o schema.json'
 
   if (dbOrOrm === 'PostgreSQL') {
     // Ask if pg_dump .sql can be used
@@ -150,7 +149,7 @@ To use tbls with Liam ERD:
 
 2. Generate a schema.json file using tbls:
 
-${yocto.blueBright(tblsInstruction)}
+${yocto.blueBright('   $ tbls out -t json -o schema.json')}
 
 For more details about using tbls with Liam ERD, see:
 ${yocto.blueBright(`${DocsUrl}/parser/supported-formats/tbls`)}
@@ -227,13 +226,13 @@ ${yocto.blueBright(DocsUrl)}
   let stepNum = 1
 
   if (dbOrOrm.includes('(via tbls)')) {
-    console.info(`${stepNum}) Generate schema.json using tbls:`)
+    console.info(`${stepNum}) Build your ERD using the generated schema.json:`)
     stepNum++
-    console.info(`${yocto.blueBright(tblsInstruction)}
-
-${stepNum}) Build your ERD using the generated schema.json:
-${yocto.blueBright('   $ npx @liam-hq/cli erd build --input schema.json --format tbls')}`)
-    stepNum++
+    console.info(
+      yocto.blueBright(
+        '   $ npx @liam-hq/cli erd build --input schema.json --format tbls',
+      ),
+    )
   } else if (dbOrOrm === 'Drizzle' && !inputFilePath) {
     // If user is using Drizzle but didn't specify any input file,
     // advise them to eventually produce a dump file.


### PR DESCRIPTION
- ref: https://github.com/liam-hq/liam/pull/608#discussion_r1933130228

Removed duplicate output ( `tbls out -t json -o schema.json` ).

## Testing

### MySQL

```bash
node frontend/packages/cli/dist-cli/bin/cli.js init

👾  Welcome to the @liam-hq/cli setup process! 👾

This `init` subcommand will guide you interactively through the setup.

🌟 This init command is a work in progress! 🌟
We’re continuously improving it. Don’t forget to run `npx @liam-hq/cli init` after updates for the latest features.

💡 Have feedback? Share it with us!
Visit https://github.com/liam-hq/liam/discussions to submit ideas or report issues.

🌟️ Love Liam ERD? Help us grow by starring our GitHub repository:
https://github.com/liam-hq/liam

----
Now, let’s get started with setting up your Liam ERD project.
  
✔ Which Technology (database or ORM) are you using? MySQL (via tbls)

Note: Direct support is not available yet. You'll need to use tbls as a bridge.

To use tbls with Liam ERD:

1. Install tbls from: https://github.com/k1LoW/tbls?tab=readme-ov-file#install

2. Generate a schema.json file using tbls:

   $ tbls out -t json -o schema.json

For more details about using tbls with Liam ERD, see:
https://liambx.com/docs/parser/supported-formats/tbls

Want direct support without using tbls? Let us know at:
https://github.com/liam-hq/liam/discussions/364

✔ Generate GitHub Actions Workflow? No

For more details about Liam ERD usage and advanced configurations, check out:
https://liambx.com/docs


--- Next Steps ---
1) Build your ERD using the generated schema.json:
   $ npx @liam-hq/cli erd build --input schema.json --format tbls

2) Start your favorite httpd for serving dist. e.g.:
   $ npx http-server dist

✅ Setup complete! Enjoy using Liam ERD to visualize your database schema!
```
