### PR TITLE
💄 Update styles for responsive design and sticky headers in TableDetail components

### DIFF
--- a/.changeset/quick-llamas-chew.md
+++ b/.changeset/quick-llamas-chew.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+💄 Update styles for responsive design and sticky headers in TableDetail components

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.module.css
@@ -5,7 +5,15 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  background-color: var(--pane-background);
   cursor: pointer;
+}
+
+@media screen and (max-width: 767px) {
+  .header {
+    position: sticky;
+    top: 0;
+  }
 }
 
 .iconTitleContainer {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/Columns.tsx
@@ -35,6 +35,7 @@ export const Columns: FC<Props> = ({ columns }) => {
         tabIndex={0}
         onClick={handleClose}
         onKeyDown={handleKeyDown}
+        data-state={isClosed ? 'closed' : 'open'}
       >
         <div className={styles.iconTitleContainer}>
           <Rows3Icon width={12} />

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Indices/Indices.module.css
@@ -5,7 +5,16 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  background-color: var(--pane-background);
   cursor: pointer;
+}
+
+@media screen and (max-width: 767px) {
+  .header {
+    position: sticky;
+    /* Columns section header height */
+    top: 41px;
+  }
 }
 
 .iconTitleContainer {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.module.css
@@ -44,3 +44,9 @@
   bottom: 0;
   background-color: var(--pane-background, #232526);
 }
+
+@media screen and (max-width: 767px) {
+  .relatedTables {
+    position: initial;
+  }
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.module.css
@@ -5,7 +5,16 @@
   justify-content: space-between;
   padding: var(--spacing-2);
   border-bottom: 1px solid var(--global-border);
+  background-color: var(--pane-background);
   cursor: pointer;
+}
+
+@media screen and (max-width: 767px) {
+  .header {
+    position: sticky;
+    /* Columns section and Indices header height */
+    top: 82px;
+  }
 }
 
 .iconTitleContainer {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
For mobile devices, the ``RelatedTables`` are no longer fixed to the bottom but scroll along with the content.
The header of each section has also been made sticky on scroll.

Since there's a lot of duplicate code, I'll refactor it in the next PR.🙏

| Before  | After |
| ------------- | ------------- |
|  RelatedTables is fixed to the buttom ![ss 2790](https://github.com/user-attachments/assets/23b82b7d-fb25-4e61-b1ee-8f734a3de076) | RelatedTables is not fixed  ![ss 2791](https://github.com/user-attachments/assets/af8e18ea-f0d3-4002-90cf-ead9e5826783) |
| The section header is scrollable. ![ss 2793](https://github.com/user-attachments/assets/51e9f304-5661-4371-927e-a7566f3f6e72) | The section header is not scrollable. ![ss 2794](https://github.com/user-attachments/assets/87028075-8a18-4916-873e-916c79d8eabc) |








## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
