### PR TITLE
🐛 Fix hydration error in Mobile

### DIFF
--- a/.changeset/olive-bees-visit.md
+++ b/.changeset/olive-bees-visit.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+🐛 Fix hydration error in Mobile

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -1,8 +1,8 @@
 import { selectTableLogEvent } from '@/features/gtm/utils'
 import { repositionTableLogEvent } from '@/features/gtm/utils/repositionTableLogEvent'
+import { useIsTouchDevice } from '@/hooks'
 import { useVersion } from '@/providers'
 import { updateActiveTableName, useUserEditingActiveStore } from '@/stores'
-import { isTouchDevice } from '@/utils'
 import {
   Background,
   BackgroundVariant,
@@ -72,6 +72,7 @@ export const ERDContentInner: FC<Props> = ({
   usePopStateListener()
 
   const { version } = useVersion()
+  const isTouchDevice = useIsTouchDevice()
   const handleNodeClick = useCallback(
     (tableId: string) => {
       updateActiveTableName(tableId)
@@ -160,7 +161,7 @@ export const ERDContentInner: FC<Props> = ({
         onNodeDragStop={handleDragStopNode}
         panOnScroll
         panOnDrag={panOnDrag}
-        selectionOnDrag={!isTouchDevice()}
+        selectionOnDrag={!isTouchDevice}
         deleteKeyCode={null} // Turn off because it does not want to be deleted
         attributionPosition="bottom-left"
         nodesConnectable={false}

--- a/frontend/packages/erd-core/src/hooks/index.ts
+++ b/frontend/packages/erd-core/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useIsTouchDevice'

--- a/frontend/packages/erd-core/src/hooks/useIsTouchDevice.ts
+++ b/frontend/packages/erd-core/src/hooks/useIsTouchDevice.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from 'react'
+
+const isTouchDevice = (): boolean => {
+  return (
+    typeof window !== 'undefined' &&
+    ('ontouchstart' in window || navigator.maxTouchPoints > 0)
+  )
+}
+
+export const useIsTouchDevice = () =>
+  useSyncExternalStore(
+    () => () => {},
+    isTouchDevice,
+    () => false,
+  )

--- a/frontend/packages/erd-core/src/utils/index.ts
+++ b/frontend/packages/erd-core/src/utils/index.ts
@@ -1,3 +1,2 @@
 export * from './compressionString'
 export * from './urlParams'
-export * from './isTouchDevice'

--- a/frontend/packages/erd-core/src/utils/isTouchDevice.ts
+++ b/frontend/packages/erd-core/src/utils/isTouchDevice.ts
@@ -1,6 +1,0 @@
-export const isTouchDevice = (): boolean => {
-  return (
-    typeof window !== 'undefined' &&
-    ('ontouchstart' in window || navigator.maxTouchPoints > 0)
-  )
-}


### PR DESCRIPTION
### **User description**
A hydration error was occurring because window operations were being called directly in the component.

<img width="400" src="https://github.com/user-attachments/assets/16f0ae3c-1d55-4212-976f-109b7c7da6b0" />

### Solution 

I used useSyncExternalStore to handle the state (window) outside of React.

ref: [useSyncExternalStore – React](https://react.dev/reference/react/useSyncExternalStore)

Therefore, This will render `false` on the server, and then `false` on the first client render, followed by a re-render with the content of window.

I am referring to the following post:
https://x.com/acdlite/status/1741161736936558721


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed hydration error by replacing `isTouchDevice` with `useIsTouchDevice`.

- Implemented `useSyncExternalStore` to manage touch device detection.

- Removed redundant `isTouchDevice` utility function.

- Updated related imports and usages across the codebase.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ERDContent.tsx</strong><dd><code>Refactored touch device detection in ERDContent component</code></dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx

<li>Replaced <code>isTouchDevice</code> with <code>useIsTouchDevice</code> hook.<br> <li> Updated <code>selectionOnDrag</code> logic to use the new hook.<br> <li> Adjusted imports to reflect the new hook usage.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/713/files#diff-ac50fc9ec72720523e17be1f4f2cee0df1e527176a4842d70e8101e03d7c3306">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Added export for `useIsTouchDevice` hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/hooks/index.ts

- Exported the new `useIsTouchDevice` hook.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/713/files#diff-afa25c85eb0d55e05f1d4c2e443f73eb2e40032e7ce3abd69fc8eecf6df0e2ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useIsTouchDevice.ts</strong><dd><code>Introduced `useIsTouchDevice` hook for touch detection</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/hooks/useIsTouchDevice.ts

<li>Created <code>useIsTouchDevice</code> hook using <code>useSyncExternalStore</code>.<br> <li> Encapsulated touch device detection logic in a reusable hook.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/713/files#diff-efce31bef447192a4b57801443df53da010b6ec96196a7ec190f23b75ea6f9da">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Removed `isTouchDevice` utility export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/utils/index.ts

- Removed export for the deprecated `isTouchDevice` utility.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/713/files#diff-feffb54947da02c97b4a54cc2d2d96aba690f647ac204f431a4416e612f43a79">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>isTouchDevice.ts</strong><dd><code>Removed `isTouchDevice` utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/utils/isTouchDevice.ts

<li>Deleted the <code>isTouchDevice</code> utility function.<br> <li> Replaced by the new <code>useIsTouchDevice</code> hook.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/713/files#diff-471d76d6a26b0c70dc92515e8a3431ab3b7eb8999e6998570c650998ccabcc18">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>olive-bees-visit.md</strong><dd><code>Documented changes in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/olive-bees-visit.md

- Added changeset entry for the bug fix and refactor.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/713/files#diff-1813749a7aa7d7becf4efb362a27cadb2e2822a7765211108b664144dfe4c43f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>