### PR TITLE
🎨 Add Mr.Jack svg to NetworkError

### DIFF
--- a/.changeset/fresh-shirts-stare.md
+++ b/.changeset/fresh-shirts-stare.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🎨 Add Mr.Jack svg to NetworkError

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx
@@ -14,6 +14,7 @@ import * as v from 'valibot'
 type ErrorObject = {
   name: string
   message: string
+  instruction?: string
 }
 
 type ERDViewerProps = {

--- a/frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx
+++ b/frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx
@@ -91,31 +91,40 @@ export default async function Page({
   const blankDbStructure = { tables: {}, relationships: {} }
 
   const contentUrl = resolveContentUrl(url)
+  const weCannotAccess = `Our signal's lost in the void! No access at this time..`
+  const pleaseCheck = `Double-check the transmission link ${url} and initiate contact again.`
   if (!contentUrl) {
     return (
       <ERDViewer
         dbStructure={blankDbStructure}
         defaultSidebarOpen={false}
-        errorObjects={[{ name: 'NetworkError', message: 'Invalid URL' }]}
+        errorObjects={[
+          {
+            name: 'NetworkError',
+            message: weCannotAccess,
+            instruction: pleaseCheck,
+          },
+        ]}
       />
     )
   }
-  console.warn(`Fetching content from ${contentUrl}`)
   const networkErrorObjects: {
     name: 'NetworkError'
     message: string
+    instruction?: string
   }[] = []
-  const pleaseCheck = `Please check the URL ${url} and try again`
   const res = await fetch(contentUrl, { cache: 'no-store' }).catch((e) => {
     if (e instanceof Error) {
       networkErrorObjects.push({
         name: 'NetworkError',
-        message: `${e.name}: ${e.message}. ${pleaseCheck}.`,
+        message: `${e.name}: ${e.message}. ${weCannotAccess}`,
+        instruction: pleaseCheck,
       })
     } else {
       networkErrorObjects.push({
         name: 'NetworkError',
-        message: `Unknown error. ${pleaseCheck}.`,
+        message: `Unknown NetworkError. ${weCannotAccess}`,
+        instruction: pleaseCheck,
       })
     }
   })
@@ -123,6 +132,7 @@ export default async function Page({
     networkErrorObjects.push({
       name: 'NetworkError',
       message: `Unknown error. ${pleaseCheck}.`,
+      instruction: pleaseCheck,
     })
   if (!res || networkErrorObjects.length > 0) {
     return (
@@ -141,7 +151,8 @@ export default async function Page({
         errorObjects={[
           {
             name: 'NetworkError',
-            message: `HTTP status is ${res.status}: ${res.statusText}. ${pleaseCheck}.`,
+            message: `HTTP status is ${res.status}: ${res.statusText}.`,
+            instruction: pleaseCheck,
           },
         ]}
       />
@@ -170,7 +181,9 @@ export default async function Page({
         errorObjects={[
           {
             name: 'NetworkError',
-            message: 'We could not detect the format of the file',
+            message: weCannotAccess,
+            instruction:
+              'Please specify the format in the URL query parameter `format`',
           },
         ]}
       />

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/ErrorDisplay.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/ErrorDisplay.tsx
@@ -7,6 +7,7 @@ import { ParseErrorDisplay } from './ParseErrorDisplay'
 type ErrorObject = {
   name: string
   message: string
+  instruction?: string
 }
 
 type Props = {
@@ -18,15 +19,15 @@ export const ErrorDisplay: FC<Props> = ({ errors }) => {
   if (!error) return <></>
   return (
     <div className={styles.wrapper}>
-      <div className={styles.main}>
-        <div className={styles.iconWrapper}>
-          <InfoIcon color="var(--callout-warning-text)" />
+      {error.name !== 'NetworkError' && (
+        <div className={styles.main}>
+          <div className={styles.iconWrapper}>
+            <InfoIcon color="var(--callout-warning-text)" />
+          </div>
+          <ParseErrorDisplay errors={errors} />
         </div>
-        {error.name === 'NetworkError' && (
-          <NetworkErrorDisplay errors={errors} />
-        )}
-        {error.name !== 'NetworkError' && <ParseErrorDisplay errors={errors} />}
-      </div>
+      )}
+      {error.name === 'NetworkError' && <NetworkErrorDisplay errors={errors} />}
     </div>
   )
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/MrJack.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/MrJack.tsx
@@ -1,0 +1,376 @@
+import type { FC } from 'react'
+
+// type Props = ComponentPropsWithoutRef<'svg'>
+
+export const MrJack: FC = () => {
+  return (
+    <svg
+      role="img"
+      aria-label="Mr. Jack is gazing at the sky through a telescope"
+      width="233"
+      height="176"
+      viewBox="0 0 233 176"
+      fill="none"
+    >
+      <path
+        d="M116.269 175.001C152.75 175.001 182.324 145.242 182.324 108.531C182.324 71.8208 152.75 42.0612 116.269 42.0612C79.7881 42.0612 50.2145 71.8208 50.2145 108.531C50.2145 145.242 79.7881 175.001 116.269 175.001Z"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <g filter="url(#filter0_i_2102_166864)">
+        <path
+          d="M69.6872 88.6641C70.5033 85.1354 69.7738 81.9491 68.0579 81.5472C66.3419 81.1454 64.2894 83.6803 63.4734 87.209C62.6574 90.7377 63.3869 93.924 65.1028 94.3258C66.8187 94.7276 68.8712 92.1928 69.6872 88.6641Z"
+          fill="#141616"
+        />
+      </g>
+      <g filter="url(#filter1_i_2102_166864)">
+        <path
+          d="M65.8308 118.586C67.0851 118.505 67.9681 116.352 67.8031 113.778C67.6382 111.204 66.4877 109.184 65.2335 109.265C63.9793 109.347 63.0962 111.499 63.2612 114.073C63.4262 116.647 64.5766 118.667 65.8308 118.586Z"
+          fill="#141616"
+        />
+      </g>
+      <g filter="url(#filter2_i_2102_166864)">
+        <path
+          d="M78.4405 107.509C79.388 107.447 80.055 105.82 79.9303 103.875C79.8056 101.929 78.9365 100.402 77.9889 100.463C77.0414 100.525 76.3744 102.152 76.4991 104.098C76.6238 106.043 77.493 107.57 78.4405 107.509Z"
+          fill="#141616"
+        />
+      </g>
+      <g filter="url(#filter3_i_2102_166864)">
+        <path
+          d="M84.3888 12.9106L84.5875 9.70057C84.5875 9.70057 81.5566 4.30057 84.7465 2.64057C87.1216 1.41057 89.278 2.24057 91.4245 3.83057C92.6866 4.77057 94.9523 5.36057 96.4728 5.14057C100.319 4.57057 107.166 3.91057 112.75 5.28057C114.082 5.61057 115.463 5.36057 116.556 4.58057C119.001 2.82057 122.648 0.120566 125.172 1.28057C129.813 3.42057 126.474 8.75057 126.196 11.3006C125.918 13.8506 134.305 24.3506 134.305 35.9606C134.305 45.1506 145.663 45.8206 145.574 50.9706C145.485 56.1306 139.015 58.5106 131.353 53.4106C123.692 48.3106 124.775 55.9106 118.892 56.0006C113.019 56.1006 110.703 54.5806 107.543 51.3106C107.543 51.3106 105.238 49.4006 102.823 52.3906C100.627 55.1206 96.6417 56.3906 92.786 53.0106C88.9302 49.6406 87.1613 52.9106 84.4186 54.3906C81.6758 55.8806 77.204 53.8206 75.9121 50.5806C74.6202 47.3406 80.2746 47.6806 81.4175 41.5006L81.6261 40.3206L81.3479 39.9606C78.5356 36.7406 75.1866 29.5006 75.1866 29.5006L84.3788 12.8906L84.3888 12.9106Z"
+          fill="#141616"
+        />
+      </g>
+      <path
+        d="M93.1934 16.9705L71.4999 9.29053C74.1432 10.6905 76.0612 14.7805 76.0413 19.5205C76.0214 24.6305 73.7656 28.8005 70.7943 29.6305L89.0892 28.1605C89.7352 22.3805 94.4555 23.5505 94.4555 23.5505C94.8431 18.9405 93.1835 16.9605 93.1835 16.9605L93.1934 16.9705Z"
+        fill="#008543"
+      />
+      <path
+        d="M101.223 27.3306C94.7039 25.0906 94.6939 22.7006 91.981 23.7706C87.6582 25.4806 89.8842 32.5806 97.1783 39.7806C104.472 46.9806 103.956 47.6306 107.126 50.9106C110.286 54.1806 113.019 56.1106 118.892 56.0106C124.765 55.9106 123.692 48.3206 131.353 53.4206C139.015 58.5206 145.475 56.1306 145.574 50.9806C145.663 45.8206 134.474 45.1506 134.305 35.9706C134.136 26.7806 127.826 16.4006 127.18 11.9706C126.812 9.44059 129.813 3.43059 125.182 1.30059C122.658 0.140586 119.011 2.84059 116.566 4.60059C115.473 5.38059 114.092 5.62059 112.76 5.30059C107.175 3.93059 100.328 4.59059 96.4827 5.16059C94.9026 5.39059 92.5077 4.74059 91.2854 3.74059C90.2618 2.90059 89.0693 2.29059 87.7476 2.21059C81.8149 1.86059 83.2161 6.63059 84.1204 8.74059C84.4285 9.46059 84.5577 10.2406 84.4981 11.0106L84.3092 13.4906"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M111.548 19.2506C108.984 20.9906 112.323 27.2206 115.95 24.6806C119.577 22.1406 113.764 17.7506 111.548 19.2506Z"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M94.2965 23.5306C94.9126 18.1506 93.1935 16.9706 93.1935 16.9706L70.6453 8.93059"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M70.1384 29.7606L89.2979 28.2106"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M82.7888 33.6506C82.7888 33.6506 82.5702 35.3406 81.4274 41.5206C80.2846 47.7006 74.6301 47.3606 75.922 50.6006C77.2139 53.8406 81.6857 55.8906 84.4285 54.4106C87.1712 52.9206 88.9401 49.6506 92.7959 53.0306C96.6516 56.4006 100.805 54.8906 102.982 52.1406"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M69.7765 29.7946C73.3379 29.7339 76.1459 24.9799 76.0482 19.1762C75.9506 13.3725 72.9843 8.71692 69.4229 8.77759C65.8615 8.83827 63.0535 13.5923 63.1512 19.396C63.2488 25.1996 66.2151 29.8553 69.7765 29.7946Z"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M71.0138 25.0595C69.2182 25.0106 67.8431 22.3734 67.9401 19.1664C68.0372 15.9594 69.5579 13.4035 71.3536 13.4523"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M71.6256 22.4005C72.4159 22.4005 73.0566 21.0797 73.0566 19.4505C73.0566 17.8212 72.4159 16.5005 71.6256 16.5005C70.8353 16.5005 70.1946 17.8212 70.1946 19.4505C70.1946 21.0797 70.8353 22.4005 71.6256 22.4005Z"
+        fill="#1DED83"
+      />
+      <path
+        d="M75.1965 29.5206C75.1965 29.5206 78.5355 36.7606 81.3578 39.9806"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M69.7765 29.7946C73.3379 29.7339 76.1459 24.9799 76.0482 19.1762C75.9506 13.3725 72.9843 8.7169 69.4229 8.77758C65.8615 8.83826 63.0535 13.5923 63.1512 19.3959C63.2488 25.1996 66.2151 29.8552 69.7765 29.7946Z"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M217.71 104.521H220.761"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M228.016 104.521H231.056"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M224.388 97.8005V100.871"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M224.388 108.171V111.231"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10.2947 103.291H11.9642"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.7379 103.291H19.4074"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.856 98.7006V100.381"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.856 106.191V107.871"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M222.967 55.3705H224.637"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M230.4 55.3705H232.08"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M227.519 50.7805V52.4705"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M227.519 58.2705V59.9505"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M198.084 36.7706V42.2406"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M200.807 39.5106H195.371"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3.44788 128.491V133.961"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.16079 131.221H0.724976"
+        stroke="#1DED83"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M186.284 96.184C171.368 107.154 149.496 119.394 124.225 130.314C73.7422 152.124 28.7949 160.384 23.836 148.754C23.359 147.624 23.2696 146.354 23.5479 144.954"
+        stroke="#1DED83"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M175.572 66.094C192.634 63.184 204.271 64.174 206.656 69.774C207.392 71.494 209.926 75.994 198.855 85.584"
+        stroke="#1DED83"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M44.2576 122.304C38.7523 126.344 34.1909 130.214 30.7526 133.784"
+        stroke="#1DED83"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M26.5787 140.084C27.5886 140.084 28.4072 139.26 28.4072 138.244C28.4072 137.228 27.5886 136.404 26.5787 136.404C25.5689 136.404 24.7502 137.228 24.7502 138.244C24.7502 139.26 25.5689 140.084 26.5787 140.084Z"
+        fill="#1DED83"
+      />
+      <path
+        d="M195.655 89.0452L191.476 88.5006L190.935 92.7055L195.114 93.2501L195.655 89.0452Z"
+        fill="#1DED83"
+      />
+      <defs>
+        <filter
+          id="filter0_i_2102_166864"
+          x="63.1392"
+          y="81.5054"
+          width="6.88232"
+          height="12.8623"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="BackgroundImageFix"
+            result="shape"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="3" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.113725 0 0 0 0 0.929412 0 0 0 0 0.513726 0 0 0 0.4 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="shape"
+            result="effect1_innerShadow_2102_166864"
+          />
+        </filter>
+        <filter
+          id="filter1_i_2102_166864"
+          x="63.2413"
+          y="109.263"
+          width="4.58167"
+          height="9.32538"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="BackgroundImageFix"
+            result="shape"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="3" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.113725 0 0 0 0 0.929412 0 0 0 0 0.513726 0 0 0 0.4 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="shape"
+            result="effect1_innerShadow_2102_166864"
+          />
+        </filter>
+        <filter
+          id="filter2_i_2102_166864"
+          x="76.4841"
+          y="100.462"
+          width="3.46118"
+          height="7.04895"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="BackgroundImageFix"
+            result="shape"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="3" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.113725 0 0 0 0 0.929412 0 0 0 0 0.513726 0 0 0 0.4 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="shape"
+            result="effect1_innerShadow_2102_166864"
+          />
+        </filter>
+        <filter
+          id="filter3_i_2102_166864"
+          x="75.1866"
+          y="1"
+          width="70.3878"
+          height="55.2433"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="BackgroundImageFix"
+            result="shape"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="14.5" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.113725 0 0 0 0 0.929412 0 0 0 0 0.513726 0 0 0 0.5 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="shape"
+            result="effect1_innerShadow_2102_166864"
+          />
+        </filter>
+      </defs>
+    </svg>
+  )
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/NetworkErrorDisplay.module.css
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/NetworkErrorDisplay.module.css
@@ -1,46 +1,70 @@
 .wrapper {
   display: flex;
+  padding: var(--spacing-5, 20px);
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--global-background);
+}
+
+.message {
+  display: flex;
+  padding-top: var(--spacing-10, 40px);
   flex-direction: column;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--spacing-5, 20px);
 }
 
-.message1 {
+.inner {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: var(--spacing-1, 4px);
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+  align-self: stretch;
 }
 
-.message1Title {
-  color: var(--callout-warning-text, #c3b476);
+.silentHere {
+  align-self: stretch;
+  color: var(--primary-color, #1ded83);
+  text-align: center;
   font-family: var(--message-font, Montserrat);
-  font-size: var(--font-size-6);
-  font-weight: 700;
-  line-height: 160%;
+  font-size: var(--font-size-18, 48px);
 }
 
-.message1Sentence {
-  max-width: 300px;
+.errorMessage {
+  align-self: stretch;
+  color: var(--global-foreground, #fff);
+  text-align: center;
+  font-family: var(--message-font-en, Montserrat);
+  font-size: var(--font-size-10, 24px);
+  font-weight: 500;
+  line-height: 120%;
+}
+
+.instruction {
+  align-self: stretch;
+  color: var(--overlay-70, rgba(255, 255, 255, 0.7));
+  text-align: center;
+  font-size: var(--font-size-6, 16px);
+  line-height: 160%;
+  overflow: hidden;
+  word-break: break-word;
   overflow-wrap: break-word;
-  color: var(--callout-warning-text, #c3b476);
-  font-size: var(--font-size-4);
-  font-weight: 400;
-  line-height: 160%;
 }
 
-@media screen and (min-width: 768px) {
-  .message1 {
-    gap: var(--spacing-2, 8px);
+@media screen and (max-width: 768px) {
+  .silentHere {
+    font-size: var(--font-size-10, 24px);
   }
 
-  .message1Title {
-    font-size: var(--font-size-8, 20px);
+  .errorMessage {
+    font-size: var(--font-size-4, 13px);
   }
 
-  .message1Sentence {
-    max-width: 600px;
-    font-size: var(--font-size-5, 14px);
+  .instruction {
+    font-size: var(--font-size-4, 13px);
   }
 }

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/NetworkErrorDisplay.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/NetworkErrorDisplay.tsx
@@ -1,9 +1,11 @@
 import type { FC } from 'react'
+import { MrJack } from './MrJack'
 import styles from './NetworkErrorDisplay.module.css'
 
 type ErrorObject = {
   name: string
   message: string
+  instruction?: string
 }
 
 type Props = {
@@ -13,23 +15,18 @@ type Props = {
 export const NetworkErrorDisplay: FC<Props> = ({ errors }) => {
   return (
     <div className={styles.wrapper}>
-      <div className={styles.message1}>
-        <div className={styles.message1Title}>
-          Oh no! We’ve encountered some NetworkErrors 🛸💫
-        </div>
-
-        {errors[0] && (
-          <div className={styles.message1Sentence}>
-            <ul>
-              <li key={errors[0].name}>
-                <code>
-                  {errors[0].name}: {errors[0].message}
-                </code>
-              </li>
-            </ul>
-          </div>
-        )}
+      <div>
+        <MrJack />
       </div>
+      {errors[0] && (
+        <div className={styles.message}>
+          <div className={styles.inner}>
+            <div className={styles.silentHere}>Hmm, it's silent here...</div>
+            <div className={styles.errorMessage}>{errors[0].message}</div>
+            <div className={styles.instruction}>{errors[0].instruction}</div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### **User description**
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

| mobile | desktop |
|--------|--------|
| <img width="382" alt="スクリーンショット 2025-02-06 9 51 56" src="https://github.com/user-attachments/assets/34b99205-ea8d-412f-8305-ce166b718e27" /> | <img width="1341" alt="スクリーンショット 2025-02-06 9 51 43" src="https://github.com/user-attachments/assets/14b39336-4d95-4bc2-8001-0be508f56eef" /> |


### message examples

#### 1. format error:

/erd/p/raw.githubusercontent.com/mastodon/mastodon/refs/heads/main/Gemfile


```
Hmm, it's silent here...
Our signal's lost in the void! No access at this time..
Please specify the format in the URL query parameter `format`
```


<img width="384" alt=" 2025-02-06 13 10 54" src="https://github.com/user-attachments/assets/59570ea2-1cf6-4bc3-86fe-f045d7ae5de3" />

#### 2. DNS error

/erd/p/no-found/path/to/file

```
Hmm, it's silent here...
TypeError: fetch failed. Our signal's lost in the void! No access at this time..
Double-check the transmission link https://no-found/path/to/file and initiate contact again.
```

<img width="374" alt="2025-02-06 13 13 51" src="https://github.com/user-attachments/assets/45a0bb2f-2dda-448c-ad86-fee9d3d708f2" />


#### 3. remote server 404

/erd/p/raw.githubusercontent.com/liam-hq/liam/refs/heads/main/no-found

```
Hmm, it's silent here...
HTTP status is 404: Not Found.
Double-check the transmission link https://raw.githubusercontent.com/liam-hq/liam/refs/heads/main/no-found and initiate contact again.
```

<img width="380" alt="スクリーンショット 2025-02-06 13 15 49" src="https://github.com/user-attachments/assets/18401110-a4cb-4cf9-96ce-9eb0aab13f61" />



## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced a new `MrJack` SVG component for enhanced error visuals.

- Improved `NetworkErrorDisplay` with structured error messages and instructions.

- Refactored error handling logic to include optional `instruction` field.

- Updated CSS for better alignment and responsive design in error displays.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>erdViewer.tsx</strong><dd><code>Add `instruction` field to `ErrorObject` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/erd-web/app/erd/p/[...slug]/erdViewer.tsx

<li>Added optional <code>instruction</code> field to <code>ErrorObject</code> type.<br> <li> Updated type definitions for error handling.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-d07a7c2f4c9e679668455bec7d3cb231de7054f73afa3007de7a39366ffd2d5b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ErrorDisplay.tsx</strong><dd><code>Update `ErrorDisplay` for conditional rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/ErrorDisplay.tsx

<li>Added conditional rendering for <code>NetworkError</code> specific display.<br> <li> Updated component structure for better error handling.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-2318ce5c00bfc33f9487368700731903f9e471feb7f7b5ce83431ced596c05b4">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MrJack.tsx</strong><dd><code>Add `MrJack` SVG component for error visuals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/MrJack.tsx

<li>Introduced <code>MrJack</code> SVG component for error visuals.<br> <li> Added detailed SVG illustration for enhanced UI.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-d4a952744a3c80801da52b4182df3fc2461a3b7974cb3c9a00caaf0c79c135bf">+376/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NetworkErrorDisplay.tsx</strong><dd><code>Integrate `MrJack` SVG and refactor error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/NetworkErrorDisplay.tsx

<li>Integrated <code>MrJack</code> SVG into <code>NetworkErrorDisplay</code>.<br> <li> Refactored error message structure for better readability.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-88c9ca11430aa551787ae1f4be63c3969966bd8a6d251df5f31196c5c794af68">+13/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NetworkErrorDisplay.module.css</strong><dd><code>Update CSS for improved error display design</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ErrorDisplay/NetworkErrorDisplay.module.css

<li>Updated styles for better alignment and responsiveness.<br> <li> Added new classes for structured error message display.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-7ce930708df3205efb703d14ef16cedac92a672b6c8df4e50050342995099eda">+47/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactor error handling logic and messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/erd-web/app/erd/p/[...slug]/page.tsx

<li>Enhanced error handling logic with <code>instruction</code> messages.<br> <li> Refactored error messages for clarity and consistency.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-7daa4b964ff93ea54946bd3d92153a003d60fea7c2bac3e1b1336a42984614fd">+20/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fresh-shirts-stare.md</strong><dd><code>Add changeset for patch updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/fresh-shirts-stare.md

<li>Added changeset for patch updates to <code>@liam-hq/erd-core</code> and <br><code>@liam-hq/cli</code>.<br> <li> Documented addition of <code>MrJack</code> SVG to <code>NetworkError</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/680/files#diff-858b9d5db058f77ba7e29009530ac0c806460ff694955e335992b9aadfba7fef">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>