### PR TITLE
🔧 fix runPreprocess to support undefined format

### DIFF
--- a/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/runPreprocess.ts
@@ -23,7 +23,7 @@ type Output = {
 export async function runPreprocess(
   inputPath: string,
   outputDir: string,
-  format: SupportedFormat,
+  format: SupportedFormat | undefined,
 ): Promise<Output> {
   const input = await getInputContent(inputPath)
   let detectedFormat: SupportedFormat | undefined


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/768

## Why is this change needed?
This change is necessary to fix a TypeScript build error in the CLI package. The format parameter was previously passed as an optional value, leading to a type mismatch. This fix ensures that runPreprocess correctly handles cases where format is undefined, allowing the build to complete successfully.

## What would you like reviewers to focus on?
Please check that:

The runPreprocess function now correctly supports an undefined format parameter.
The TypeScript type definitions align with the expected function behavior.
There are no unintended side effects in the CLI package.

## Testing Verification
The changes were verified locally by:

Running pnpm dev --filter @liam-hq/cli to confirm that the TypeScript error is resolved.
Reviewing the build output to ensure no new errors were introduced.
Running relevant CLI commands to verify functionality.

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
