### PR TITLE
🔧 Update default ERD page redirect to Mastodon schema

### DIFF
--- a/frontend/apps/erd-web/app/page.tsx
+++ b/frontend/apps/erd-web/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export default function Page() {
-  redirect('/erd/galaxy')
+  redirect('/erd/p/github.com/mastodon/mastodon/blob/main/db/schema.rb')
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

To easily check the correctness of the ERD display, the redirect destination for `/` has been changed.
https://liam-erd-i4l9slvml-route-06-core.vercel.app

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
