### PR TITLE
Fix package execution check(🐛 fix outputs name) and  slack notification to liam-hq team

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Trigger released_package_test.yml via API
-        if: ${{ steps.changesets-action.outputs.release_created == 'true' }}
+        if: ${{ steps.changesets-action.outputs.published == 'true' }}
         run: |
           version=$(cat frontend/packages/cli/package.json | jq -r '.version')
           curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/released_package_test.yml
+++ b/.github/workflows/released_package_test.yml
@@ -39,3 +39,54 @@ jobs:
             exit 1
           fi
           npx --yes @liam-hq/cli@${version} --version
+
+      # derived from https://github.com/route06/actions/blob/8e3ac6855302a4fe3bd621ebd16c7a0da261948a/.github/workflows/notify_slack_on_ci_failed.yml
+      - name: Slack Notification on Success
+        if: success()
+        uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
+        env:
+          # https://api.slack.com/apps/A08CVT65VAT/general
+          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CI_WEBHOOK_URL }}
+        with:
+          text: "Liam CLI released package test"
+          attachments: |
+            [
+              {
+                "color": "good",
+                "fields": [
+                  {
+                    "title": "Version",
+                    "value": "${{ github.event.inputs.version }}"
+                  },
+                  {
+                    "title": "Result",
+                    "value": "success"
+                  }
+                ]
+              }
+            ]
+
+      - name: Slack Notification on Failure
+        if: failure()
+        uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
+        env:
+          # https://api.slack.com/apps/A08CVT65VAT/general
+          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CI_WEBHOOK_URL }}
+        with:
+          text: "Liam CLI released package test"
+          attachments: |
+            [
+              {
+                "color": "bad",
+                "fields": [
+                  {
+                    "title": "Version",
+                    "value": "${{ github.event.inputs.version }}"
+                  },
+                  {
+                    "title": "Result",
+                    "value": "failure"
+                  }
+                ]
+              }
+            ]


### PR DESCRIPTION
### **User description**
* 718f2818 : 🐛 fix outputs name
* b81c7208 : Add slack notification to released_package_test.yml

#### Related Issue
<!-- Mention the related issue number if applicable. -->

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed incorrect output name in `release.yml`.

- Updated condition to check `published` instead of `release_created`.

- Added Slack notifications for success and failure in `released_package_test.yml`.

- Enhanced CI workflow with detailed Slack message formatting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix output condition in `release.yml`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<li>Fixed the condition to check <code>published</code> instead of <code>release_created</code>.<br> <li> Ensured proper triggering of <code>released_package_test.yml</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/728/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>released_package_test.yml</strong><dd><code>Add Slack notifications to `released_package_test.yml`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/released_package_test.yml

<li>Added Slack notification for successful CI runs.<br> <li> Added Slack notification for failed CI runs.<br> <li> Included detailed message formatting for Slack notifications.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/728/files#diff-e509db49b8628f887dd708240cb326d94942534881b684104c08788e89b1ae75">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>