### PR TITLE
✨ Improve DropdownMenu keyboard accessibility

### DIFF
--- a/.changeset/mean-houses-film.md
+++ b/.changeset/mean-houses-film.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+✨ Improve DropdownMenu keyboard accessibility

--- a/frontend/packages/ui/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/frontend/packages/ui/src/components/DropdownMenu/DropdownMenu.module.css
@@ -57,7 +57,8 @@
   color: var(--primary-accent);
 }
 
-.item:hover {
+.item:hover,
+.item:focus {
   background-color: var(--dropdown-background-hover);
 }
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/683

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

The `DropdownMenu` is actually controllable by keyboard but it doesn't show any indicator and hard to use. This change will add styles to make uses be able to control the component by keyboards.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

1. run `pnpm run dev --filter @liam-hq/erd-web` and visit "localhost:3001"
2. focus Show mode menu button by pressing the Tab key, and press Space to open.
3. press Arrow Up/Down to focus on items and press either Enter or Space to select it.

https://github.com/user-attachments/assets/589acc24-48a4-4f96-b99e-fc79040caa74


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->

In the issue, it requires "Set focus on the currently selected mode when the menu is opened." but this change doesn't satisfied it, it focus on the first element always. However, it looks this is the required specification of `menuitemradio` role. 

> When a menu opens, or when a menubar receives focus, keyboard focus is placed on the first item.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemradio_role#keyboard_interactions

radix-ui, which is the base component of `DropdownMenu`, also follows this specification, so I just used it.
