### PR TITLE
💄Improve version display styling with flexbox alignment

### DIFF
--- a/.changeset/bright-cougars-nail.md
+++ b/.changeset/bright-cougars-nail.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+💄Improve version display styling with flexbox alignment

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -67,7 +67,8 @@
 }
 
 .version {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   padding: var(--spacing-1) var(--spacing-2);
   border-radius: var(--border-radius-full);
   background: var(--pane-muted-background);


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

The LeftPane version was slightly lower than the center. 
It has been modified to display in the vertical center.

## Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

| Before | After |
|--------|--------|
| ![スクリーンショット 2025-02-04 17 45 23](https://github.com/user-attachments/assets/df9b1899-3483-42be-a820-310b87fa0178) | ![スクリーンショット 2025-02-04 17 45 07](https://github.com/user-attachments/assets/c59592d7-c7e1-4da3-bc2f-76b21461d40e) | 

## Other Information
<!-- Add any other relevant information for the reviewer. -->

N/A