### PR TITLE
🔧 Refactor getAuthCallbackUrl function to handle VERCEL_URL environment variable

### DIFF
--- a/frontend/apps/app/app/(app)/app/login/actions.ts
+++ b/frontend/apps/app/app/(app)/app/login/actions.ts
@@ -10,7 +10,9 @@ function getAuthCallbackUrl({
   next = '/app',
   provider,
 }: { next?: string; provider: OAuthProvider }): string {
-  let url = process.env.VERCEL_URL ?? 'http://localhost:3001/'
+  let url = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'http://localhost:3001/'
   url = url.endsWith('/') ? url : `${url}/`
   return `${url}app/auth/callback/${provider}?next=${encodeURIComponent(next)}`
 }


### PR DESCRIPTION
## Issue

- resolve:


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
In the preview and production environments, fallback to localhost:3001 occurred, preventing the request from reaching the final code receiving endpoint.

The update addresses URL protocol handling across all environments (production, preview, and local development). The solution explicitly prepends https:// to VERCEL_URL in both production and preview environments, while maintaining http:// for local development:


https://github.com/user-attachments/assets/e28fa9d3-3a2a-4cfe-b3c7-5eddd7176242



## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at d9b9565a24586fbc3930ac33b39ece68e2387d2f

- Refactored `getAuthCallbackUrl` to handle `VERCEL_URL` environment variable.
- Ensured correct URL protocol for production, preview, and local environments.
- Improved URL handling by appending a trailing slash if missing.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Refactored `getAuthCallbackUrl` for environment-specific URL handling</code></dd></summary>
<hr>

frontend/apps/app/app/(app)/app/login/actions.ts

<li>Updated <code>getAuthCallbackUrl</code> to prepend <code>https://</code> to <code>VERCEL_URL</code> in <br>production and preview environments.<br> <li> Maintained <code>http://</code> for local development when <code>VERCEL_URL</code> is undefined.<br> <li> Ensured the URL ends with a trailing slash.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/899/files#diff-972ff9c03d82039efa179ec980d8691600b790985f3930d2b81f6eceb9762c4f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>