### PR TITLE
Revert "Fix: Rollup error in initCommand/index.ts"

### DIFF
--- a/frontend/packages/cli/src/cli/initCommand/index.ts
+++ b/frontend/packages/cli/src/cli/initCommand/index.ts
@@ -16,8 +16,7 @@ const initCommand = new Command('init').description(
 )
 
 // Map user-friendly selections to the correct --format value
-type FormatMap = Record<string, string>
-const formatMap: FormatMap = {
+const formatMap: Record<string, string> = {
   PostgreSQL: 'postgresql',
   'Ruby on Rails (schema.rb)': 'schemarb',
   'Prisma (schema.prisma)': 'prisma',


### PR DESCRIPTION
### **User description**
Reverts liam-hq/liam#779

Because it is not a direct solution to the problem. ref: https://github.com/liam-hq/liam/issues/778


___

### **PR Type**
Bug fix


___

### **Description**
- Reverts a previous fix for Rollup error in `initCommand/index.ts`.

- Restores the original type definition for `formatMap`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Revert type alias and restore `formatMap` structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/initCommand/index.ts

<li>Reverted the type alias <code>FormatMap</code> to inline type definition.<br> <li> Restored the original structure of <code>formatMap</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/782/files#diff-927569ca321915530a5c635f660996e7ea7da3e1c89046324e4cab2acb5e55c7">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>