### PR TITLE
✨ Add format detection to CLI build command

### DIFF
--- a/.changeset/twenty-swans-sin.md
+++ b/.changeset/twenty-swans-sin.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": patch
+---
+
+✨ Made `--format` optional in CLI command

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -9,7 +9,7 @@ import { runPreprocess } from '../runPreprocess.js'
 export const buildCommand = async (
   inputPath: string,
   outDir: string,
-  format: SupportedFormat,
+  format?: SupportedFormat,
 ): Promise<CliError[]> => {
   // generate schema.json
   const { errors: preprocessErrors } = await runPreprocess(

--- a/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
@@ -26,24 +26,24 @@ export async function runPreprocess(
   format: SupportedFormat,
 ): Promise<Output> {
   const input = await getInputContent(inputPath)
-let detectedFormat: SupportedFormat | undefined
+  let detectedFormat: SupportedFormat | undefined
 
-if(format === undefined) {
-  detectedFormat = detectFormat(inputPath)
-}else{
-  detectedFormat = format
-}
-
-if(detectedFormat === undefined){
-  return {
-    outputFilePath: null,
-    errors: [
-      new ArgumentError(
-        `--format is missing, invalid, or specifies an unsupported format. Please provide a valid format.`,
-      ),
-    ],
+  if (format === undefined) {
+    detectedFormat = detectFormat(inputPath)
+  } else {
+    detectedFormat = format
   }
-}
+
+  if (detectedFormat === undefined) {
+    return {
+      outputFilePath: null,
+      errors: [
+        new ArgumentError(
+          '--format is missing, invalid, or specifies an unsupported format. Please provide a valid format.',
+        ),
+      ],
+    }
+  }
 
   const result = v.safeParse(supportedFormatSchema, detectedFormat)
   if (!result.success) {


### PR DESCRIPTION
### **User description**
#### Summary
- Made `--format` optional in `npx @liam-hq/cli erd build --input <path|url>`.
- Applied `detectFormat` in `runPreprocess` to automatically determine the schema format.
- Updated `buildCommand` to accept an optional `format` parameter (`format?: SupportedFormat`).
- This improves CLI UX by allowing users to omit `--format`, making the command more intuitive.


https://github.com/user-attachments/assets/586b2933-0f73-4e60-9eab-6f949ab080a5

It is now possible to run npx @liam-hq/cli erd build --input <path|url> without specifying --format <format>.

#### Related Issue
resolve: https://github.com/liam-hq/liam/issues/418

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
Since this PR changes the CLI behavior by allowing `--format` to be optional, should we update the documentation as part of this PR?
- If so, where should we add this information? (`README.md`, etc.)
- Or should we create a follow-up PR to update the docs separately?


___

### **PR Type**
Enhancement


___

### **Description**
- Made the `--format` parameter optional in CLI commands.

- Added `detectFormat` to automatically determine schema format.

- Updated error handling for missing or invalid formats.

- Enhanced CLI UX by simplifying the `erd build` command.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update `buildCommand` to support optional format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts

<li>Made the <code>format</code> parameter optional in <code>buildCommand</code>.<br> <li> Adjusted function signature to accept optional format.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/760/files#diff-40e5647ca5c26b5c00d835caebbd61f2952f36203890fe2b412fe24d1192ba45">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runPreprocess.ts</strong><dd><code>Add format detection and error handling in `runPreprocess`</code></dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts

<li>Integrated <code>detectFormat</code> to determine schema format automatically.<br> <li> Added logic to handle missing or invalid <code>--format</code> values.<br> <li> Updated parsing to use detected format if provided.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/760/files#diff-0a783f48946cfba77cba86c6adb32c3d332bedcf4413c65ccf8397e4543a20e4">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>twenty-swans-sin.md</strong><dd><code>Add changeset for optional `--format` in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/twenty-swans-sin.md

- Documented the change making `--format` optional in CLI.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/760/files#diff-6fe13090a5dc8347266a5290f198006b5c96f06c8ca048cbf3c542d0b3d7d4b6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>