### PR TITLE
🐛 Improve ERD auto-layout rendering with state-based approach

### DIFF
--- a/.changeset/spotty-berries-collect.md
+++ b/.changeset/spotty-berries-collect.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 Improve ERD auto-layout rendering with state-based approach


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Fixed an issue in mobile Safari where the initial auto layout was not applied. 

https://github.com/user-attachments/assets/dd726ef7-1441-4bb9-bab4-2efe911b3111


The problem was caused by executing setInitializeComplete(true) and performing layout calculations before the nodes were updated by setNodes. 
To resolve this, setInitializeComplete is now executed after setNodes has completed.

## Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->


### cli ver.

| Chrome / Mac | Safari / Mac |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/7fcaa2ad-7c0e-4f2b-96b8-3b4a14a748aa" /> | <video src="https://github.com/user-attachments/assets/acd3342f-72b2-4587-a094-804c365dd9ce" /> | 

| Chrome / iPhone | Safari / iPhone |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/a47ed159-7edd-4a45-ac0f-2ff00c9961bb" /> | <video src="https://github.com/user-attachments/assets/7537ebe5-8c8f-447e-9322-d1d90a429fa4" /> | 



### web ver.

| Chrome / Mac | Safari / Mac |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/72069100-28e3-48f7-96e5-973d46117bbf" /> | <video src="https://github.com/user-attachments/assets/1707e359-a270-496e-9fc4-996a69ab4715" /> | 

| Chrome / iPhone | Safari / iPhone |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/4b05f4b1-26a0-4c85-880a-c5364fbdd64a" /> | <video src="https://github.com/user-attachments/assets/3f70dd88-dbd6-4df8-a83a-1e87b45dcf0d" /> | 




## Other Information
<!-- Add any other relevant information for the reviewer. -->
