### PR TITLE
💄 Adjust UI of LeftPane on mobile widths

### DIFF
--- a/.changeset/seven-rivers-run.md
+++ b/.changeset/seven-rivers-run.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/ui": patch
+"@liam-hq/cli": patch
+---
+
+💄 Adjust UI of LeftPane on mobile widths

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/CopyLinkButton/CopyLinkButton.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/CopyLinkButton/CopyLinkButton.module.css
@@ -1,0 +1,19 @@
+.button {
+  display: grid;
+  grid-auto-flow: column;
+  gap: var(--spacing-2);
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--overlay-70);
+}
+
+.label {
+  color: var(--global-foreground);
+  font-family: var(--main-font);
+  font-size: var(--font-size-2);
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/CopyLinkButton/CopyLinkButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/CopyLinkButton/CopyLinkButton.tsx
@@ -1,0 +1,45 @@
+import { clickLogEvent } from '@/features/gtm/utils'
+import { useVersion } from '@/providers'
+import { Copy, SidebarMenuButton, SidebarMenuItem, useToast } from '@liam-hq/ui'
+import { type FC, useCallback } from 'react'
+import styles from './CopyLinkButton.module.css'
+
+export const CopyLinkButton: FC = () => {
+  const toast = useToast()
+  const { version } = useVersion()
+
+  const handleCopyUrl = useCallback(() => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        toast({
+          title: 'Link copied!',
+          status: 'success',
+        })
+      })
+      .catch((err) => {
+        console.error(err)
+        toast({
+          title: 'URL copy failed',
+          status: 'error',
+        })
+      })
+
+    clickLogEvent({
+      element: 'copyLinkButton',
+      platform: version.displayedOn,
+      ver: version.version,
+      gitHash: version.gitHash,
+      appEnv: version.envName,
+    })
+  }, [toast, version])
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton className={styles.button} onClick={handleCopyUrl}>
+        <Copy className={styles.icon} />
+        <span className={styles.label}>Copy Link</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/CopyLinkButton/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/CopyLinkButton/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyLinkButton'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -1,0 +1,81 @@
+.groupLabel {
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tableCount {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: var(--spacing-half);
+  color: var(--overlay-70);
+  font-family: var(--code-font);
+  font-size: var(--font-size-1);
+  font-weight: 400;
+
+  @media (min-width: 768px) {
+    display: none !important;
+  }
+}
+
+.tableCountDivider {
+  color: var(--overlay-20);
+}
+
+.tableCounterWrapper {
+  display: none;
+
+  @media (min-width: 768px) {
+    display: block;
+  }
+}
+
+.footer {
+  padding: 0;
+
+  @media (min-width: 768px) {
+    padding: var(--spacing-2);
+  }
+}
+
+.footerControls {
+  padding: var(--spacing-2) 0;
+  border-bottom: solid 1px var(--global-border);
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+}
+
+.footerLinks {
+  padding: var(--spacing-1) 0;
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+}
+
+.icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--overlay-70);
+}
+
+.versionWrapper {
+  padding: var(--spacing-2);
+}
+
+.version {
+  display: inline-block;
+  padding: var(--spacing-1) var(--spacing-2);
+  border-radius: var(--border-radius-full);
+  background: var(--pane-muted-background);
+}
+
+.versionText {
+  color: var(--global-mute-text);
+  font-family: var(--code-font);
+  font-size: var(--font-size-1);
+  font-weight: 400;
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -1,4 +1,10 @@
+import { useVersion } from '@/providers'
 import {
+  BookText,
+  GithubLogo,
+  LiamLogoMark,
+  Megaphone,
+  MessagesSquare,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -6,15 +12,52 @@ import {
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarMenu,
+  SidebarMenuItem,
   SidebarRail,
 } from '@liam-hq/ui'
 import { useNodes } from '@xyflow/react'
 import { useMemo } from 'react'
 import { isTableNode } from '../ERDContent'
+import { CopyLinkButton } from './CopyLinkButton'
+import styles from './LeftPane.module.css'
+import { MenuItemLink, type Props as MenuItemLinkProps } from './MenuItemLink'
 import { TableCounter } from './TableCounter'
 import { TableNameMenuButton } from './TableNameMenuButton'
 
+const menuItemLinks: MenuItemLinkProps[] = [
+  {
+    label: 'Release Notes',
+    href: 'https://github.com/liam-hq/liam/releases',
+    isExternalLink: true,
+    icon: <Megaphone className={styles.icon} />,
+  },
+  {
+    label: 'Documentation',
+    href: 'https://liambx.com/docs',
+    icon: <BookText className={styles.icon} />,
+  },
+  {
+    label: 'Community Forum',
+    href: 'https://github.com/liam-hq/liam/discussions',
+    isExternalLink: true,
+    icon: <MessagesSquare className={styles.icon} />,
+  },
+  {
+    label: 'Go to Homepage',
+    href: 'https://liambx.com/',
+    icon: <LiamLogoMark className={styles.icon} />,
+  },
+  {
+    label: 'Go to GitHub',
+    href: 'https://github.com/liam-hq/liam',
+    isExternalLink: true,
+    icon: <GithubLogo className={styles.icon} />,
+  },
+]
+
 export const LeftPane = () => {
+  const { version } = useVersion()
+
   const nodes = useNodes()
   const tableNodes = useMemo(() => {
     return nodes.filter(isTableNode).sort((a, b) => {
@@ -30,11 +73,21 @@ export const LeftPane = () => {
     })
   }, [nodes])
 
+  const allCount = tableNodes.length
+  const visibleCount = tableNodes.filter((node) => !node.hidden).length
+
   return (
     <Sidebar>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Tables</SidebarGroupLabel>
+          <SidebarGroupLabel className={styles.groupLabel} asChild>
+            <span>Tables</span>
+            <span className={styles.tableCount}>
+              {visibleCount}
+              <span className={styles.tableCountDivider}>/</span>
+              {allCount}
+            </span>
+          </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {tableNodes.map((node) => (
@@ -45,8 +98,25 @@ export const LeftPane = () => {
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter>
-        <TableCounter />
+      <SidebarFooter className={styles.footer}>
+        <div className={styles.tableCounterWrapper}>
+          <TableCounter allCount={allCount} visibleCount={visibleCount} />
+        </div>
+        <SidebarMenu className={styles.footerControls}>
+          <CopyLinkButton />
+        </SidebarMenu>
+        <SidebarMenu className={styles.footerLinks}>
+          {menuItemLinks.map((item) => (
+            <MenuItemLink {...item} key={item.label} />
+          ))}
+          <SidebarMenuItem className={styles.versionWrapper}>
+            <div className={styles.version}>
+              <span
+                className={styles.versionText}
+              >{`${version.version} + ${version.gitHash.slice(0, 7)} (${version.date})`}</span>
+            </div>
+          </SidebarMenuItem>
+        </SidebarMenu>
       </SidebarFooter>
 
       <SidebarRail />

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/MenuItemLink/MenuItemLink.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/MenuItemLink/MenuItemLink.module.css
@@ -1,0 +1,13 @@
+.link {
+  display: grid;
+  grid-auto-flow: column;
+  gap: var(--spacing-2);
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.label {
+  color: var(--global-foreground);
+  font-family: var(--main-font);
+  font-size: var(--font-size-2);
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/MenuItemLink/MenuItemLink.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/MenuItemLink/MenuItemLink.tsx
@@ -1,0 +1,33 @@
+import { SidebarMenuButton, SidebarMenuItem } from '@liam-hq/ui'
+import type { FC, ReactNode } from 'react'
+import styles from './MenuItemLink.module.css'
+
+export type Props = {
+  label: string
+  href: string
+  isExternalLink?: boolean
+  icon: ReactNode
+}
+
+export const MenuItemLink: FC<Props> = ({
+  label,
+  href,
+  isExternalLink,
+  icon,
+}) => {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild>
+        <a
+          className={styles.link}
+          href={href}
+          target={isExternalLink ? '_blank' : '_self'}
+          rel={isExternalLink ? 'noreferrer' : ''}
+        >
+          {icon}
+          <span className={styles.label}>{label}</span>
+        </a>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/MenuItemLink/index.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/MenuItemLink/index.ts
@@ -1,0 +1,1 @@
+export * from './MenuItemLink'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableCounter/TableCounter.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableCounter/TableCounter.tsx
@@ -1,14 +1,13 @@
 import { Table2 } from '@liam-hq/ui'
-import { useNodes } from '@xyflow/react'
 import type { FC } from 'react'
 import styles from './TableCounter.module.css'
 
-export const TableCounter: FC = () => {
-  const tableNodes = useNodes().filter((node) => node.type === 'table')
+type Props = {
+  allCount: number
+  visibleCount: number
+}
 
-  const allCount = tableNodes.length
-  const visibleCount = tableNodes.filter((node) => !node.hidden).length
-
+export const TableCounter: FC<Props> = ({ allCount, visibleCount }) => {
   return (
     <div className={styles.wrapper}>
       <Table2 width="12px" />

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -324,9 +324,7 @@ const SidebarGroupContent = forwardRef<HTMLDivElement, ComponentProps<'div'>>(
 SidebarGroupContent.displayName = 'SidebarGroupContent'
 
 const SidebarMenu = forwardRef<HTMLUListElement, ComponentProps<'ul'>>(
-  ({ className, ...props }, ref) => (
-    <ul ref={ref} data-sidebar="menu" {...props} />
-  ),
+  ({ ...props }, ref) => <ul ref={ref} data-sidebar="menu" {...props} />,
 )
 SidebarMenu.displayName = 'SidebarMenu'
 

--- a/frontend/packages/ui/src/icons/index.ts
+++ b/frontend/packages/ui/src/icons/index.ts
@@ -30,6 +30,7 @@ export * from './Eye'
 export * from './EyeClosed'
 
 export {
+  Copy,
   KeyRound,
   Hash,
   Link,

--- a/frontend/packages/ui/src/styles/variables.css
+++ b/frontend/packages/ui/src/styles/variables.css
@@ -6,10 +6,10 @@
   --code-font: 'ui-monospace', 'IBM Plex Mono', SF Mono, Menlo, Monaco, Consolas,
     monospace;
 
+  --z-index-toolbar: 800;
   --z-index-sidebar: 900;
   --z-index-drawer: 900;
   --z-index-header: 1000;
-  --z-index-toolbar: 1050;
   --z-index-dropdown-menu: 1100;
   --z-index-tooltip: 2000;
   --z-index-toast: 3000;


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

The information that was displayed on the AppBar in mobile width has been adjusted to be displayed on the LeftPane side.

## Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

## Changes
<!-- List the main changes made in this PR. -->

N/A

## Testing
<!-- Briefly describe the testing steps or results. -->

**@liam-hq/cli**

| mobile | desktop |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/052de265-f206-424f-8899-db6b589b72cc" /> | ![スクリーンショット 2025-01-31 11 34 48](https://github.com/user-attachments/assets/79603841-cda2-4c61-8e15-5703fbc924a2) | 


**@liam-hq/erd-web**

| mobile | desktop |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/412733df-c6cf-4d9b-b436-ce04a854e3b0" /> | ![スクリーンショット 2025-01-31 11 34 27](https://github.com/user-attachments/assets/b030b634-2c20-4e79-ba4a-a21f573be887) | 

## Other Information
<!-- Add any other relevant information for the reviewer. -->

N/A