### PR TITLE
🔧 【erd-web】update turbo json outputs setting 

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
       "dependsOn": ["^build"],
       "outputs": [".next"]
     },
+    "@liam-hq/erd-web#build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
#### Related Issue
<!-- Mention the related issue number if applicable. -->
This PR is to allow vercel to perform an automatic deployment.
If I try to auto-deploy in its current state, the deployment fails with the error that .next/routes-manifest.json is missing.

![ss 2850](https://github.com/user-attachments/assets/6b88dbf4-c364-4817-99e9-b7d22cbbe0a5)

I'm making the same code changes as below:
- https://github.com/liam-hq/liam/pull/720

It worked in the test environment.✅

![ss 2931](https://github.com/user-attachments/assets/d4ea8ccc-bb19-4ca0-a755-2bb4d552973f)


#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->
