### PR TITLE
feat: Add external link flag to LeftPane menu items

### DIFF
--- a/.changeset/perfect-pots-join.md
+++ b/.changeset/perfect-pots-join.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🔧Add ExternalLink flag to some LeftPane menu items

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -34,6 +34,7 @@ const menuItemLinks: MenuItemLinkProps[] = [
   {
     label: 'Documentation',
     href: 'https://liambx.com/docs',
+    isExternalLink: true,
     icon: <BookText className={styles.icon} />,
   },
   {
@@ -45,6 +46,7 @@ const menuItemLinks: MenuItemLinkProps[] = [
   {
     label: 'Go to Homepage',
     href: 'https://liambx.com/',
+    isExternalLink: true,
     icon: <LiamLogoMark className={styles.icon} />,
   },
   {


### PR DESCRIPTION
The documentation and home page links in the mobile version should open in a separate tab, just as they do in the PC version.