### PR TITLE
✨ Add --output-dir option to specify output directory

### DIFF
--- a/.changeset/rare-rings-warn.md
+++ b/.changeset/rare-rings-warn.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": minor
+---
+
+✨ Add --output-dir option to specify output directory

--- a/frontend/apps/docs/content/docs/cli/ci-cd.mdx
+++ b/frontend/apps/docs/content/docs/cli/ci-cd.mdx
@@ -47,6 +47,7 @@ jobs:
 
       # 2. Generate the ER diagram
       - name: Generate ER Diagram
+        # You can specify a custom output directory with --output-dir option if needed
         run: liam erd build --input ./db/schema.rb --format=schemarb
 
       # 3. Publish the build artifacts (dist folder) to a static hosting service
@@ -66,7 +67,7 @@ The same approach can be applied to hosting services such as [Cloudflare Pages](
 
 ## Liam ERD’s HTML Structure (Vite-based SPA)
 
-When you run `npx @liam-hq/cli erd build` or `liam erd build`, a `./dist` directory is created with the following structure. Here, `index.html` acts as the single entry point for your **single-page application (SPA)**:
+When you run `npx @liam-hq/cli erd build` or `liam erd build`, a `./dist` directory (or the directory specified by `--output-dir` option) is created with the following structure. Here, `index.html` acts as the single entry point for your **single-page application (SPA)**:
 
 <Files>
   <Folder name="dist" defaultOpen>
@@ -130,6 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Generate ER Diagrams
+        # You can specify a custom output directory with --output-dir option if needed
         run: npx @liam-hq/cli erd build --input prisma/schema.prisma --format prisma
       - name: Deploy ERD to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/frontend/apps/docs/content/docs/cli/index.mdx
+++ b/frontend/apps/docs/content/docs/cli/index.mdx
@@ -24,7 +24,7 @@ Generate an ERD from your schema file using the following command:
 npx @liam-hq/cli erd build --input <path|url>
 ```
 
-This command processes your schema file and generates interactive ERD visualization files in the `dist` directory. The schema format is automatically detected (see [Format Auto-Detection](/docs/parser/supported-formats#format-auto-detection)), but you can override it using the `--format` option if needed. Also, output directly can be specified by `--output-dir` option.
+This command processes your schema file and generates interactive ERD visualization files in the `dist` directory. The schema format is automatically detected (see [Format Auto-Detection](/docs/parser/supported-formats#format-auto-detection)), but you can override it using the `--format` option if needed. Also, output directory can be specified by `--output-dir` option.
 
 Once the ERD is generated, you can view it by serving the files using a local HTTP server:
 

--- a/frontend/apps/docs/content/docs/cli/index.mdx
+++ b/frontend/apps/docs/content/docs/cli/index.mdx
@@ -24,12 +24,12 @@ Generate an ERD from your schema file using the following command:
 npx @liam-hq/cli erd build --input <path|url>
 ```
 
-This command processes your schema file and generates interactive ERD visualization files in the `dist` directory. The schema format is automatically detected (see [Format Auto-Detection](/docs/parser/supported-formats#format-auto-detection)), but you can override it using the `--format` option if needed.
+This command processes your schema file and generates interactive ERD visualization files in the `dist` directory. The schema format is automatically detected (see [Format Auto-Detection](/docs/parser/supported-formats#format-auto-detection)), but you can override it using the `--format` option if needed. Also, output directly can be specified by `--output-dir` option.
 
 Once the ERD is generated, you can view it by serving the files using a local HTTP server:
 
 ```package-install
-npx http-server dist
+npx http-server dist  # or your custom output directory
 ```
 
 The server will start and provide you with a local URL (typically http://localhost:8080) where you can view your ERD in a web browser.
@@ -40,6 +40,7 @@ You can use any hosting service of your choice to serve the generated files.
 
 - `--input <path|url>`: Path to your schema file or URL
 - `--format <format>`: (Optional) Override the auto-detected schema format
+- `--output-dir <path>`: (Optional) Specify the output directory for generated files (default: "dist")
 
 ### From GitHub Public Repository
 
@@ -56,12 +57,12 @@ npx @liam-hq/cli erd build --input https://raw.githubusercontent.com/user/repo/m
 
 ### Output
 
-The command generates a simple web application using [Vite](https://vite.dev/), which includes JavaScript, CSS, and HTML files, in the `dist` directory of your current working directory.
+The command generates a simple web application using [Vite](https://vite.dev/), which includes JavaScript, CSS, and HTML files, in the `dist` directory of your current working directory (or the directory specified by `--output-dir` option).
 
-To view the generated ERD, serve the `dist` directory using any HTTP server:
+To view the generated ERD, serve the output directory using any HTTP server:
 
 ```package-install
-npx http-server dist
+npx http-server dist  # or your custom output directory
 ```
 
 ## Sample Projects

--- a/frontend/packages/cli/src/cli/erdCommand/index.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.test.ts
@@ -32,5 +32,24 @@ describe('program', () => {
         )
       },
     )
+
+    it('should use custom output directory when --output-dir is specified', () => {
+      const inputFile = './fixtures/input.schema.rb'
+      const format = 'schemarb'
+      const customOutputDir = 'custom-output'
+
+      program.parse(
+        ['erd', 'build', '--input', inputFile, '--format', format, '--output-dir', customOutputDir],
+        {
+          from: 'user',
+        },
+      )
+
+      expect(buildCommand).toHaveBeenCalledWith(
+        inputFile,
+        customOutputDir,
+        format,
+      )
+    })
   })
 })

--- a/frontend/packages/cli/src/cli/erdCommand/index.test.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.test.ts
@@ -39,7 +39,16 @@ describe('program', () => {
       const customOutputDir = 'custom-output'
 
       program.parse(
-        ['erd', 'build', '--input', inputFile, '--format', format, '--output-dir', customOutputDir],
+        [
+          'erd',
+          'build',
+          '--input',
+          inputFile,
+          '--format',
+          format,
+          '--output-dir',
+          customOutputDir,
+        ],
         {
           from: 'user',
         },

--- a/frontend/packages/cli/src/cli/erdCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/index.ts
@@ -1,10 +1,9 @@
-import path from 'node:path'
 import { supportedFormatSchema } from '@liam-hq/db-structure/parser'
 import { Command } from 'commander'
 import { actionRunner } from '../actionRunner.js'
 import { buildCommand } from './buildCommand/index.js'
 
-const distDir = path.join(process.cwd(), 'dist')
+const defaultDistDir = 'dist'
 
 const erdCommand = new Command('erd').description('ERD commands')
 
@@ -19,9 +18,14 @@ erdCommand
     '--format <format>',
     `Format of the input file (${supportedFormatSchema.options.join('|')})`,
   )
+  .option(
+    '--output-dir <path>',
+    `Output directory for generated files (default: "${defaultDistDir}")`,
+    defaultDistDir,
+  )
   .action(
     actionRunner((options) =>
-      buildCommand(options.input, distDir, options.format),
+      buildCommand(options.input, options.outputDir, options.format),
     ),
   )
 

--- a/frontend/packages/db-structure/package.json
+++ b/frontend/packages/db-structure/package.json
@@ -23,6 +23,7 @@
     "@liam-hq/configs": "workspace:*",
     "@pgsql/types": "15.0.2",
     "@prisma/generator-helper": "6.2.1",
+    "@types/node": "22.9.0",
     "json-refs": "3.0.15",
     "json-schema-to-zod": "2.6.0",
     "typescript": "5",

--- a/frontend/packages/db-structure/tsconfig.json
+++ b/frontend/packages/db-structure/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "module": "ESNext",
     "target": "ES2022",
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,10 +39,10 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: 0.3.42
-        version: 0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))
+        version: 0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1))
       '@langchain/openai':
         specifier: 0.4.4
-        version: 0.4.4(@langchain/core@0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8)))(encoding@0.1.13)(ws@8.18.1)
+        version: 0.4.4(@langchain/core@0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1)))(encoding@0.1.13)(ws@8.18.1)
       '@liam-hq/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -75,7 +75,7 @@ importers:
         version: 3.3.17(typescript@5.8.2)
       '@trigger.dev/sdk':
         specifier: 3.3.17
-        version: 3.3.17(zod@3.23.8)
+        version: 3.3.17(zod@3.24.1)
       cheerio:
         specifier: 1.0.0
         version: 1.0.0
@@ -381,6 +381,9 @@ importers:
       '@prisma/generator-helper':
         specifier: 6.2.1
         version: 6.2.1
+      '@types/node':
+        specifier: 22.9.0
+        version: 22.9.0
       json-refs:
         specifier: 3.0.15
         version: 3.0.15
@@ -392,7 +395,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 3.0.8
-        version: 3.0.8(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0)
+        version: 3.0.8(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.9.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0)
 
   frontend/packages/e2e:
     devDependencies:
@@ -9520,14 +9523,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@langchain/core@0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))':
+  '@langchain/core@0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.13(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))
+      langsmith: 0.3.13(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -9537,9 +9540,9 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/openai@0.4.4(@langchain/core@0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8)))(encoding@0.1.13)(ws@8.18.1)':
+  '@langchain/openai@0.4.4(@langchain/core@0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1)))(encoding@0.1.13)(ws@8.18.1)':
     dependencies:
-      '@langchain/core': 0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))
+      '@langchain/core': 0.3.42(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1))
       js-tiktoken: 1.0.19
       openai: 4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1)
       zod: 3.24.1
@@ -11880,7 +11883,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@trigger.dev/sdk@3.3.17(zod@3.23.8)':
+  '@trigger.dev/sdk@3.3.17(zod@3.24.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
@@ -11896,7 +11899,7 @@ snapshots:
       uncrypto: 0.1.3
       uuid: 9.0.1
       ws: 8.18.0
-      zod: 3.23.8
+      zod: 3.24.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15097,7 +15100,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langsmith@0.3.13(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8)):
+  langsmith@0.3.13(openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -15107,7 +15110,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8)
+      openai: 4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1)
 
   language-subtag-registry@0.3.23: {}
 
@@ -16056,22 +16059,6 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
-
-  openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8):
-    dependencies:
-      '@types/node': 18.19.80
-      '@types/node-fetch': 2.6.12
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-    optionalDependencies:
-      ws: 8.18.1
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - encoding
-    optional: true
 
   openai@4.86.2(encoding@0.1.13)(ws@8.18.1)(zod@3.24.1):
     dependencies:


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

Currently, the CLI tool always outputs build results to the `dist/` directory, which can cause conflicts when this directory is already being used for other purposes. This is particularly problematic in CI/CD environments where multiple build processes might run in the same workspace.

With this change, users can specify the output directory using the optional `--output-dir` option, avoiding directory conflicts.

## What would you like reviewers to focus on?

- Does the option name sounds good?
- Is the implementation of the `--output-dir` option appropriate?
- Does it properly handle both absolute and relative paths?
- Are the documentation updates sufficient and clear?
  - The option should be  besides Options section?
- More automated tests necessary?

## Testing Verification

I tested the following three cases and confirmed that all work correctly:

### Using the default output directory (`dist/`)

```console
node ./dist-cli/bin/cli.js erd build --input https://github.com/mastodon/mastodon/blob/main/db/schema.rb --format schemarb`
```

Result: Files were output to the `dist/` directory, and the success message displayed `dist/`.

### Specifying a relative path

```console
node ./dist-cli/bin/cli.js erd build --input https://github.com/mastodon/mastodon/blob/main/db/schema.rb --format schemarb --output-dir custom-output
```

Result: Files were output to the `custom-output/` directory, and the success message displayed `custom-output/`.

### Specifying an absolute path

```console
node ./dist-cli/bin/cli.js erd build --input https://github.com/mastodon/mastodon/blob/main/db/schema.rb --format schemarb --output-dir /tmp/liam-output
```

Result: Files were output to the `/tmp/liam-output/` directory, and the success message displayed `/tmp/liam-output/`.

I also added a verification test to `frontend/packages/cli/src/cli/erdCommand/index.test.ts` that the `--output-dir` option functions correctly.

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 218666fca6826c7d44d0e10742e7a5f6424c4eb0

- Added `--output-dir` option to specify output directory for CLI tool.
- Updated CLI documentation to include `--output-dir` usage examples.
- Enhanced test coverage for `--output-dir` functionality in CLI commands.
- Improved user feedback for relative and absolute output paths.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement `--output-dir` option in build command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts

<li>Added support for resolving and creating custom output directories.<br> <li> Updated logic to handle relative and absolute paths for output.<br> <li> Enhanced user feedback to display correct output directory paths.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/908/files#diff-40e5647ca5c26b5c00d835caebbd61f2952f36203890fe2b412fe24d1192ba45">+15/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add `--output-dir` option to CLI command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/index.ts

<li>Introduced <code>--output-dir</code> option with default value <code>dist</code>.<br> <li> Updated command action to use the new option.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/908/files#diff-a0bbdf65b5519866ec4a2042a60d0642bb6fbbfc914447ad8e8f824de4ba0fc5">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add tests for `--output-dir` option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/index.test.ts

<li>Added a test case for <code>--output-dir</code> option.<br> <li> Verified correct handling of custom output directories.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/908/files#diff-09125d60edb40cea892c084b61e84437232cd97d4258e7da37bb955fa7dd6597">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rare-rings-warn.md</strong><dd><code>Add changeset for `--output-dir` feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/rare-rings-warn.md

- Documented the addition of `--output-dir` option.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/908/files#diff-73dc0defafda43f562979eaf6fd8c6b4667519a3cff9ace9ad06e780d2f5ef21">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-cd.mdx</strong><dd><code>Update CI/CD docs for `--output-dir` option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/docs/content/docs/cli/ci-cd.mdx

<li>Updated CI/CD examples to include <code>--output-dir</code> usage.<br> <li> Clarified output directory customization in documentation.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/908/files#diff-218538ff72e8a5f2d6139903ca8cb969f7e77c7d226b51f8b14720f7b7365259">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.mdx</strong><dd><code>Enhance CLI documentation with `--output-dir` details</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/docs/content/docs/cli/index.mdx

<li>Added <code>--output-dir</code> option to CLI usage examples.<br> <li> Updated output directory references to include customization.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/908/files#diff-e7c5208ef5297be5455cc6b1b141ccfb2cb3b53dc05e5c33ef4d743c1cf7dbed">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This change should be backward compatible and does not affect existing code or workflows. If the `--output-dir` option is not specified, the output will continue to go to the `dist/` directory as before.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>