### PR TITLE
✨ Pre-calculate layout for Related Tables before displaying in Main Area

### DIFF
--- a/.changeset/gorgeous-lobsters-complain.md
+++ b/.changeset/gorgeous-lobsters-complain.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/cli": minor
+"@liam-hq/erd-core": minor
+---
+
+✨ Pre-calculate layout for Related Tables before displaying in Main Area


### PR DESCRIPTION
### **User description**
### Summary

At https://github.com/liam-hq/liam/pull/708, when displaying the Related Table in the Main Area, the layout is now pre-arranged before being rendered. 
Since this change affects the user experience, we decided to bump the minor version.


___

### **PR Type**
enhancement, other


___

### **Description**
- Pre-calculate layout for Related Tables before rendering.

- Update minor version for `@liam-hq/cli` and `@liam-hq/erd-core`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gorgeous-lobsters-complain.md</strong><dd><code>Document minor version updates and layout enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/gorgeous-lobsters-complain.md

<li>Added a changeset file to document the minor version updates.<br> <li> Specified minor version updates for <code>@liam-hq/cli</code> and <br><code>@liam-hq/erd-core</code>.<br> <li> Included a description of the layout pre-calculation enhancement.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/739/files#diff-c9fcaab5b6470ac1adc010504cfa10691b2e8661477deb05ee7b838c9809560c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>