### PR TITLE
✅ Add global setup for cookie acceptance in E2E tests

### DIFF
--- a/frontend/packages/e2e/.gitignore
+++ b/frontend/packages/e2e/.gitignore
@@ -5,3 +5,5 @@
 /playwright/.cache/
 # Files created when tests are run locally
 /tests/vrt/vrt.test.ts-snapshots/top-1-chromium-darwin.png
+
+storageState.json

--- a/frontend/packages/e2e/global-setup.ts
+++ b/frontend/packages/e2e/global-setup.ts
@@ -1,0 +1,18 @@
+import { type FullConfig, chromium } from '@playwright/test'
+
+async function globalSetup(config: FullConfig) {
+  const { baseURL, storageState } = config.projects[0].use
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  await page.goto(`${baseURL}/`)
+
+  const cookieButton = page.getByRole('button', {
+    name: 'Accept All Cookies',
+  })
+  await cookieButton.click({ timeout: 3000, force: true }).catch(() => {})
+  await page.context().storageState({ path: storageState as string })
+
+  await browser.close()
+}
+
+export default globalSetup

--- a/frontend/packages/e2e/playwright.config.ts
+++ b/frontend/packages/e2e/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
+  globalSetup: require.resolve('./global-setup'),
   testDir: 'tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
@@ -11,6 +12,7 @@ export default defineConfig({
   use: {
     baseURL: process.env.URL || 'http://localhost:5173',
     trace: 'on-first-retry',
+    storageState: 'storageState.json',
   },
 
   projects: [

--- a/frontend/packages/e2e/tests/e2e/toolbar.test.ts
+++ b/frontend/packages/e2e/tests/e2e/toolbar.test.ts
@@ -2,10 +2,6 @@ import { expect, test } from '@playwright/test'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/')
-  const cookieButton = page.getByRole('button', {
-    name: 'Accept All Cookies',
-  })
-  await cookieButton.click({ timeout: 3000, force: true }).catch(() => {})
 })
 
 test.describe('Desktop Toolbar', () => {

--- a/frontend/packages/e2e/tests/vrt/vrt.test.ts
+++ b/frontend/packages/e2e/tests/vrt/vrt.test.ts
@@ -4,12 +4,6 @@ import { expect, test } from '@playwright/test'
 const screenshot = async (page: Page, targetPage: TargetPage) => {
   await page.goto(targetPage.path)
 
-  const cookieAcceptButton = page.getByRole('button', {
-    name: 'Accept All Cookies',
-  })
-  if ((await cookieAcceptButton.count()) > 0) {
-    await cookieAcceptButton.click()
-  }
   await expect(page).toHaveScreenshot({ fullPage: true })
 }
 


### PR DESCRIPTION
Add global setup for cookie acceptance in E2E tests.

#### Related Issue
<!-- Mention the related issue number if applicable. -->

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->
