### PR TITLE
✨ Support field name mapping with @map in Prisma

### DIFF
--- a/.changeset/many-boats-dance.md
+++ b/.changeset/many-boats-dance.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/db-structure": patch
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+✨ Support field name mapping with @map in Prisma

--- a/frontend/packages/db-structure/src/parser/prisma/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/index.test.ts
@@ -380,5 +380,28 @@ describe(_processor, () => {
 
       expect(value).toEqual(expected)
     })
+
+    it('map', async () => {
+      const { value } = await processor(`
+        model users {
+          id   BigInt    @id @default(autoincrement())
+          email String   @map("user_email_address")
+        }
+      `)
+
+      const expected = userTable({
+        columns: {
+          email: aColumn({
+            name: 'email',
+            actualName: 'user_email_address',
+            type: 'text',
+            notNull: true,
+            unique: false,
+          }),
+        },
+      })
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/frontend/packages/db-structure/src/parser/prisma/parser.ts
+++ b/frontend/packages/db-structure/src/parser/prisma/parser.ts
@@ -27,6 +27,7 @@ async function parsePrismaSchema(schemaString: string): Promise<ProcessResult> {
       const defaultValue = extractDefaultValue(field)
       columns[field.name] = {
         name: field.name,
+        actualName: field.dbName ?? undefined,
         type: convertToPostgresColumnType(
           field.type,
           field.nativeType,

--- a/frontend/packages/db-structure/src/schema/dbStructure.ts
+++ b/frontend/packages/db-structure/src/schema/dbStructure.ts
@@ -10,6 +10,7 @@ const relationshipNameSchema = v.string()
 
 const columnSchema = v.object({
   name: columnNameSchema,
+  actualName: v.optional(v.undefinedable(v.string())),
   type: v.string(),
   default: v.nullable(v.union([v.string(), v.number(), v.boolean()])),
   check: v.nullable(v.string()),

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx
@@ -60,7 +60,7 @@ export const TableColumn: FC<TableColumnProps> = ({
       ) : null}
 
       <span className={styles.columnNameWrapper}>
-        <span>{column.name}</span>
+        <span>{column.actualName ?? column.name}</span>
         <span className={styles.columnType}>{column.type}</span>
       </span>
 

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const ColumnsItem: FC<Props> = ({ column }) => {
   return (
     <div className={styles.wrapper}>
-      <h3 className={styles.heading}>{column.name}</h3>
+      <h3 className={styles.heading}>{column.actualName ?? column.name}</h3>
       {column.comment && <p className={styles.comment}>{column.comment}</p>}
       <dl className={styles.dl}>
         <div className={styles.dlItem}>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx
@@ -33,7 +33,7 @@ export const Unique: FC<Props> = ({ columns }) => {
             if (!column.unique) return null
             return (
               <li key={key} className={styles.listItem}>
-                {column.name}
+                {column.actualName ?? column.name}
               </li>
             )
           })}


### PR DESCRIPTION
### **User description**
#### Summary

Support `@map` field of Prisma.
With the Prisma parser, `dbName` field represents a original DB field name specified with `@map`.
This change will add the `dbName` value with `actualName` field into `Column` object. The component will render a `actualName` instead of name if it exists.

#### Related Issue
<!-- Mention the related issue number if applicable. -->

resolve: https://github.com/liam-hq/liam/issues/556

#### Testing
<!-- Briefly describe the testing steps or results. -->

1. run `pnpm run build`
1. copy & paste the following `schema.prisma` file at the root of the repository
1. run `node frontend/packages/cli/dist-cli/bin/cli.js erd build --format prisma --input schema.prisma` to build a page with the prisma schema
1. run `npx http-server dist` and go to http://localhost:8080/?showMode=ALL_FIELDS

<details>
<summary>schema.prisma</summary>

```prisma
datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}

generator client {
  provider = "prisma-client-js"
}

model users {
  id Int @id @default(autoincrement())
  posts posts[]
}

model posts {
  id Int @id @default(autoincrement())
  user users @relation(fields: [user_id], references: [id])
  user_id Int @map("raw_user_id")
  hash String @map("unique_hash") @unique
}

enum Role {
  USER
  ADMIN
}
```

</details>

It shows `raw_user_id` and `unique_hash`, which are db original field names, rather than `user_id` and `hash`.

![Screenshot 0007-02-15 at 22 07 32](https://github.com/user-attachments/assets/9312332d-f0a4-4f21-9620-e8eacf4bbbd5)


#### Other Information
<!-- Add any other relevant information for the reviewer. -->

I understand you suppose to overwrite the field name with `dbName` if it exists by [this comment](https://github.com/liam-hq/liam/issues/556#issuecomment-2611883547). However, overwriting fields looks very complex, especially overwriting the relations. I would like to suggest another idea to resolve this in this PR. If you think that idea fits better with this project, I completely agree with you. I found some pros/cons of this change comparing to the renaming strategy.

- pros
  - Adding `actualName` filed may be useful, other format can use the same field.
  - The logic is simpler then renaming all the fields and relations. I saw [another issue to support `@@map`](https://github.com/liam-hq/liam/issues/557) which make mapping of table name, and it will make the logic more complex if it takes the renaming strategy.
- cons
  - `actualName` may be useless for other format.
  - It requires `column.actualName ?? column.name` logic on everywhere it renders column names. It may cause mis-implementation and show `column.name` unexpectedly.

---

It seems the prisma supports [name mapping for enum as well](https://www.prisma.io/docs/orm/prisma-schema/data-model/database-mapping#map-enum-names-and-values) with `@map` as well. However I didn't implement it in this PR.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added support for `@map` in Prisma to handle field name mapping.

- Introduced `actualName` field to represent database column names.

- Updated UI components to display `actualName` when available.

- Added tests to validate `@map` functionality in Prisma parser.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add test for `@map` syntax in Prisma parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/prisma/index.test.ts

<li>Added a test case to validate <code>@map</code> functionality.<br> <li> Ensured <code>actualName</code> is correctly parsed and matched with expected <br>output.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-994ebc8ffb1813364f3eec0fb07d7d81a7ce221866d6eb5cd68df4acee202730">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser.ts</strong><dd><code>Parse and assign `actualName` for columns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/prisma/parser.ts

<li>Added <code>actualName</code> field to represent database column names.<br> <li> Used <code>dbName</code> from Prisma schema for <code>actualName</code> if available.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-52b9ab11a0672d7499bd2071f94edbead07d3439f608ceb3ec2ae13a7acb1f67">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dbStructure.ts</strong><dd><code>Extend schema to support `actualName`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/schema/dbStructure.ts

<li>Updated schema to include optional <code>actualName</code> field.<br> <li> Ensured compatibility with new <code>actualName</code> property.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-4b515a306720530aa982bde7c25cdcfb29ebf75338229c2a9e4ca95f14b56af3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableColumn.tsx</strong><dd><code>Display `actualName` in table column list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableColumnList/TableColumn/TableColumn.tsx

<li>Updated column display to show <code>actualName</code> if available.<br> <li> Fallback to <code>name</code> if <code>actualName</code> is not present.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-47010af7c824532e617bd4e1df65d70dcdabb0a21520172492788a856c9795e1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ColumnsItem.tsx</strong><dd><code>Update column heading to show `actualName`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx

<li>Modified column heading to prioritize <code>actualName</code>.<br> <li> Ensured fallback to <code>name</code> for compatibility.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-180ea2caf93487bff1d22edc03bc896f77d32ca0592111ccff944bfa4f8c4919">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Unique.tsx</strong><dd><code>Show `actualName` for unique columns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/Unique/Unique.tsx

<li>Updated unique column display to use <code>actualName</code>.<br> <li> Fallback to <code>name</code> if <code>actualName</code> is unavailable.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-185d1fd2885bafbe0026cf004445563614f5eeb1a934aecb9185d2539c761ad8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>many-boats-dance.md</strong><dd><code>Document changes for `@map` support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/many-boats-dance.md

<li>Added changeset for <code>@map</code> support in Prisma.<br> <li> Documented updates to <code>db-structure</code>, <code>erd-core</code>, and <code>cli</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/737/files#diff-ddea9bbf0d415adf825af2442550baeb2820bd0f46e3fc4b86e4eac8a2c132b6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>