### PR TITLE
🐛  Fixed forever loading of related tables section for table without relationships

### DIFF
--- a/.changeset/serious-olives-watch.md
+++ b/.changeset/serious-olives-watch.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+🐛 Fixed forever loading of related tables section for table without relationships

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -3,6 +3,7 @@ import {
   addHiddenNodeIds,
   updateActiveTableName,
   updateShowMode,
+  useDBStructureStore,
 } from '@/stores'
 import {
   getActiveTableNameFromUrl,
@@ -20,15 +21,19 @@ export const useInitialAutoLayout = (
   shouldFitViewToActiveTable: boolean,
 ) => {
   const [initializeComplete, setInitializeComplete] = useState(false)
+  const dbStructure = useDBStructureStore()
 
-  const tableNodesInitialized = useMemo(
-    () =>
-      nodes
-        .filter((node) => node.type === 'table')
-        .some((node) => node.measured),
-    [nodes],
-  )
+  const tableNodesInitialized = useMemo(() => {
+    const tableNodes = nodes.filter((node) => node.type === 'table')
+    const isInitializedDbStructure = Object.keys(dbStructure.tables).length > 0
+
+    return (
+      tableNodes.some((node) => node.measured) ||
+      (isInitializedDbStructure && tableNodes.length === 0)
+    )
+  }, [nodes, dbStructure.tables])
   const { getEdges, setNodes, setEdges, fitView } = useCustomReactflow()
+
   const {
     actions: { setLoading },
   } = useERDContentContext()


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

The table without the relationShip has a node length of 1.
As a result, tablenodesinitialized was always false
![CleanShot 2025-01-31 at 23 50 20@2x](https://github.com/user-attachments/assets/97d65085-3a10-4e47-b476-085964ff658b)

![CleanShot 2025-01-31 at 23 50 30@2x](https://github.com/user-attachments/assets/9f2be331-f1b2-4b52-bb39-e322cec9b545)


## Related Issue
<!-- Mention the related issue number if applicable. -->
resolve: #347 


## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
