### PR TITLE
✨ Add touch device detection for ERD selection behavior

### DIFF
--- a/.changeset/real-hairs-reply.md
+++ b/.changeset/real-hairs-reply.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+✨ Disable selectionOnDrag on touch devices

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -2,6 +2,7 @@ import { selectTableLogEvent } from '@/features/gtm/utils'
 import { repositionTableLogEvent } from '@/features/gtm/utils/repositionTableLogEvent'
 import { useVersion } from '@/providers'
 import { updateActiveTableName, useUserEditingActiveStore } from '@/stores'
+import { isTouchDevice } from '@/utils'
 import {
   Background,
   BackgroundVariant,
@@ -159,7 +160,7 @@ export const ERDContentInner: FC<Props> = ({
         onNodeDragStop={handleDragStopNode}
         panOnScroll
         panOnDrag={panOnDrag}
-        selectionOnDrag
+        selectionOnDrag={!isTouchDevice()}
         deleteKeyCode={null} // Turn off because it does not want to be deleted
         attributionPosition="bottom-left"
         nodesConnectable={false}

--- a/frontend/packages/erd-core/src/utils/index.ts
+++ b/frontend/packages/erd-core/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './compressionString'
 export * from './urlParams'
+export * from './isTouchDevice'

--- a/frontend/packages/erd-core/src/utils/isTouchDevice.ts
+++ b/frontend/packages/erd-core/src/utils/isTouchDevice.ts
@@ -1,0 +1,6 @@
+export const isTouchDevice = (): boolean => {
+  return (
+    typeof window !== 'undefined' &&
+    ('ontouchstart' in window || navigator.maxTouchPoints > 0)
+  )
+}


### PR DESCRIPTION
### **User description**
#### Background

Currently, selectionOnDrag is enabled in ReactFlow and a normal drag on the canvas will show a selection box.
This is a deliberate adjustment to provide a Figma-like experience.

ref: https://reactflow.dev/api-reference/react-flow#selection-on-drag
ref: https://reactflow.dev/learn/concepts/the-viewport#figma-like-viewport-controls

However, this does not allow for good panning and zooming on mobile (touch devices).
When opening Figma on a mobile device, when dragging, the canvas moves, so we want to match that.

#### Testing
<!-- Briefly describe the testing steps or results. -->


Before

https://github.com/user-attachments/assets/a02c31a5-e37f-4be7-8429-b0a59ad6b1cd

After

https://github.com/user-attachments/assets/2b4ed3b3-e69b-401b-aec5-6ee6282555d2


#### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added touch device detection utility to improve mobile experience.

- Disabled `selectionOnDrag` for touch devices in `ERDContent`.

- Exported `isTouchDevice` utility for broader usage.

- Updated changeset to document the enhancement.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ERDContent.tsx</strong><dd><code>Adjusted `selectionOnDrag` for touch devices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx

<li>Integrated <code>isTouchDevice</code> utility to conditionally disable <br><code>selectionOnDrag</code>.<br> <li> Improved mobile usability by enabling panning instead of selection.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/690/files#diff-ac50fc9ec72720523e17be1f4f2cee0df1e527176a4842d70e8101e03d7c3306">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Added export for `isTouchDevice` utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/utils/index.ts

- Exported `isTouchDevice` utility for external usage.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/690/files#diff-feffb54947da02c97b4a54cc2d2d96aba690f647ac204f431a4416e612f43a79">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>isTouchDevice.ts</strong><dd><code>Added utility to detect touch devices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/utils/isTouchDevice.ts

<li>Implemented <code>isTouchDevice</code> utility to detect touch devices.<br> <li> Checks for touch capabilities using <code>ontouchstart</code> or <code>maxTouchPoints</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/690/files#diff-471d76d6a26b0c70dc92515e8a3431ab3b7eb8999e6998570c650998ccabcc18">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>real-hairs-reply.md</strong><dd><code>Added changeset for touch device enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/real-hairs-reply.md

<li>Documented the change to disable <code>selectionOnDrag</code> for touch devices.<br> <li> Marked the change as a patch update.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/690/files#diff-e66d5399c321c7473b9e7c0238ce71e315b53edd78122a7acc09c4c61bc59477">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>