### PR TITLE
✅ Wait for loading status to be hidden before taking screenshots in VRT

### DIFF
--- a/frontend/packages/e2e/tests/vrt/vrt.test.ts
+++ b/frontend/packages/e2e/tests/vrt/vrt.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test'
 
 const screenshot = async (page: Page, targetPage: TargetPage) => {
   await page.goto(targetPage.path)
+  await expect(page.getByRole('status', { name: 'Loading' })).toBeHidden()
 
   await expect(page).toHaveScreenshot({ fullPage: true })
 }


### PR DESCRIPTION
### **User description**
I made it so that the execution of VRT waits until the loading is complete.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a wait for the loading status to be hidden before taking screenshots in VRT tests.

- Improved test reliability by ensuring screenshots are taken only after the page is fully loaded.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vrt.test.ts</strong><dd><code>Wait for loading status before screenshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/e2e/tests/vrt/vrt.test.ts

<li>Added a check to ensure the loading status is hidden before taking <br>screenshots.<br> <li> Enhanced the <code>screenshot</code> function for better test reliability.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/719/files#diff-7562e3c4e16d89f0cf3e0163c5389fec2d9dbb446d072d2b0ec9cb1597f8ede1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>