### PR TITLE
🐛 integrate user editing state into related tables component

### DIFF
--- a/.changeset/empty-baboons-doubt.md
+++ b/.changeset/empty-baboons-doubt.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+🐛 integrate user editing state into related tables component

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/RelatedTables/RelatedTables.tsx
@@ -1,3 +1,4 @@
+import { useUserEditingActiveStore } from '@/stores'
 import { GotoIcon, IconButton, Waypoints as WaypointsIcon } from '@liam-hq/ui'
 import { type Edge, type Node, ReactFlowProvider } from '@xyflow/react'
 import { type FC, type MouseEvent, useCallback } from 'react'
@@ -12,6 +13,8 @@ type Props = {
 }
 
 export const RelatedTables: FC<Props> = ({ nodes, edges, onOpenMainPane }) => {
+  const { tableName } = useUserEditingActiveStore()
+
   const handleClick = useCallback(
     async (event: MouseEvent) => {
       event.stopPropagation()
@@ -42,6 +45,7 @@ export const RelatedTables: FC<Props> = ({ nodes, edges, onOpenMainPane }) => {
         <div className={styles.contentWrapper}>
           <ReactFlowProvider>
             <ERDContent
+              key={tableName}
               nodes={nodes}
               edges={edges}
               displayArea="relatedTables"


### PR DESCRIPTION
## Issue

- resolve: #781

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I would like to be able to select a series of tables and still see the related tables correctly, but The first selected related tables are displayed.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

I added key props so that RelatedTables re-renders when the selected table changes.

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/a24bb943-f3a9-4e8f-9d45-bf0ce428cc5b" /> | <video src="https://github.com/user-attachments/assets/5da500e6-35ff-431a-9820-0a04fe728a1e" /> | 



## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 5c06c79dd971c63154a2b08824c4779cb8b48283

- Fixed issue where related tables were not updated when switching tables.
- Integrated `useUserEditingActiveStore` to track active table state.
- Added `key` prop to force re-rendering of `RelatedTables` component.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelatedTables.tsx</strong><dd><code>Ensure `RelatedTables` updates on table selection change</code>&nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/RelatedTables/RelatedTables.tsx

<li>Imported <code>useUserEditingActiveStore</code> to track active table state.<br> <li> Added <code>key</code> prop to <code>ERDContent</code> to trigger re-render on table change.<br> <li> Integrated <code>tableName</code> from the store to ensure correct table rendering.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/798/files#diff-38719dc3117f0117a1bc8b7c56fa09723edb98398ac768ba280b7f317688ce1c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>empty-baboons-doubt.md</strong><dd><code>Document changes for related tables bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/empty-baboons-doubt.md

<li>Added a changeset entry for the bug fix.<br> <li> Documented the integration of user editing state.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/798/files#diff-353dc20acb0cc74a956b4d622806b386b8b7ad5b7a0d9a6af6ee7120c4b7a055">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>