### PR TITLE
Fix/truncated button change size on hover 794

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css
@@ -4,10 +4,18 @@
   text-overflow: ellipsis;
   width: 100%;
   flex: 1;
+  min-width: 0;
+  max-width: 100%;
+  display: block;
 }
 
 .button {
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
 }
 
 .active {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css
@@ -2,6 +2,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  width: 100%;
+  flex: 1;
 }
 
 .button {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css
@@ -4,18 +4,10 @@
   text-overflow: ellipsis;
   width: 100%;
   flex: 1;
-  min-width: 0;
-  max-width: 100%;
-  display: block;
 }
 
 .button {
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  width: 100%;
-  min-width: 0;
 }
 
 .active {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -74,6 +74,8 @@ export const TableNameMenuButton: FC<Props> = ({ node }) => {
           node.data.isActiveHighlighted && styles.active
         )}
         asChild
+        tooltip={name}
+        showtooltip={isTruncated}
       >
         <div
           // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -45,7 +45,7 @@ export const TableNameMenuButton: FC<Props> = ({ node }) => {
       window.removeEventListener('resize', checkTruncation)
       observer.disconnect()
     }
-  }, [name])
+  }, [])
 
   // TODO: Move handleClickMenuButton outside of TableNameMenuButton
   // after logging is complete

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -1,22 +1,22 @@
-import { useTableSelection } from "@/features/erd/hooks";
-import type { TableNodeType } from "@/features/erd/types";
-import { selectTableLogEvent } from "@/features/gtm/utils";
-import { useVersion } from "@/providers";
-import { SidebarMenuButton, SidebarMenuItem, Table2 } from "@liam-hq/ui";
-import clsx from "clsx";
-import { type FC, useEffect, useRef, useState } from "react";
-import styles from "./TableNameMenuButton.module.css";
-import { VisibilityButton } from "./VisibilityButton";
+import { useTableSelection } from '@/features/erd/hooks'
+import type { TableNodeType } from '@/features/erd/types'
+import { selectTableLogEvent } from '@/features/gtm/utils'
+import { useVersion } from '@/providers'
+import { SidebarMenuButton, SidebarMenuItem, Table2 } from '@liam-hq/ui'
+import clsx from 'clsx'
+import { type FC, useEffect, useRef, useState } from 'react'
+import styles from './TableNameMenuButton.module.css'
+import { VisibilityButton } from './VisibilityButton'
 
 type Props = {
-  node: TableNodeType;
-};
+  node: TableNodeType
+}
 
 export const TableNameMenuButton: FC<Props> = ({ node }) => {
-  const name = node.data.table.name;
+  const name = node.data.table.name
 
-  const { selectTable } = useTableSelection();
-  const textRef = useRef<HTMLSpanElement>(null);
+  const { selectTable } = useTableSelection()
+  const textRef = useRef<HTMLSpanElement>(null)
   const [isTruncated, setIsTruncated] = useState<boolean>(false)
 
   useEffect(() => {
@@ -49,29 +49,29 @@ export const TableNameMenuButton: FC<Props> = ({ node }) => {
 
   // TODO: Move handleClickMenuButton outside of TableNameMenuButton
   // after logging is complete
-  const { version } = useVersion();
+  const { version } = useVersion()
   const handleClickMenuButton = (tableId: string) => () => {
     selectTable({
       tableId,
-      displayArea: "main",
-    });
+      displayArea: 'main',
+    })
 
     selectTableLogEvent({
-      ref: "leftPane",
+      ref: 'leftPane',
       tableId,
       platform: version.displayedOn,
       gitHash: version.gitHash,
       ver: version.version,
       appEnv: version.envName,
-    });
-  };
+    })
+  }
 
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
         className={clsx(
           styles.button,
-          node.data.isActiveHighlighted && styles.active
+          node.data.isActiveHighlighted && styles.active,
         )}
         asChild
         tooltip={name}
@@ -95,5 +95,5 @@ export const TableNameMenuButton: FC<Props> = ({ node }) => {
         </div>
       </SidebarMenuButton>
     </SidebarMenuItem>
-  );
-};
+  )
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx
@@ -1,98 +1,97 @@
-import { useTableSelection } from '@/features/erd/hooks'
-import type { TableNodeType } from '@/features/erd/types'
-import { selectTableLogEvent } from '@/features/gtm/utils'
-import { useVersion } from '@/providers'
-import { SidebarMenuButton, SidebarMenuItem, Table2 } from '@liam-hq/ui'
-import {
-  TooltipContent,
-  TooltipPortal,
-  TooltipProvider,
-  TooltipRoot,
-  TooltipTrigger,
-} from '@liam-hq/ui'
-import clsx from 'clsx'
-import { type FC, useEffect, useRef, useState } from 'react'
-import styles from './TableNameMenuButton.module.css'
-import { VisibilityButton } from './VisibilityButton'
+import { useTableSelection } from "@/features/erd/hooks";
+import type { TableNodeType } from "@/features/erd/types";
+import { selectTableLogEvent } from "@/features/gtm/utils";
+import { useVersion } from "@/providers";
+import { SidebarMenuButton, SidebarMenuItem, Table2 } from "@liam-hq/ui";
+import clsx from "clsx";
+import { type FC, useEffect, useRef, useState } from "react";
+import styles from "./TableNameMenuButton.module.css";
+import { VisibilityButton } from "./VisibilityButton";
 
 type Props = {
-  node: TableNodeType
-}
+  node: TableNodeType;
+};
 
 export const TableNameMenuButton: FC<Props> = ({ node }) => {
-  const name = node.data.table.name
+  const name = node.data.table.name;
 
-  const { selectTable } = useTableSelection()
-  const textRef = useRef<HTMLSpanElement>(null)
-  const [isTruncated, setIsTruncated] = useState(false)
+  const { selectTable } = useTableSelection();
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState<boolean>(false)
 
   useEffect(() => {
-    if (textRef.current) {
-      setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth)
+    const checkTruncation = () => {
+      if (textRef.current) {
+        const element = textRef.current
+        const isTruncated = element.scrollWidth > element.clientWidth
+        setIsTruncated(isTruncated)
+      }
     }
-  }, [])
+
+    // Initial check after a small delay to ensure DOM is rendered
+    const timeoutId = setTimeout(checkTruncation, 0)
+
+    // Check on window resize and when sidebar width changes
+    window.addEventListener('resize', checkTruncation)
+
+    // Add a mutation observer to watch for width changes
+    const observer = new ResizeObserver(checkTruncation)
+    if (textRef.current) {
+      observer.observe(textRef.current)
+    }
+
+    return () => {
+      clearTimeout(timeoutId)
+      window.removeEventListener('resize', checkTruncation)
+      observer.disconnect()
+    }
+  }, [name])
 
   // TODO: Move handleClickMenuButton outside of TableNameMenuButton
   // after logging is complete
-  const { version } = useVersion()
+  const { version } = useVersion();
   const handleClickMenuButton = (tableId: string) => () => {
     selectTable({
       tableId,
-      displayArea: 'main',
-    })
+      displayArea: "main",
+    });
 
     selectTableLogEvent({
-      ref: 'leftPane',
+      ref: "leftPane",
       tableId,
       platform: version.displayedOn,
       gitHash: version.gitHash,
       ver: version.version,
       appEnv: version.envName,
-    })
-  }
+    });
+  };
 
   return (
-    <TooltipProvider>
-      <TooltipRoot>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            className={clsx(
-              styles.button,
-              node.data.isActiveHighlighted && styles.active,
-            )}
-            asChild
-          >
-            <div
-              // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
-              role="button"
-              tabIndex={0}
-              onClick={handleClickMenuButton(name)}
-              onKeyDown={handleClickMenuButton(name)}
-              aria-label={`Menu button for ${name}`}
-            >
-              <Table2 size="10px" />
-              {isTruncated ? (
-                <TooltipTrigger asChild>
-                  <span ref={textRef} className={styles.tableName}>
-                    {name}
-                  </span>
-                </TooltipTrigger>
-              ) : (
-                <span ref={textRef} className={styles.tableName}>
-                  {name}
-                </span>
-              )}
-
-              <VisibilityButton tableName={name} hidden={node.hidden} />
-            </div>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-        {isTruncated && (
-          <TooltipPortal>
-            <TooltipContent>{name}</TooltipContent>
-          </TooltipPortal>
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        className={clsx(
+          styles.button,
+          node.data.isActiveHighlighted && styles.active
         )}
-      </TooltipRoot>
-    </TooltipProvider>
-  )
-}
+        asChild
+      >
+        <div
+          // biome-ignore lint/a11y/useSemanticElements: Implemented with div button to be button in button
+          role="button"
+          tabIndex={0}
+          onClick={handleClickMenuButton(name)}
+          onKeyDown={handleClickMenuButton(name)}
+          aria-label={`Menu button for ${name}`}
+        >
+          <Table2 size="10px" />
+
+          <span ref={textRef} className={styles.tableName}>
+            {name}
+          </span>
+
+          <VisibilityButton tableName={name} hidden={node.hidden} />
+        </div>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+};

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -86,7 +86,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  right: var(--spacing-5);
+  right: var(--spacing-3);
   border-radius: var(--border-radius-base);
   padding: 0 var(--spacing-1, 4px);
 }

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -298,7 +298,7 @@ const SidebarMenuButton = forwardRef<
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button'
-    const { state } = useSidebar()
+    
 
     const button = (
       <Comp

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -290,10 +290,11 @@ const SidebarMenuButton = forwardRef<
     asChild?: boolean
     isActive?: boolean
     tooltip?: string | ComponentProps<typeof TooltipContent>
+    showtooltip?: boolean
   }
 >(
   (
-    { asChild = false, isActive = false, tooltip, className, ...props },
+    { asChild = false, isActive = false, tooltip, className, showtooltip, ...props },
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button'
@@ -323,9 +324,9 @@ const SidebarMenuButton = forwardRef<
       <TooltipRoot>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent
-          side="right"
-          align="center"
-          hidden={state !== 'collapsed'}
+          side="top"
+          align="end"
+          hidden={!showtooltip}
           {...tooltip}
         />
       </TooltipRoot>

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -331,7 +331,7 @@ const SidebarMenuButton = forwardRef<
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent
           side="top"
-          align="end"
+          align="center"
           hidden={!showtooltip}
           {...tooltip}
         />

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.tsx
@@ -294,11 +294,17 @@ const SidebarMenuButton = forwardRef<
   }
 >(
   (
-    { asChild = false, isActive = false, tooltip, className, showtooltip, ...props },
+    {
+      asChild = false,
+      isActive = false,
+      tooltip,
+      className,
+      showtooltip,
+      ...props
+    },
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button'
-    
 
     const button = (
       <Comp


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at eb5850419ff1558c418cf81f77819e64eb124492

- Implemented text truncation detection for table names.
  - Added `ResizeObserver` for dynamic truncation checks.
  - Tooltip visibility now depends on truncation state.
- Updated `SidebarMenuButton` to support conditional tooltips.
  - Introduced `showtooltip` prop for tooltip control.
  - Adjusted tooltip alignment and visibility logic.
- Improved styling for table name container.
  - Ensured proper truncation and responsive design.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TableNameMenuButton.tsx</strong><dd><code>Implement text truncation detection and tooltip control</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.tsx

<li>Added logic to detect text truncation using <code>ResizeObserver</code>.<br> <li> Updated tooltip behavior to show only when text is truncated.<br> <li> Refactored event listeners for resize and DOM changes.<br> <li> Simplified tooltip integration with <code>SidebarMenuButton</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/820/files#diff-a48040ff3bb203c0c5144c96034d1c08a03a797d4df0bf2fc97c2074caa5d370">+74/-73</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Sidebar.tsx</strong><dd><code>Add conditional tooltip support to SidebarMenuButton</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/ui/src/components/Sidebar/Sidebar.tsx

<li>Added <code>showtooltip</code> prop to control tooltip visibility.<br> <li> Adjusted tooltip alignment and visibility logic.<br> <li> Refactored tooltip integration for <code>SidebarMenuButton</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/820/files#diff-4877efceb404121c866d2574bcd7d5bafdb6d2fb3c88c1abc4dc41741224b6b2">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableNameMenuButton.module.css</strong><dd><code>Improve styling for table name truncation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/TableNameMenuButton/TableNameMenuButton.module.css

<li>Updated <code>.tableName</code> styles for proper truncation.<br> <li> Enhanced <code>.button</code> styles for responsive design.<br> <li> Added flex properties for alignment and spacing.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/820/files#diff-3ab40cae6f42a9f2c06b049d9768f9de9586aaded4f0317af283697c5cd08584">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>