### PR TITLE
✅ Add e2e test for fitview button functionality

### DIFF
--- a/frontend/packages/e2e/tests/e2e/toolbar.test.ts
+++ b/frontend/packages/e2e/tests/e2e/toolbar.test.ts
@@ -78,7 +78,11 @@ test('zoom out button should decrease zoom level', async ({ page }) => {
 
 test('fitview button should make the table nodes fit the viewport', async ({
   page,
+  isMobile,
 }) => {
+  // TODO: Fix this test for mobile as it's flaky
+  if (isMobile) test.skip()
+
   const toolbar = page.getByRole('toolbar', { name: 'Toolbar' })
   const fitViewButton = toolbar.getByRole('button', { name: 'Zoom to Fit' })
 

--- a/frontend/packages/e2e/tests/e2e/toolbar.test.ts
+++ b/frontend/packages/e2e/tests/e2e/toolbar.test.ts
@@ -76,6 +76,32 @@ test('zoom out button should decrease zoom level', async ({ page }) => {
   )
 })
 
+test('fitview button should make the table nodes fit the viewport', async ({
+  page,
+}) => {
+  const toolbar = page.getByRole('toolbar', { name: 'Toolbar' })
+  const fitViewButton = toolbar.getByRole('button', { name: 'Zoom to Fit' })
+
+  const tableNode = page.getByRole('button', {
+    name: 'accounts table',
+    exact: true,
+  })
+  await expect(tableNode).toBeInViewport()
+
+  const zoomInButton = toolbar.getByRole('button', { name: 'Zoom in' })
+
+  // Zoom in to ensure the table is out of viewport
+  for (let i = 0; i < 10; i++) {
+    await zoomInButton.click()
+  }
+
+  await expect(tableNode).not.toBeInViewport()
+
+  await fitViewButton.click()
+
+  await expect(tableNode).toBeInViewport()
+})
+
 test.describe('Show Mode', () => {
   test.beforeEach(async ({ page, isMobile }) => {
     // TODO: Mobile test is flaky, so fix it later

--- a/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/FitviewButton/FitviewButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/FitviewButton/FitviewButton.tsx
@@ -39,7 +39,12 @@ export const FitviewButton: FC<FitviewButtonProps> = ({
 
   return (
     <ToolbarButton asChild onClick={handleClick} className={styles.menuButton}>
-      <IconButton size={size} icon={<Scan />} tooltipContent="Zoom to Fit">
+      <IconButton
+        size={size}
+        icon={<Scan />}
+        tooltipContent="Zoom to Fit"
+        aria-label="Zoom to fit"
+      >
         {children}
       </IconButton>
     </ToolbarButton>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/MobileToolbar/OpenedMobileToolbar.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/MobileToolbar/OpenedMobileToolbar.tsx
@@ -96,12 +96,8 @@ export const OpenedMobileToolbar: FC<Props> = ({
           </IconButton>
         </ToolbarButton>
 
-        <FitviewButton size="sm" aria-label="Zoom to fit">
-          Zoom to Fit
-        </FitviewButton>
-        <TidyUpButton size="sm" aria-label="Tidy up">
-          Tidy up
-        </TidyUpButton>
+        <FitviewButton size="sm">Zoom to Fit</FitviewButton>
+        <TidyUpButton size="sm">Tidy up</TidyUpButton>
       </div>
       <hr className={styles.divider} />
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/TidyUpButton/TidyUpButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/TidyUpButton/TidyUpButton.tsx
@@ -50,6 +50,7 @@ export const TidyUpButton: FC<TidyUpButtonProps> = ({
         tooltipContent="Tidy up"
         onClick={handleClick}
         size={size}
+        aria-label="Tidy up"
       >
         {children}
       </IconButton>


### PR DESCRIPTION
### **User description**
Check Fitview button functionality.

This PR includes only tests for desktop.
Mobile is handled with another PR.

#### Related Issue
<!-- Mention the related issue number if applicable. -->

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Added an end-to-end test for the `fitview` button functionality.

- Enhanced accessibility by adding `aria-labels` to toolbar buttons.

- Updated `FitviewButton` and `TidyUpButton` components for better usability.

- Included a TODO comment for mobile compatibility in the `fitview` test.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.test.ts</strong><dd><code>Added e2e test for `fitview` button functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/e2e/tests/e2e/toolbar.test.ts

<li>Added a new test for <code>fitview</code> button functionality.<br> <li> Ensured the test skips on mobile due to flakiness.<br> <li> Verified viewport adjustments for table nodes.<br> <li> Included a TODO comment for mobile compatibility.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/730/files#diff-588d467fc6e4ec55a8106e9d04be9786dba77a283e2b2c8f05c52dc20efa4949">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FitviewButton.tsx</strong><dd><code>Enhanced `FitviewButton` with accessibility improvements</code>&nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/FitviewButton/FitviewButton.tsx

<li>Added <code>aria-label</code> for accessibility to <code>FitviewButton</code>.<br> <li> Improved button usability with better labeling.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/730/files#diff-e1ba1105c46eb5ce0cafc7d15173a21161fea1c7fcc3326d1810df10d9e83b44">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OpenedMobileToolbar.tsx</strong><dd><code>Simplified toolbar button definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/MobileToolbar/OpenedMobileToolbar.tsx

<li>Removed redundant <code>aria-label</code> attributes from <code>FitviewButton</code> and <br><code>TidyUpButton</code>.<br> <li> Simplified button definitions for better maintainability.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/730/files#diff-147f8e5add9cb5af664faf4afbd27e6508d1d312ac6f84e26416b0609b8dd56c">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TidyUpButton.tsx</strong><dd><code>Enhanced `TidyUpButton` with accessibility improvements</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/Toolbar/TidyUpButton/TidyUpButton.tsx

<li>Added <code>aria-label</code> for accessibility to <code>TidyUpButton</code>.<br> <li> Improved button usability with better labeling.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/730/files#diff-a6642062fac14d85b98966be3492e616ef2478b82be623689d8a92909b8f86ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>