### PR TITLE
🐛 Fix file operations to support Windows compatibility

### DIFF
--- a/.changeset/dry-crews-whisper.md
+++ b/.changeset/dry-crews-whisper.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": patch
+---
+
+🐛 Fix file operations to support Windows compatibility. ref. https://github.com/liam-hq/liam/issues/751

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -1,7 +1,5 @@
-import { execFile } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { dirname } from 'node:path'
-import { resolve } from 'node:path'
+import { cpSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { SupportedFormat } from '@liam-hq/db-structure/parser'
 import { blueBright } from 'yoctocolors'
@@ -39,25 +37,14 @@ export const buildCommand = async (
     return errors
   }
 
-  // Ensure the output directory exists
-  execFile('mkdir', ['-p', outDir], (error) => {
-    if (error) {
-      errors.push(
-        new FileSystemError(`Error creating output directory: ${error}`),
-      )
-      return
-    }
-
-    execFile(
-      'cp',
-      ['-R', `${cliHtmlPath}/.`, outDir],
-      (error, _stdout, stderr) => {
-        if (error) {
-          errors.push(new FileSystemError(`Error copying files: ${stderr}`))
-        }
-      },
-    )
-  })
+  try {
+    // Ensure the output directory exists
+    mkdirSync(outDir, { recursive: true })
+    // Copy files recursively
+    cpSync(cliHtmlPath, outDir, { recursive: true })
+  } catch (error) {
+    errors.push(new FileSystemError(`Error processing files: ${error}`))
+  }
 
   if (errors.length === 0) {
     console.info(`


### PR DESCRIPTION
### **User description**
- Replaced `execFile` calls for `mkdir` and `cp` with native `fs` methods.
- Used `mkdirSync` with `{ recursive: true }` to ensure the output directory exists.
- Used `cpSync` with `{ recursive: true }` to copy files without relying on shell commands.
- Improved cross-platform compatibility by avoiding Unix-specific commands.

#### Related Issue

closes https://github.com/liam-hq/liam/issues/751


<!-- Mention the related issue number if applicable. -->


#### Testing
<!-- Briefly describe the testing steps or results. -->

The tests were run on a GitHub Actions Windows Server runner.

To verify the changes, I pushed another branch with two additional test commits:

- **bb17dd23cb46e2500b152bb900c40a924701ce91**  
  - Temporary: Added tarball  
  - Generated the CLI package tarball using `$ pnpm pack`.  
- **1fd221d57f8caf82a6f2da06204cb7a0d1478acb**  
  - Defined a temporary CI workflow.  
  - The workflow executed successfully.  
  - [GitHub Actions Run](https://github.com/liam-hq/liam/actions/runs/13407853420/job/37451072083)
    - <details><summary>Screenshot</summary>
      <img width="1148" alt="screenshot 2025-02-19 17 04 35" src="https://github.com/user-attachments/assets/c2613f6b-68e3-429e-b57d-09164d3557cc" />
      </details>



#### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced Unix-specific `execFile` calls with native `fs` methods.

- Ensured cross-platform compatibility for file operations.

- Used `mkdirSync` and `cpSync` for directory creation and file copying.

- Added a changeset file for versioning and documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Replace Unix-specific file operations with native methods</code></dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts

<li>Replaced <code>execFile</code> calls with <code>mkdirSync</code> and <code>cpSync</code>.<br> <li> Ensured output directory creation with <code>{ recursive: true }</code>.<br> <li> Improved error handling for file operations.<br> <li> Removed reliance on Unix-specific commands for cross-platform support.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/754/files#diff-40e5647ca5c26b5c00d835caebbd61f2952f36203890fe2b412fe24d1192ba45">+10/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dry-crews-whisper.md</strong><dd><code>Add changeset for Windows compatibility fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/dry-crews-whisper.md

<li>Added a changeset file documenting the bug fix.<br> <li> Referenced the related GitHub issue for context.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/754/files#diff-1a714f836c0e706e4b6aa472e9c193e988654254d0650b90355f9edb352562e6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>