### PR TITLE
🎨 Make SidebarFooter appear after scrolling when table list overflows

### DIFF
--- a/.changeset/twenty-pigs-accept.md
+++ b/.changeset/twenty-pigs-accept.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🎨 Make SidebarFooter appear after scrolling when table list overflows

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -39,16 +39,16 @@
   }
 }
 
-.footerControls {
+.contentControls {
   padding: var(--spacing-2) 0;
-  border-bottom: solid 1px var(--global-border);
+  border-block: 1px solid var(--global-border);
 
   @media (min-width: 768px) {
     display: none;
   }
 }
 
-.footerLinks {
+.contentLinks {
   padding: var(--spacing-1) 0;
 
   @media (min-width: 768px) {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -96,6 +96,23 @@ export const LeftPane = () => {
                 <TableNameMenuButton key={node.id} node={node} />
               ))}
             </SidebarMenu>
+
+            <SidebarMenu className={styles.contentControls}>
+              <CopyLinkButton />
+            </SidebarMenu>
+
+            <SidebarMenu className={styles.contentLinks}>
+              {menuItemLinks.map((item) => (
+                <MenuItemLink {...item} key={item.label} />
+              ))}
+              <SidebarMenuItem className={styles.versionWrapper}>
+                <div className={styles.version}>
+                  <span
+                    className={styles.versionText}
+                  >{`${version.version} + ${version.gitHash.slice(0, 7)} (${version.date})`}</span>
+                </div>
+              </SidebarMenuItem>
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
@@ -104,21 +121,6 @@ export const LeftPane = () => {
         <div className={styles.tableCounterWrapper}>
           <TableCounter allCount={allCount} visibleCount={visibleCount} />
         </div>
-        <SidebarMenu className={styles.footerControls}>
-          <CopyLinkButton />
-        </SidebarMenu>
-        <SidebarMenu className={styles.footerLinks}>
-          {menuItemLinks.map((item) => (
-            <MenuItemLink {...item} key={item.label} />
-          ))}
-          <SidebarMenuItem className={styles.versionWrapper}>
-            <div className={styles.version}>
-              <span
-                className={styles.versionText}
-              >{`${version.version} + ${version.gitHash.slice(0, 7)} (${version.date})`}</span>
-            </div>
-          </SidebarMenuItem>
-        </SidebarMenu>
       </SidebarFooter>
 
       <SidebarRail />


### PR DESCRIPTION




## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

🎨 Make SidebarFooter appear after scrolling when table list overflows 

Refactored Sidebar layout to allow the table list to occupy more space initially. The entire sidebar is now scrollable, and SidebarFooter is displayed only after scrolling.


before:


https://github.com/user-attachments/assets/ef4aed8b-adc0-46a9-a5fe-ac93dc22d525

after:

https://github.com/user-attachments/assets/4accbb26-2939-4a47-9229-95f834b7e88e





## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
