### PR TITLE
🐛 fix: Apply repositoryDbId

### DIFF
--- a/frontend/apps/app/src/functions/postComment.ts
+++ b/frontend/apps/app/src/functions/postComment.ts
@@ -9,17 +9,17 @@ export async function postComment(
   payload: ReviewResponse,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const { reviewComment, pullRequestId, repositoryId } = payload
+    const { reviewComment, pullRequestId, repositoryDbId } = payload
 
     // Get repository information
     const repository = await prisma.repository.findUnique({
       where: {
-        id: repositoryId,
+        id: repositoryDbId,
       },
     })
 
     if (!repository) {
-      throw new Error(`Repository with ID ${repositoryId} not found`)
+      throw new Error(`Repository with ID ${repositoryDbId} not found`)
     }
 
     // Check if there's an existing PR record with a comment

--- a/frontend/apps/app/src/functions/processSavePullRequest.ts
+++ b/frontend/apps/app/src/functions/processSavePullRequest.ts
@@ -25,6 +25,7 @@ export type SavePullRequestResult = {
     changes: number
     patch: string
   }>
+  repositoryDbId: number
 }
 
 export async function processSavePullRequest(
@@ -79,5 +80,6 @@ export async function processSavePullRequest(
     success: true,
     prId: prRecord.id,
     schemaChanges,
+    repositoryDbId: repository.id,
   }
 }

--- a/frontend/apps/app/src/trigger/jobs.ts
+++ b/frontend/apps/app/src/trigger/jobs.ts
@@ -35,6 +35,7 @@ export const savePullRequestTask = task({
         projectId: undefined,
         repositoryId: payload.repositoryId,
         schemaChanges: result.schemaChanges,
+        repositoryDbId: result.repositoryDbId,
       })
 
       return result
@@ -69,6 +70,7 @@ export const saveReviewTask = task({
         projectId: payload.projectId,
         pullRequestId: payload.pullRequestId,
         repositoryId: payload.repositoryId,
+        repositoryDbId: payload.repositoryDbId,
       })
       return { success: true }
     } catch (error) {

--- a/frontend/apps/app/src/types/index.ts
+++ b/frontend/apps/app/src/types/index.ts
@@ -16,6 +16,7 @@ export type GenerateReviewPayload = {
     changes: number
     patch: string
   }>
+  repositoryDbId: number
 }
 
 export type ReviewResponse = {
@@ -23,4 +24,5 @@ export type ReviewResponse = {
   projectId: number | undefined
   pullRequestId: number
   repositoryId: number
+  repositoryDbId: number
 }


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at d909d13df3adb1b44f9e08279299f293f5360b79

- Replaced `repositoryId` with `repositoryDbId` across multiple files for consistency.
- Updated function parameters and error messages to reflect the new variable name.
- Added `repositoryDbId` to payloads and return objects in several functions.
- Ensured seamless integration of `repositoryDbId` in task triggers and type definitions.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postComment.ts</strong><dd><code>Refactor to use `repositoryDbId` in postComment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/src/functions/postComment.ts

<li>Replaced <code>repositoryId</code> with <code>repositoryDbId</code> in function parameters.<br> <li> Updated error messages to use <code>repositoryDbId</code>.<br> <li> Adjusted database query to use <code>repositoryDbId</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/898/files#diff-b68b23a170974106fdbf6cfbf1fae9956a6d019b36721cc73748b01c1b567636">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>processSavePullRequest.ts</strong><dd><code>Include `repositoryDbId` in processSavePullRequest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/src/functions/processSavePullRequest.ts

<li>Added <code>repositoryDbId</code> to the return object.<br> <li> Updated function logic to include <code>repositoryDbId</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/898/files#diff-cff950b9d59239ee4634fa2d3f3bcbd37161c360ac56bc4fb431fca1659e2e5c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>jobs.ts</strong><dd><code>Integrate `repositoryDbId` into task triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/src/trigger/jobs.ts

<li>Added <code>repositoryDbId</code> to task payloads.<br> <li> Updated task triggers to include <code>repositoryDbId</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/898/files#diff-f59dcca9048641d0588315ab628cc432c0f9b951059a5318eacd7166e3692bd3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Extend types to include `repositoryDbId`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/src/types/index.ts

<li>Added <code>repositoryDbId</code> to <code>GenerateReviewPayload</code> and <code>ReviewResponse</code> <br>types.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/898/files#diff-b089b8d8679891df678d348c9fdae73d44122ca2a733b8ea7ae163265ee39800">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>