### PR TITLE
💄Fixed an issue where the length of the TableNameButton text would change when hovering

### DIFF
--- a/.changeset/eight-parrots-relate.md
+++ b/.changeset/eight-parrots-relate.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+💄Fixed an issue where the length of the Sidebar button text would change when hovering.

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -74,7 +74,6 @@
 }
 
 .sidebarMenuButton:hover {
-  padding-right: var(--spacing-9);
   background: var(--pane-background-hover);
 }
 
@@ -83,10 +82,6 @@
 }
 
 .sidebarMenuAction {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: var(--spacing-3);
   border-radius: var(--border-radius-base);
   padding: 0 var(--spacing-1, 4px);
 }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/764
- ref: https://github.com/liam-hq/liam/pull/820

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

As the title says.
ref: https://github.com/liam-hq/liam/pull/820#issuecomment-2705263610

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

|before|after|
| --- | --- |
| <video src="https://github.com/user-attachments/assets/74eb0752-f085-4118-b844-74269f4defbb" /> | <video src="https://github.com/user-attachments/assets/0da8b158-a61a-40d0-ad17-edde86cd6a59" /> |




## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at a1a9751c3fe0514227ec2f486e8b005e3a7b4239

- Fixed an issue where Sidebar button text length changed on hover.
- Removed unnecessary padding adjustment on hover for `.sidebarMenuButton`.
- Simplified `.sidebarMenuAction` by removing absolute positioning.
- Updated changeset to document the fix and improvement.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sidebar.module.css</strong><dd><code>Fix and simplify Sidebar button hover behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/ui/src/components/Sidebar/Sidebar.module.css

<li>Removed padding adjustment on hover for <code>.sidebarMenuButton</code>.<br> <li> Simplified <code>.sidebarMenuAction</code> by removing absolute positioning.<br> <li> Improved hover behavior for Sidebar buttons.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/825/files#diff-cf94aa961dba4df5a06b112782bdd9eae6939b64806c9b738ad29cdcbdbd1610">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eight-parrots-relate.md</strong><dd><code>Document Sidebar button hover fix in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/eight-parrots-relate.md

- Added a changeset entry documenting the Sidebar button hover fix.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/825/files#diff-fa382e7c04259eaed24c34db181ad1c6980b5a9d1ad1d1fde49d274414d10537">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>