### PR TITLE
✅ Add E2E tests for Show Mode menu in desktop toolbar

### DIFF
--- a/frontend/packages/e2e/tests/e2e/toolbar.test.ts
+++ b/frontend/packages/e2e/tests/e2e/toolbar.test.ts
@@ -43,4 +43,58 @@ test.describe('Desktop Toolbar', () => {
       Number.parseInt(zoomLevelAfter),
     )
   })
+
+  test.describe('Show Mode', () => {
+    type ShowModeTest = {
+      mode: string
+      expectedColumns: string[]
+    }
+
+    const showModeTests: ShowModeTest[] = [
+      {
+        mode: 'Table Name',
+        expectedColumns: [],
+      },
+      {
+        mode: 'Key Only',
+        expectedColumns: ['idbigserial', 'account_idbigint'],
+      },
+      {
+        mode: 'All Fields',
+        expectedColumns: [
+          'idbigserial',
+          'account_idbigint',
+          'titlevarchar',
+          'created_attimestamp',
+          'updated_attimestamp',
+          'replies_policyinteger',
+          'exclusiveboolean',
+        ],
+      },
+    ]
+
+    test.beforeEach(async ({ page }) => {
+      const showModeButton = page.getByRole('button', {
+        name: 'Show mode',
+      })
+      await showModeButton.click()
+    })
+
+    for (const { mode, expectedColumns } of showModeTests) {
+      test(`Show Mode: ${mode}`, async ({ page }) => {
+        const modeButton = page.getByRole('menuitemradio', {
+          name: mode,
+        })
+        await modeButton.click()
+
+        const tableNode = page.getByRole('button', {
+          name: 'lists table',
+          exact: true,
+        })
+
+        const columns = tableNode.getByRole('listitem')
+        await expect(columns).toHaveText(expectedColumns)
+      })
+    }
+  })
 })

--- a/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/ShowModeMenu/ShowModeMenu.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/ShowModeMenu/ShowModeMenu.tsx
@@ -55,6 +55,7 @@ export const ShowModeMenu: FC = () => {
             size="sm"
             variant="ghost-secondary"
             rightIcon={<ChevronDown />}
+            aria-label="Show mode"
           >
             {OPTION_LIST.find((opt) => opt.value === showMode)?.label}
           </Button>


### PR DESCRIPTION
### **User description**
Add E2E tests for Show Mode menu in desktop toolbar.

#### Related Issue
<!-- Mention the related issue number if applicable. -->

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Tests


___

### **Description**
- Added E2E tests for the "Show Mode" menu in the desktop toolbar.

- Introduced parameterized tests for different "Show Mode" options.

- Enhanced accessibility with `aria-label` for the "Show Mode" button.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.test.ts</strong><dd><code>Add E2E tests for "Show Mode" menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/e2e/tests/e2e/toolbar.test.ts

<li>Added E2E tests for "Show Mode" menu functionality.<br> <li> Implemented parameterized tests for different "Show Mode" options.<br> <li> Validated expected columns for each mode.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/705/files#diff-588d467fc6e4ec55a8106e9d04be9786dba77a283e2b2c8f05c52dc20efa4949">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ShowModeMenu.tsx</strong><dd><code>Add accessibility label to "Show Mode" button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/ShowModeMenu/ShowModeMenu.tsx

<li>Added <code>aria-label</code> for the "Show Mode" button.<br> <li> Improved accessibility for the dropdown menu trigger.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/705/files#diff-aa2e76b75a10352664c6be0f2c0e2bd5edb3ae914baba42c73dc9788c0fb513e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>