### PR TITLE
🐛 Exclude hidden and showMode query parameters from ERDContent rendering in RelatedTables

### DIFF
--- a/.changeset/young-owls-relate.md
+++ b/.changeset/young-owls-relate.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/cli": patch
+---
+
+🐛 Exclude hidden and showMode query parameters from ERDContent rendering in RelatedTables

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/ERDContent.tsx
@@ -23,6 +23,7 @@ import { RelationshipEdge } from './RelationshipEdge'
 import { Spinner } from './Spinner'
 import { TableNode } from './TableNode'
 import { highlightNodesAndEdges } from './highlightNodesAndEdges'
+import type { DisplayArea } from './types'
 import { useInitialAutoLayout } from './useInitialAutoLayout'
 import { usePopStateListener } from './usePopStateListener'
 import { useTableSelection } from './useTableSelection'
@@ -39,18 +40,13 @@ const edgeTypes = {
 type Props = {
   nodes: Node[]
   edges: Edge[]
-  enabledFeatures?:
-    | {
-        fitViewWhenActiveTableChange?: boolean | undefined
-        initialFitViewToActiveTable?: boolean | undefined
-      }
-    | undefined
+  displayArea: DisplayArea
 }
 
 export const ERDContentInner: FC<Props> = ({
   nodes: _nodes,
   edges: _edges,
-  enabledFeatures,
+  displayArea,
 }) => {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>(_nodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(_edges)
@@ -60,10 +56,10 @@ export const ERDContentInner: FC<Props> = ({
   const { tableName: activeTableName } = useUserEditingActiveStore()
   const { selectTable, deselectTable } = useTableSelection()
 
-  useInitialAutoLayout(
+  useInitialAutoLayout({
     nodes,
-    enabledFeatures?.initialFitViewToActiveTable ?? true,
-  )
+    displayArea,
+  })
   usePopStateListener()
 
   const { version } = useVersion()
@@ -72,8 +68,7 @@ export const ERDContentInner: FC<Props> = ({
     (tableId: string) => {
       selectTable({
         tableId,
-        shouldFitViewToActiveTable:
-          enabledFeatures?.fitViewWhenActiveTableChange ?? true,
+        displayArea,
       })
 
       selectTableLogEvent({
@@ -85,7 +80,7 @@ export const ERDContentInner: FC<Props> = ({
         appEnv: version.envName,
       })
     },
-    [version, enabledFeatures?.fitViewWhenActiveTableChange, selectTable],
+    [version, displayArea, selectTable],
   )
 
   const handlePaneClick = useCallback(() => {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
@@ -44,10 +44,7 @@ export const RelatedTables: FC<Props> = ({ nodes, edges, onOpenMainPane }) => {
             <ERDContent
               nodes={nodes}
               edges={edges}
-              enabledFeatures={{
-                fitViewWhenActiveTableChange: false,
-                initialFitViewToActiveTable: false,
-              }}
+              displayArea="relatedTables"
             />
           </ReactFlowProvider>
         </div>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/TableNode/TableDetail/TableDetail.tsx
@@ -117,7 +117,6 @@ export const TableDetail: FC<Props> = ({ table }) => {
         <Unique columns={table.columns} />
         <div className={styles.relatedTables}>
           <RelatedTables
-            key={table.name}
             nodes={nodes}
             edges={edges}
             onOpenMainPane={handleOpenMainPane}

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/types.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/types.ts
@@ -1,0 +1,1 @@
+export type DisplayArea = 'main' | 'relatedTables'

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useInitialAutoLayout.ts
@@ -14,11 +14,14 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useERDContentContext } from './ERDContentContext'
 import { computeAutoLayout } from './computeAutoLayout'
 import { highlightNodesAndEdges } from './highlightNodesAndEdges'
+import type { DisplayArea } from './types'
 
-export const useInitialAutoLayout = (
-  nodes: Node[],
-  shouldFitViewToActiveTable: boolean,
-) => {
+type Params = {
+  nodes: Node[]
+  displayArea: DisplayArea
+}
+
+export const useInitialAutoLayout = ({ nodes, displayArea }: Params) => {
   const [initializeComplete, setInitializeComplete] = useState(false)
 
   const tableNodesInitialized = useMemo(
@@ -41,11 +44,14 @@ export const useInitialAutoLayout = (
     const activeTableName = getActiveTableNameFromUrl()
     updateActiveTableName(activeTableName)
 
-    const hiddenNodeIds = await getHiddenNodeIdsFromUrl()
-    addHiddenNodeIds(hiddenNodeIds)
+    const hiddenNodeIds: string[] = []
+    if (displayArea === 'main') {
+      hiddenNodeIds.push(...(await getHiddenNodeIdsFromUrl()))
+      addHiddenNodeIds(hiddenNodeIds)
 
-    const showMode = getShowModeFromUrl()
-    updateShowMode(showMode)
+      const showMode = getShowModeFromUrl()
+      updateShowMode(showMode)
+    }
 
     if (tableNodesInitialized) {
       setLoading(true)
@@ -64,7 +70,7 @@ export const useInitialAutoLayout = (
       setEdges(layoutedEdges)
 
       const fitViewOptions =
-        shouldFitViewToActiveTable && activeTableName
+        displayArea === 'main' && activeTableName
           ? { maxZoom: 1, duration: 300, nodes: [{ id: activeTableName }] }
           : { duration: 0 }
       await fitView(fitViewOptions)
@@ -74,6 +80,7 @@ export const useInitialAutoLayout = (
     }
   }, [
     nodes,
+    displayArea,
     getEdges,
     setNodes,
     setEdges,
@@ -81,7 +88,6 @@ export const useInitialAutoLayout = (
     fitView,
     initializeComplete,
     tableNodesInitialized,
-    shouldFitViewToActiveTable,
   ])
 
   useEffect(() => {

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useTableSelection/useTableSelection.ts
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDContent/useTableSelection/useTableSelection.ts
@@ -2,10 +2,11 @@ import { useCustomReactflow } from '@/features/reactflow/hooks'
 import { updateActiveTableName } from '@/stores'
 import { useCallback } from 'react'
 import { highlightNodesAndEdges } from '../highlightNodesAndEdges'
+import type { DisplayArea } from '../types'
 
 type SelectTableParams = {
   tableId: string
-  shouldFitViewToActiveTable: boolean
+  displayArea: DisplayArea
 }
 
 export const useTableSelection = () => {
@@ -13,7 +14,7 @@ export const useTableSelection = () => {
     useCustomReactflow()
 
   const selectTable = useCallback(
-    ({ tableId, shouldFitViewToActiveTable }: SelectTableParams) => {
+    ({ tableId, displayArea }: SelectTableParams) => {
       updateActiveTableName(tableId)
 
       const { nodes, edges } = highlightNodesAndEdges(getNodes(), getEdges(), {
@@ -23,7 +24,7 @@ export const useTableSelection = () => {
       setNodes(nodes)
       setEdges(edges)
 
-      if (shouldFitViewToActiveTable) {
+      if (displayArea === 'main') {
         fitView({
           maxZoom: 1,
           duration: 300,

--- a/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/ERDRenderer.tsx
@@ -83,6 +83,7 @@ export const ERDRenderer: FC<Props> = ({
                       key={`${nodes.length}-${showMode}`}
                       nodes={nodes}
                       edges={edges}
+                      displayArea="main"
                     />
                     <TableDetailDrawer />
                   </>

--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -22,7 +22,7 @@ export const TableNameMenuButton: FC<Props> = ({ node }) => {
   const handleClickMenuButton = (tableId: string) => () => {
     selectTable({
       tableId,
-      shouldFitViewToActiveTable: true,
+      displayArea: 'main',
     })
 
     selectTableLogEvent({


### PR DESCRIPTION
### **User description**
There were instances where the TableNodes displayed in the Related Tables were insufficient. 

The cause was that when rendering the TableNodes in the Related Tables, the query parameters—including hiddenTables and showMode, which are used for rendering the MainArea—were taken into account. 

I resolved the issue by adding logic to consider the section where ERDContent is rendered.

### Related Issue
<!-- Mention the related issue number if applicable. -->

N/A

### Testing
<!-- Briefly describe the testing steps or results. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/1021aec5-5f46-40b5-a980-68275eab6343" /> | <video src="https://github.com/user-attachments/assets/80518787-4859-4960-8664-4c733f2664b6" /> | 



### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Excluded `hiddenTables` and `showMode` query parameters from `ERDContent` rendering in `RelatedTables`.

- Introduced `DisplayArea` type to manage rendering context (`main` or `relatedTables`).

- Refactored `useInitialAutoLayout` and `useTableSelection` to use `displayArea` instead of feature flags.

- Updated components to pass `displayArea` for consistent behavior across rendering contexts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>ERDContent.tsx</strong><dd><code>Refactored `ERDContentInner` to use `displayArea` prop</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-ac50fc9ec72720523e17be1f4f2cee0df1e527176a4842d70e8101e03d7c3306">+8/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RelatedTables.tsx</strong><dd><code>Updated `RelatedTables` to pass `displayArea` prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-8cb4290fce7a4000ce8d164262c9e0f56302e463eb6b1d92e05e633d6ff5c7ab">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Added `DisplayArea` type for rendering context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-f1faa844748050109db9d3da29bac86fff9b230ce2a7ce2263a02f841d68bb55">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useInitialAutoLayout.ts</strong><dd><code>Refactored `useInitialAutoLayout` to use `displayArea`</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-de3aba10df71b3bcd0d1cd5c1f634e18c85a96916ec1e9c2c07f94104d2273c3">+16/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useTableSelection.ts</strong><dd><code>Updated `useTableSelection` to use `displayArea`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-e678b3b690fd0e5b3268705faae7882172af437927db3429a0123cf2faf2bfb0">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ERDRenderer.tsx</strong><dd><code>Passed `displayArea` as `main` in `ERDRenderer`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-8c3fcffc8422b04a1f3b4eb22b8aeaa9ff44a313f496964fdac07377e75c045b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TableNameMenuButton.tsx</strong><dd><code>Updated `TableNameMenuButton` to use `displayArea`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-8cda81268fa3f6521f9690cccda4cb7722e7d4c56576e4c7d3add962f5c50ba5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>TableDetail.tsx</strong><dd><code>Removed redundant `key` prop in `TableDetail`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-694653d4038dfd3b95db668593ad185a5cfa4959e20c50aae2b53192ad28dd7e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>young-owls-relate.md</strong><dd><code>Added changeset for bug fix and enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/746/files#diff-423536bd9cb3eb2849b173ba811e7697ea8db5ebaf2615d927c79a763b67188c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>