### PR TITLE
🐛 Removed a green dot on the left top when it rendered

### DIFF
--- a/.changeset/fast-pugs-change.md
+++ b/.changeset/fast-pugs-change.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 Removed a green dot on the left top when it rendered

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/RelationshipEdge/RelationshipEdge.tsx
@@ -59,7 +59,7 @@ export const RelationshipEdge: FC<Props> = ({
             fill="url(#myGradient)"
           >
             <animateMotion
-              begin={`${i * (ANIMATE_DURATION / PARTICLE_COUNT)}s`}
+              begin={`${-i * (ANIMATE_DURATION / PARTICLE_COUNT)}s`}
               dur={`${ANIMATE_DURATION}s`}
               repeatCount="indefinite"
               rotate="auto"


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Removed a green dot on the left top when it rendered.
The green dot on the let top is an group of `ellipse` objects who are specified positive values of `begin` attributes.

The `animateMotion` element will position the object at its original coordinates (`cx`, `cy`) before the time specified in the begin attribute has elapsed. If a negative value is specified to `begin` attribute, the object is considered to have started moving before it is rendered.
I created a minimal reproduction how positive/negative `begin` values works. I hope this will help your understanding.
https://codepen.io/tnyo43/pen/vEBqNxw


## Related Issue
<!-- Mention the related issue number if applicable. -->

resolve: https://github.com/liam-hq/liam/issues/641

## Changes
<!-- List the main changes made in this PR. -->

- specify non-positive number to `begin` attribute of `animateMotion` of `ellipse` object to make them move from the beginning.

## Testing
<!-- Briefly describe the testing steps or results. -->

1. run `pnpm run dev`
2. go to http://localhost:3001/erd/p/raw.githubusercontent.com/liam-hq/liam/b7b9228de8840eb4ac3ca8342ebbda6d611d7ae5/frontend/packages/db-structure/src/parser/schemarb/input/schema1.in.rb?showMode=ALL_FIELDS&active=users
3. check the green dot is not rendered

## Other Information
<!-- Add any other relevant information for the reviewer. -->

Unfortunately, it looks that this change won't resolve this issue completely. In my laptop (macOS 15.2, M1 Pro, 32GB), with the today's latest Chrome (version 132.0.6834.160), it shows a green dot in a very small period of time. It doesn't happen in Firefox (version 135.0 (aarch64)) tho.
It's obvious especially in rigt bottom panel.

A green dot in Chrome

https://github.com/user-attachments/assets/bcacabb9-f530-423d-b85b-ff749f9cb17b

No green dot in Firefox

https://github.com/user-attachments/assets/67aa00d2-4e06-498b-bfff-df3338815b17

I believe this is a performance issue because it's rendering a large number of ellipse object (six times more than the number of edges). We can take other actions to solve this problem if you would like. However, this change resolve the core issue and the most meaningful step forward.

---
I really love your idea to implement that particles on edges and make it look be connected with directions. I hope this change will make a bit better decoration with it 😉 
