### PR TITLE
🐛 fix toolbar flaky tests

### DIFF
--- a/frontend/packages/e2e/tests/e2e/toolbar.test.ts
+++ b/frontend/packages/e2e/tests/e2e/toolbar.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/')
+  await expect(page.getByRole('status', { name: 'Loading' })).toBeHidden()
 })
 
 type ShowModeTest = {
@@ -46,6 +47,7 @@ test.describe('Desktop Toolbar', () => {
 
     const zoomInButton = toolbar.getByRole('button', { name: 'Zoom in' })
     await zoomInButton.click()
+    await expect(zoomLevelText).not.toHaveText(zoomLevelBefore)
 
     const zoomLevelAfter = await zoomLevelText.textContent()
     expect(Number.parseInt(zoomLevelBefore)).toBeLessThan(

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Spinner/Spinner.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Spinner/Spinner.tsx
@@ -8,10 +8,16 @@ type Props = {
 
 export const Spinner: FC<Props> = ({ className }) => {
   return (
-    <span className={clsx(styles.spinnerBox, className)}>
+    <div
+      className={clsx(styles.spinnerBox, className)}
+      // biome-ignore lint/a11y/useSemanticElements: Because div and status role are common for loading spinners
+      role="status"
+      aria-label="Loading"
+      aria-live="polite"
+    >
       <span className={styles.circleBorder}>
         <span className={styles.circleCore} />
       </span>
-    </span>
+    </div>
   )
 }


### PR DESCRIPTION
### **User description**
### Background

The toolbar test was failing flaky.
https://github.com/liam-hq/liam/actions/runs/13298819442/job/37136559259?pr=714

### Cause

It appears that the values were obtained before the initial loading was completed.
Waiting until loading was complete solved the problem.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Fixed flaky toolbar test by ensuring loading completion.

- Added a loading state check in toolbar E2E test.

- Improved Spinner accessibility with semantic markup and ARIA attributes.

- Enhanced zoom interaction test in toolbar E2E tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.test.ts</strong><dd><code>Fixed flaky toolbar test and enhanced zoom interaction test</code></dd></summary>
<hr>

frontend/packages/e2e/tests/e2e/toolbar.test.ts

<li>Added a check to ensure loading is complete before tests.<br> <li> Enhanced zoom interaction test to verify zoom level changes.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/715/files#diff-588d467fc6e4ec55a8106e9d04be9786dba77a283e2b2c8f05c52dc20efa4949">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Spinner.tsx</strong><dd><code>Improved Spinner accessibility with semantic markup and ARIA </code><br><code>attributes</code></dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/Spinner/Spinner.tsx

<li>Changed Spinner container from <code>span</code> to <code>div</code> for semantic correctness.<br> <li> Added ARIA attributes (<code>role</code>, <code>aria-label</code>, <code>aria-live</code>) for accessibility.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/715/files#diff-70a12f1988c8919695e80e57478604bce28a12a550efce540be8170790db283b">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>