### PR TITLE
🎨 Hide Sidebar trigger at canvas on mobile view

### DIFF
--- a/.changeset/seven-chicken-jam.md
+++ b/.changeset/seven-chicken-jam.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🎨 Hide Sidebar trigger at canvas on mobile view

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.module.css
@@ -62,4 +62,8 @@
   .main {
     overflow: hidden;
   }
+
+  .triggerWrapper {
+    display: none;
+  }
 }


### PR DESCRIPTION


## Summary  
<!-- Briefly describe the changes and the purpose of the PR. -->  

Hide Sidebar trigger on the canvas on mobile view.

Since `1` already provides the necessary functionality on mobile, `2` becomes a redundant button.

<img width="664" alt="12" src="https://github.com/user-attachments/assets/fd1521e4-e51f-4438-bfa2-fcffb0cd22e3" />  



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
