### PR TITLE
🔧 Make ``projectId`` nullable in ``OverallReview`` table.

### DIFF
--- a/frontend/apps/app/package.json
+++ b/frontend/apps/app/package.json
@@ -12,6 +12,7 @@
     "@next/third-parties": "15.1.5",
     "@octokit/auth-app": "6.1.3",
     "@octokit/rest": "20.0.2",
+    "@prisma/client": "6.4.1",
     "@sentry/nextjs": "8",
     "@trigger.dev/sdk": "3.3.17",
     "cheerio": "1.0.0",

--- a/frontend/apps/app/src/functions/__tests__/postComment.test.ts
+++ b/frontend/apps/app/src/functions/__tests__/postComment.test.ts
@@ -94,7 +94,7 @@ describe('postComment', () => {
 
     const testPayload = {
       reviewComment: 'Test review comment',
-      projectId: testProject.id,
+      projectId: testProject.id ?? null,
       pullRequestId: testPullRequest.id,
       repositoryId: testRepo.id,
     }
@@ -133,7 +133,7 @@ describe('postComment', () => {
 
     const testPayload = {
       reviewComment: 'Updated review comment',
-      projectId: testProject.id,
+      projectId: testProject.id ?? null,
       pullRequestId: testPullRequest.id,
       repositoryId: testRepo.id,
     }
@@ -154,7 +154,7 @@ describe('postComment', () => {
   it('should throw error when repository not found', async () => {
     const testPayload = {
       reviewComment: 'Test review comment',
-      projectId: testProject.id,
+      projectId: testProject.id ?? null,
       pullRequestId: testPullRequest.id,
       repositoryId: 999, // Non-existent repository ID
     }
@@ -167,7 +167,7 @@ describe('postComment', () => {
   it('should throw error when pull request not found', async () => {
     const testPayload = {
       reviewComment: 'Test review comment',
-      projectId: testProject.id,
+      projectId: testProject.id ?? null,
       pullRequestId: 999, // Non-existent pull request ID
       repositoryId: testRepo.id,
     }
@@ -188,7 +188,7 @@ describe('postComment', () => {
 
     const testPayload = {
       reviewComment: 'Test review comment',
-      projectId: testProject.id,
+      projectId: testProject.id ?? null,
       pullRequestId: prWithoutMigration.id,
       repositoryId: testRepo.id,
     }

--- a/frontend/apps/app/src/functions/processSaveReview.ts
+++ b/frontend/apps/app/src/functions/processSaveReview.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@liam-hq/db'
+import type { Prisma } from '@prisma/client'
 import type { ReviewResponse } from '../types'
 
 export async function processSaveReview(
@@ -15,25 +16,25 @@ export async function processSaveReview(
       throw new Error('PullRequest not found')
     }
 
-    if (payload.projectId === undefined) {
-      throw new Error('ProjectId is required')
-    }
-
     // create overall review
     await prisma.overallReview.create({
       data: {
-        project: {
-          connect: {
-            id: payload.projectId,
-          },
-        },
+        ...(payload.projectId
+          ? {
+              project: {
+                connect: {
+                  id: payload.projectId,
+                },
+              },
+            }
+          : {}),
         pullRequest: {
           connect: {
             id: pullRequest.id,
           },
         },
         reviewComment: payload.reviewComment,
-      },
+      } as Prisma.OverallReviewCreateInput,
     })
 
     return {

--- a/frontend/apps/app/src/trigger/jobs.ts
+++ b/frontend/apps/app/src/trigger/jobs.ts
@@ -66,7 +66,7 @@ export const saveReviewTask = task({
       await processSaveReview(payload)
       await postCommentTask.trigger({
         reviewComment: payload.reviewComment,
-        projectId: payload.projectId,
+        projectId: undefined,
         pullRequestId: payload.pullRequestId,
         repositoryId: payload.repositoryId,
       })

--- a/frontend/packages/db/prisma/migrations/20250314091509_make_overall_review_project_id_nullable/migration.sql
+++ b/frontend/packages/db/prisma/migrations/20250314091509_make_overall_review_project_id_nullable/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "OverallReview" DROP CONSTRAINT "OverallReview_projectId_fkey";
+
+-- AlterTable
+ALTER TABLE "OverallReview" ALTER COLUMN "projectId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "OverallReview" ADD CONSTRAINT "OverallReview_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/frontend/packages/db/prisma/schema.prisma
+++ b/frontend/packages/db/prisma/schema.prisma
@@ -57,8 +57,8 @@ model Migration {
 
 model OverallReview {
   id            Int     @id @default(autoincrement())
-  projectId     Int
-  project       Project    @relation(fields: [projectId], references: [id])
+  projectId     Int?
+  project       Project?    @relation(fields: [projectId], references: [id])
   pullRequestId Int
   pullRequest   PullRequest @relation(fields: [pullRequestId], references: [id])
   reviewComment String?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@octokit/rest':
         specifier: 20.0.2
         version: 20.0.2
+      '@prisma/client':
+        specifier: 6.4.1
+        version: 6.4.1(prisma@6.4.1(typescript@5.8.2))(typescript@5.8.2)
       '@sentry/nextjs':
         specifier: '8'
         version: 8.55.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.2(@opentelemetry/api@1.9.0)(@playwright/test@1.51.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.98.0(esbuild@0.25.1))


### PR DESCRIPTION
## Issue

Since the ``projectId`` is passed as undefined at the beginning of the job, we have taken action to make it nullable to avoid errors when saving the ``OverallReview``.

https://github.com/liam-hq/liam/blob/0ca2e9c0da1acbf6ac59a6e13bf6291e26821e90/frontend/apps/app/app/api/webhook/github/route.ts#L52-L59

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

We can run: `` pnpm test:vitest`` at frontend/apps/app

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at a1780228ec20e18a07e7fcc6c7ec4a6b6c3236a8

- Made `projectId` nullable in `OverallReview` table to prevent errors.
- Updated tests to handle nullable `projectId` scenarios.
- Adjusted logic in `processSaveReview` to account for optional `projectId`.
- Added migration script to modify database schema for `OverallReview`.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>postComment.test.ts</strong><dd><code>Updated tests to handle nullable `projectId`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-58308c61129be76faeaad0f743472d7d66754a75070be183f48601904626d412">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>processSaveReview.ts</strong><dd><code>Adjusted logic to handle optional `projectId`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-7b41fedb54d651ba2f76da77ee59297ed2b76c1eaa10a72feb66a7b687469359">+11/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>jobs.ts</strong><dd><code>Set `projectId` to undefined in task payload.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-f59dcca9048641d0588315ab628cc432c0f9b951059a5318eacd7166e3692bd3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Added `@prisma/client` dependency.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-1cb683806b3ef955a38fae27b87a08febf12a8b1465dedad3a3f92c0136f132a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Updated lockfile to include `@prisma/client` dependency.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>migration.sql</strong><dd><code>Added migration to make `projectId` nullable in `OverallReview`.</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-84bd12acd08aac248dd6e82a050201cff5e552e7b5af6c17e3b20f081780b4eb">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.prisma</strong><dd><code>Updated schema to make `projectId` nullable in `OverallReview`.</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/904/files#diff-4db42f5f6ccb9d136f2dacd9f88bda16ba12ebc00fb74fd219d4383f4de52bba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>