### PR TITLE
✨  Add toggle function for all sections in TableDetailDrawer

### DIFF
--- a/.changeset/quick-crabs-smile.md
+++ b/.changeset/quick-crabs-smile.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+✨ Add toggle function for all sections in TableDetailDrawer

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -1,7 +1,3 @@
-.wrapper {
-  border-bottom: 1px solid var(--global-border);
-}
-
 .header {
   display: grid;
   grid-auto-flow: column;

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
@@ -6,7 +6,7 @@ import {
   Rows3 as Rows3Icon,
 } from '@liam-hq/ui'
 import clsx from 'clsx'
-import { type FC, useState } from 'react'
+import { type FC, type MouseEvent, useState } from 'react'
 import styles from './Columns.module.css'
 import { ColumnsItem } from './ColumnsItem'
 
@@ -16,17 +16,18 @@ type Props = {
 
 export const Columns: FC<Props> = ({ columns }) => {
   const [isClosed, setIsClosed] = useState(false)
-  const handleClose = () => {
+  const handleClose = (event: MouseEvent) => {
+    event.stopPropagation()
     setIsClosed(!isClosed)
   }
   const handleKeyDown = (event: { key: string }) => {
     if (event.key === 'Enter' || event.key === ' ') {
-      handleClose()
+      setIsClosed(!isClosed)
     }
   }
 
   return (
-    <div className={styles.wrapper}>
+    <>
       <div
         className={styles.header}
         // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
@@ -53,6 +54,6 @@ export const Columns: FC<Props> = ({ columns }) => {
           <ColumnsItem column={column} />
         </div>
       ))}
-    </div>
+    </>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
@@ -1,7 +1,3 @@
-.wrapper {
-  border-bottom: 1px solid var(--global-border);
-}
-
 .header {
   display: grid;
   grid-auto-flow: column;
@@ -9,6 +5,7 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  cursor: pointer;
 }
 
 .iconTitleContainer {
@@ -24,6 +21,17 @@
   font-size: var(--font-size-2);
   font-style: normal;
   line-height: normal;
+}
+
+.listWrapper {
+  max-height: 0;
+  transition: max-height 0.1s var(--default-timing-function);
+  overflow: hidden;
+}
+
+.listWrapper.visible {
+  max-height: 100vh;
+  border-bottom: 1px solid var(--global-border);
 }
 
 .list {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.tsx
@@ -1,6 +1,7 @@
 import type { Indices as IndicesType } from '@liam-hq/db-structure'
-import { Hash } from '@liam-hq/ui'
-import type { FC } from 'react'
+import { ChevronDown, ChevronUp, Hash, IconButton } from '@liam-hq/ui'
+import clsx from 'clsx'
+import { type FC, type MouseEvent, useState } from 'react'
 import styles from './Indices.module.css'
 
 type Props = {
@@ -8,23 +9,48 @@ type Props = {
 }
 
 export const Indices: FC<Props> = ({ indices }) => {
+  const [isClosed, setIsClosed] = useState(false)
+  const handleClose = (event: MouseEvent) => {
+    event.stopPropagation()
+    setIsClosed(!isClosed)
+  }
+  const handleKeyDown = (event: { key: string }) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      setIsClosed(!isClosed)
+    }
+  }
+
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.header}>
+    <>
+      <div
+        className={styles.header}
+        // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
+        role="button"
+        tabIndex={0}
+        onClick={handleClose}
+        onKeyDown={handleKeyDown}
+      >
         <div className={styles.iconTitleContainer}>
           <Hash width={12} />
           <h2 className={styles.heading}>Indexes</h2>
         </div>
+        <IconButton
+          icon={isClosed ? <ChevronDown /> : <ChevronUp />}
+          tooltipContent={isClosed ? 'Open' : 'Close'}
+          onClick={handleClose}
+        />
       </div>
       {Object.keys(indices).length !== 0 && (
-        <ul className={styles.list}>
-          {Object.entries(indices).map(([key, index]) => (
-            <li key={key} className={styles.listItem}>
-              {index.name}
-            </li>
-          ))}
-        </ul>
+        <div className={clsx(!isClosed && styles.visible, styles.listWrapper)}>
+          <ul className={styles.list}>
+            {Object.entries(indices).map(([key, index]) => (
+              <li key={key} className={styles.listItem}>
+                {index.name}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
-    </div>
+    </>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.module.css
@@ -5,6 +5,7 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  cursor: pointer;
 }
 
 .iconTitleContainer {
@@ -15,6 +16,13 @@
   color: var(--overlay-70);
 }
 
+.iconContainer {
+  display: grid;
+  grid-auto-flow: column;
+  gap: var(--spacing-1);
+  align-items: center;
+}
+
 .heading {
   color: var(--global-foreground);
   font-size: var(--font-size-2);
@@ -23,13 +31,21 @@
 }
 
 .outerWrapper {
-  padding: var(--spacing-3);
+  max-height: 0;
+  transition: max-height 0.1s var(--default-timing-function);
+  overflow: hidden;
+}
+
+.outerWrapper.visible {
+  max-height: 100vh;
+  border-bottom: 1px solid var(--global-border);
 }
 
 .contentWrapper {
   border-radius: var(--border-radius-smbase);
   border: 1px solid var(--pane-border);
   background: var(--global-background);
-  width: 100%;
+  width: 92%;
   height: 333px;
+  margin: var(--spacing-3);
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
@@ -7,9 +7,16 @@ import {
   useDBStructureStore,
 } from '@/stores'
 import type { Table } from '@liam-hq/db-structure'
-import { GotoIcon, IconButton, Waypoints as WaypointsIcon } from '@liam-hq/ui'
+import {
+  ChevronDown,
+  ChevronUp,
+  GotoIcon,
+  IconButton,
+  Waypoints as WaypointsIcon,
+} from '@liam-hq/ui'
 import { ReactFlowProvider, useReactFlow } from '@xyflow/react'
-import { type FC, useCallback } from 'react'
+import clsx from 'clsx'
+import { type FC, type MouseEvent, useCallback, useState } from 'react'
 import { ERDContent } from '../../../ERDContent'
 import styles from './RelatedTables.module.css'
 import { extractDBStructureForTable } from './extractDBStructureForTable'
@@ -27,38 +34,66 @@ export const RelatedTables: FC<Props> = ({ table }) => {
   })
   const { getNodes } = useReactFlow()
   const { version } = useVersion()
-  const handleClick = useCallback(() => {
-    const visibleNodeIds: string[] = nodes.map((node) => node.id)
-    const mainPaneNodes = getNodes()
-    const hiddenNodeIds = mainPaneNodes
-      .filter((node) => !visibleNodeIds.includes(node.id))
-      .map((node) => node.id)
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      const visibleNodeIds: string[] = nodes.map((node) => node.id)
+      const mainPaneNodes = getNodes()
+      const hiddenNodeIds = mainPaneNodes
+        .filter((node) => !visibleNodeIds.includes(node.id))
+        .map((node) => node.id)
 
-    replaceHiddenNodeIds(hiddenNodeIds)
-    updateActiveTableName(undefined)
-    openRelatedTablesLogEvent({
-      tableId: table.name,
-      platform: version.displayedOn,
-      gitHash: version.gitHash,
-      ver: version.version,
-      appEnv: version.envName,
-    })
-  }, [nodes, getNodes, table.name, version])
+      event.stopPropagation()
+      replaceHiddenNodeIds(hiddenNodeIds)
+      updateActiveTableName(undefined)
+      openRelatedTablesLogEvent({
+        tableId: table.name,
+        platform: version.displayedOn,
+        gitHash: version.gitHash,
+        ver: version.version,
+        appEnv: version.envName,
+      })
+    },
+    [nodes, getNodes, table.name, version],
+  )
+  const [isClosed, setIsClosed] = useState(false)
+  const handleClose = (event: MouseEvent) => {
+    event.stopPropagation()
+    setIsClosed(!isClosed)
+  }
+  const handleKeyDown = (event: { key: string }) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      setIsClosed(!isClosed)
+    }
+  }
 
   return (
-    <div>
-      <div className={styles.header}>
+    <>
+      <div
+        className={styles.header}
+        // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
+        role="button"
+        tabIndex={0}
+        onClick={handleClose}
+        onKeyDown={handleKeyDown}
+      >
         <div className={styles.iconTitleContainer}>
           <WaypointsIcon width={12} />
           <h2 className={styles.heading}>Related tables</h2>
         </div>
-        <IconButton
-          icon={<GotoIcon />}
-          tooltipContent="Open in main area"
-          onClick={handleClick}
-        />
+        <div className={styles.iconContainer}>
+          <IconButton
+            icon={<GotoIcon />}
+            tooltipContent="Open in main area"
+            onClick={handleClick}
+          />
+          <IconButton
+            icon={isClosed ? <ChevronDown /> : <ChevronUp />}
+            tooltipContent={isClosed ? 'Open' : 'Close'}
+            onClick={handleClose}
+          />
+        </div>
       </div>
-      <div className={styles.outerWrapper}>
+      <div className={clsx(!isClosed && styles.visible, styles.outerWrapper)}>
         <div className={styles.contentWrapper}>
           <ReactFlowProvider>
             <ERDContent
@@ -72,6 +107,6 @@ export const RelatedTables: FC<Props> = ({ table }) => {
           </ReactFlowProvider>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
@@ -1,7 +1,3 @@
-.wrapper {
-  border-bottom: 1px solid var(--global-border);
-}
-
 .header {
   display: grid;
   grid-auto-flow: column;
@@ -9,6 +5,7 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  cursor: pointer;
 }
 
 .iconTitleContainer {
@@ -24,6 +21,17 @@
   font-size: var(--font-size-2);
   font-style: normal;
   line-height: normal;
+}
+
+.listWrapper {
+  max-height: 0;
+  transition: max-height 0.1s var(--default-timing-function);
+  overflow: hidden;
+}
+
+.listWrapper.visible {
+  max-height: 100vh;
+  border-bottom: 1px solid var(--global-border);
 }
 
 .list {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx
@@ -1,6 +1,7 @@
 import type { Columns } from '@liam-hq/db-structure'
-import { Fingerprint } from '@liam-hq/ui'
-import type { FC } from 'react'
+import { ChevronDown, ChevronUp, Fingerprint, IconButton } from '@liam-hq/ui'
+import clsx from 'clsx'
+import { type FC, type MouseEvent, useState } from 'react'
 import styles from './Unique.module.css'
 
 type Props = {
@@ -8,24 +9,50 @@ type Props = {
 }
 
 export const Unique: FC<Props> = ({ columns }) => {
+  const [isClosed, setIsClosed] = useState(false)
+  const handleClose = (event: MouseEvent) => {
+    event.stopPropagation()
+    setIsClosed(!isClosed)
+  }
+  const handleKeyDown = (event: { key: string }) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      setIsClosed(!isClosed)
+    }
+  }
+
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.header}>
+    <>
+      <div
+        className={styles.header}
+        // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
+        role="button"
+        tabIndex={0}
+        onClick={handleClose}
+        onKeyDown={handleKeyDown}
+      >
         <div className={styles.iconTitleContainer}>
           <Fingerprint width={12} />
           <h2 className={styles.heading}>Unique</h2>
         </div>
+        <IconButton
+          icon={isClosed ? <ChevronDown /> : <ChevronUp />}
+          tooltipContent={isClosed ? 'Open' : 'Close'}
+          onClick={handleClose}
+        />
       </div>
-      <ul className={styles.list}>
-        {Object.entries(columns).map(([key, column]) => {
-          if (!column.unique) return null
-          return (
-            <li key={key} className={styles.listItem}>
-              {column.name}
-            </li>
-          )
-        })}
-      </ul>
-    </div>
+
+      <div className={clsx(!isClosed && styles.visible, styles.listWrapper)}>
+        <ul className={styles.list}>
+          {Object.entries(columns).map(([key, column]) => {
+            if (!column.unique) return null
+            return (
+              <li key={key} className={styles.listItem}>
+                {column.name}
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

In PR #607, we added a toggle feature to the Columns section. Now, we've extended this functionality to include all remaining sections: ``Indices``, ``Unique``, and ``RelatedTables``.

![ss 2788](https://github.com/user-attachments/assets/c4a6a3bd-3d0a-4680-a57a-ab6ee1c99488)


## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->


https://github.com/user-attachments/assets/04dbad17-77b0-4e1c-a726-89a949049925

Since the ｀``RelatedTable`` is fixed at the bottom, it may behave in the following way.


https://github.com/user-attachments/assets/3aea6007-0545-452c-964a-94641a9ad50a



## Other Information
<!-- Add any other relevant information for the reviewer. -->
