### PR TITLE
test: Disable Vercel Toolbar in VRT screenshots

### DIFF
--- a/frontend/packages/e2e/tests/vrt/vrt.test.ts
+++ b/frontend/packages/e2e/tests/vrt/vrt.test.ts
@@ -5,6 +5,9 @@ const screenshot = async (page: Page, targetPage: TargetPage) => {
   await page.goto(targetPage.path)
   await expect(page.getByRole('status', { name: 'Loading' })).toBeHidden()
 
+  // Turn off the Vercel Toolbar in the Preview environment.
+  await page.keyboard.press('ControlOrMeta+.')
+
   await expect(page).toHaveScreenshot({ fullPage: true })
 }
 


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


Add keyboard shortcut to turn off Vercel Toolbar during visual regression testing to ensure consistent screenshot captures

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

VRT is green ✅ 

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 158ca1b8e3c55c201b6cf52fa1f9ab6b9afd8e93

- Added a keyboard shortcut to disable the Vercel Toolbar.
- Ensured consistent screenshot captures during visual regression testing.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vrt.test.ts</strong><dd><code>Disable Vercel Toolbar for consistent VRT screenshots</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/e2e/tests/vrt/vrt.test.ts

<li>Added a keyboard shortcut to disable the Vercel Toolbar.<br> <li> Ensured the toolbar is turned off before taking screenshots.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/850/files#diff-7562e3c4e16d89f0cf3e0163c5389fec2d9dbb446d072d2b0ec9cb1597f8ede1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>