### PR TITLE
🐛 Display Related Tables for Nodes without Relations

### DIFF
--- a/.changeset/gold-birds-occur.md
+++ b/.changeset/gold-birds-occur.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 When nodes without a relation are present, set the hidden property to false for the non related group node.

--- a/.changeset/lucky-flowers-reply.md
+++ b/.changeset/lucky-flowers-reply.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+♻️ Replace hidden update logic with a shared function.

--- a/.changeset/strange-clouds-know.md
+++ b/.changeset/strange-clouds-know.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 handle case with no related relationships in extractDBStructureForTable

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/extractDBStructureForTable.test.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/extractDBStructureForTable.test.ts
@@ -70,7 +70,9 @@ describe(extractDBStructureForTable, () => {
     }
     const result = extractDBStructureForTable(users, emptyDBStructure)
     expect(result).toEqual({
-      tables: {},
+      tables: {
+        users,
+      },
       relationships: {},
     })
   })

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/extractDBStructureForTable.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/extractDBStructureForTable.ts
@@ -17,6 +17,15 @@ export const extractDBStructureForTable = (
       relationship.foreignTableName === table.name,
   )
 
+  if (relatedRelationshipsArray.length === 0) {
+    return {
+      tables: {
+        [table.name]: table,
+      },
+      relationships: {},
+    }
+  }
+
   const relatedRelationships: Relationships = {}
   for (const relationship of relatedRelationshipsArray) {
     relatedRelationships[relationship.name] = relationship

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/hasNonRelatedChildNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/hasNonRelatedChildNodes.ts
@@ -1,0 +1,6 @@
+import type { Node } from '@xyflow/react'
+import { NON_RELATED_TABLE_GROUP_NODE_ID } from '../constants'
+
+export const hasNonRelatedChildNodes = (nodes: Node[]): boolean => {
+  return nodes.some((node) => node.parentId === NON_RELATED_TABLE_GROUP_NODE_ID)
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/updateNodesHiddenState.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/updateNodesHiddenState.ts
@@ -1,0 +1,21 @@
+import type { Node } from '@xyflow/react'
+import { NON_RELATED_TABLE_GROUP_NODE_ID } from '../constants'
+
+type Params = {
+  nodes: Node[]
+  hiddenNodeIds: string[]
+  shouldHideGroupNodeId: boolean
+}
+
+export function updateNodesHiddenState({
+  nodes,
+  hiddenNodeIds,
+  shouldHideGroupNodeId,
+}: Params): Node[] {
+  return nodes.map((node) => ({
+    ...node,
+    hidden:
+      hiddenNodeIds.includes(node.id) ||
+      (shouldHideGroupNodeId && node.id === NON_RELATED_TABLE_GROUP_NODE_ID),
+  }))
+}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -13,7 +13,9 @@ import type { Node } from '@xyflow/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useERDContentContext } from './ERDContentContext'
 import { computeAutoLayout } from './computeAutoLayout'
+import { hasNonRelatedChildNodes } from './hasNonRelatedChildNodes'
 import { highlightNodesAndEdges } from './highlightNodesAndEdges'
+import { updateNodesHiddenState } from './updateNodesHiddenState'
 
 export const useInitialAutoLayout = (
   nodes: Node[],
@@ -49,10 +51,12 @@ export const useInitialAutoLayout = (
 
     if (tableNodesInitialized) {
       setLoading(true)
-      const updatedNodes = nodes.map((node) => ({
-        ...node,
-        hidden: hiddenNodeIds.includes(node.id),
-      }))
+
+      const updatedNodes = updateNodesHiddenState({
+        nodes,
+        hiddenNodeIds,
+        shouldHideGroupNodeId: !hasNonRelatedChildNodes(nodes),
+      })
 
       const { nodes: highlightedNodes, edges: highlightedEdges } =
         highlightNodesAndEdges(updatedNodes, getEdges(), {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/constants.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/constants.ts
@@ -3,3 +3,5 @@ export const zIndex = {
   edgeHighlighted: 1,
   edgeDefault: 0,
 }
+
+export const NON_RELATED_TABLE_GROUP_NODE_ID = 'non-related-table-group'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/convertDBStructureToNodes.ts
@@ -2,9 +2,7 @@ import type { ShowMode } from '@/schemas/showMode'
 import type { Cardinality, DBStructure } from '@liam-hq/db-structure'
 import type { Edge, Node } from '@xyflow/react'
 import { columnHandleId } from './columnHandleId'
-import { zIndex } from './constants'
-
-export const NON_RELATED_TABLE_GROUP_NODE_ID = 'non-related-table-group'
+import { NON_RELATED_TABLE_GROUP_NODE_ID, zIndex } from './constants'
 
 type Params = {
   dbStructure: DBStructure


### PR DESCRIPTION
There was an issue where, when selecting a table without any relations, the RelatedTables area remained in a loading state and was not displayed. Additionally, pressing the "Open in Main area" button resulted in nothing being shown.

To resolve these issues, we modified the logic that takes into account the parent-child relationships of nodes, so that everything now displays as intended.

#### Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

#### Testing
<!-- Briefly describe the testing steps or results. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e1e3aaae-6aaa-4da1-a88f-829e7edf0b3c" /> | <video src="https://github.com/user-attachments/assets/af370965-2ed3-4ddd-b786-4067365ddc29" /> | 

#### Other Information
<!-- Add any other relevant information for the reviewer. -->






