### PR TITLE
wrapped the sidebarMenuItem componet with tooltip provider component …

### DIFF
--- a/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -1,62 +1,97 @@
-import { selectTableLogEvent } from '@/features/gtm/utils'
-import { useVersion } from '@/providers'
-import { SidebarMenuButton, SidebarMenuItem, Table2 } from '@liam-hq/ui'
-import clsx from 'clsx'
-import type { FC } from 'react'
-import { type TableNodeType, useTableSelection } from '../../ERDContent'
-import styles from './TableNameMenuButton.module.css'
-import { VisibilityButton } from './VisibilityButton'
+import { selectTableLogEvent } from "@/features/gtm/utils";
+import { useVersion } from "@/providers";
+import { SidebarMenuButton, SidebarMenuItem, Table2 } from "@liam-hq/ui";
+import clsx from "clsx";
+import { useRef, useState, type FC, useEffect } from "react";
+import { type TableNodeType, useTableSelection } from "../../ERDContent";
+import styles from "./TableNameMenuButton.module.css";
+import { VisibilityButton } from "./VisibilityButton";
+import {
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from "@liam-hq/ui";
 
 type Props = {
-  node: TableNodeType
-}
+  node: TableNodeType;
+};
 
 export const TableNameMenuButton: FC<Props> = ({ node }) => {
-  const name = node.data.table.name
+  const name = node.data.table.name;
 
-  const { selectTable } = useTableSelection()
+  const { selectTable } = useTableSelection();
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    if (textRef.current) {
+      setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
+    }
+  }, [name]);
 
   // TODO: Move handleClickMenuButton outside of TableNameMenuButton
   // after logging is complete
-  const { version } = useVersion()
+  const { version } = useVersion();
   const handleClickMenuButton = (tableId: string) => () => {
     selectTable({
       tableId,
-      displayArea: 'main',
-    })
+      displayArea: "main",
+    });
 
     selectTableLogEvent({
-      ref: 'leftPane',
+      ref: "leftPane",
       tableId,
       platform: version.displayedOn,
       gitHash: version.gitHash,
       ver: version.version,
       appEnv: version.envName,
-    })
-  }
+    });
+  };
 
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
-        className={clsx(
-          styles.button,
-          node.data.isActiveHighlighted && styles.active,
+    <TooltipProvider>
+      <TooltipRoot>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            className={clsx(
+              styles.button,
+              node.data.isActiveHighlighted && styles.active
+            )}
+            asChild
+          >
+            <div
+              // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
+              role="button"
+              tabIndex={0}
+              onClick={handleClickMenuButton(name)}
+              onKeyDown={handleClickMenuButton(name)}
+              aria-label={`Menu button for ${name}`}
+            >
+              <Table2 size="10px" />
+              {isTruncated ? (
+                <TooltipTrigger asChild>
+                  <span ref={textRef} className={styles.tableName}>
+                    {name}
+                  </span>
+                </TooltipTrigger>
+              ) : (
+                <span ref={textRef} className={styles.tableName}>
+                  {name}
+                </span>
+              )}
+
+              <VisibilityButton tableName={name} hidden={node.hidden} />
+            </div>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        {isTruncated && (
+          <TooltipPortal>
+            <TooltipContent>{name}</TooltipContent>
+          </TooltipPortal>
         )}
-        asChild
-      >
-        <div
-          // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
-          role="button"
-          tabIndex={0}
-          onClick={handleClickMenuButton(name)}
-          onKeyDown={handleClickMenuButton(name)}
-          aria-label={`Menu button for ${name}`}
-        >
-          <Table2 size="10px" />
-          <span className={styles.tableName}>{name}</span>
-          <VisibilityButton tableName={name} hidden={node.hidden} />
-        </div>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
-  )
-}
+      </TooltipRoot>
+    </TooltipProvider>
+  );
+};


### PR DESCRIPTION
### **User description**
…in tableNameMenuButton.tsx file

#### Related Issue
<!-- Mention the related issue number if applicable. -->

#### Testing
<!-- Briefly describe the testing steps or results. -->

#### Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Wrapped `SidebarMenuItem` with `TooltipProvider` for tooltips.

- Added tooltip functionality for truncated table names.

- Introduced state and effect to detect text truncation.

- Improved accessibility with ARIA attributes and semantic updates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TableNameMenuButton.tsx</strong><dd><code>Add tooltip and truncation detection for table names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx

<li>Wrapped <code>SidebarMenuItem</code> with <code>TooltipProvider</code> and <code>TooltipRoot</code>.<br> <li> Added <code>TooltipTrigger</code>, <code>TooltipPortal</code>, and <code>TooltipContent</code> for tooltips.<br> <li> Implemented truncation detection using <code>useRef</code>, <code>useState</code>, and <br><code>useEffect</code>.<br> <li> Enhanced accessibility with ARIA attributes and keyboard event <br>handling.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/783/files#diff-8cda81268fa3f6521f9690cccda4cb7722e7d4c56576e4c7d3add962f5c50ba5">+76/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>