### PR TITLE
🐛  add step to install WebKit system dependencies

### DIFF
--- a/.github/workflows/_run_e2e_test.yml
+++ b/.github/workflows/_run_e2e_test.yml
@@ -35,6 +35,11 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
 
+      - name: Install system dependencies for WebKit
+        # Some WebKit dependencies seem to lay outside the cache and will need to be installed separately
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+        run: pnpm exec playwright install-deps webkit
+
       - name: Run e2e tests
         run: pnpm test:e2e
         env:


### PR DESCRIPTION
### **User description**
The e2e tests are failing, but this appears to be an environment issue:

- Error: Missing library libwoff2dec.so.1.0.2 in the CI environment
- This is affecting the WebKit browser tests in Playwright

I added a step to install the dependencies required for testing the WebKit browser.

#### Related Issue
<!-- Mention the related issue number if applicable. -->

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->

https://github.com/liam-hq/liam/actions/runs/13323394893/job/37212094119?pr=727


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a step to install WebKit system dependencies.

- Ensured WebKit dependencies are installed when cache is hit.

- Improved reliability of WebKit browser tests in CI.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_run_e2e_test.yml</strong><dd><code>Add WebKit dependencies installation step in CI workflow</code>&nbsp; </dd></summary>
<hr>

.github/workflows/_run_e2e_test.yml

<li>Added a new step to install WebKit system dependencies.<br> <li> Conditional installation based on Playwright cache status.<br> <li> Enhanced CI workflow for WebKit browser tests.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/729/files#diff-aa92eda07dfd3c394f246037a2331fe4233447bea2a57acac83391ab548e7581">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>