### PR TITLE
✨ Set table show mode in related tables to TABLE_NAME

### DIFF
--- a/.changeset/wicked-feet-jog.md
+++ b/.changeset/wicked-feet-jog.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+✨ Set table show mode in related tables to TABLE_NAME

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
@@ -18,7 +18,7 @@ import {
   useNodesState,
 } from '@xyflow/react'
 import { type FC, useCallback } from 'react'
-import { highlightNodesAndEdges } from '../../utils'
+import { highlightNodesAndEdges, isTableNode } from '../../utils'
 import styles from './ERDContent.module.css'
 import { ERDContentProvider, useERDContentContext } from './ERDContentContext'
 import {
@@ -49,7 +49,16 @@ export const ERDContentInner: FC<Props> = ({
   edges: _edges,
   displayArea,
 }) => {
-  const [nodes, setNodes, onNodesChange] = useNodesState<Node>(_nodes)
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>(
+    displayArea === 'relatedTables'
+      ? _nodes.map((node) =>
+          isTableNode(node)
+            ? { ...node, data: { ...node.data, showMode: 'TABLE_NAME' } }
+            : node,
+        )
+      : _nodes,
+  )
+
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(_edges)
   const {
     state: { loading },

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableHeader/TableHeader.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableHeader/TableHeader.tsx
@@ -1,4 +1,5 @@
 import type { TableNodeData } from '@/features/erd/types'
+import type { ShowMode } from '@/schemas'
 import { useUserEditingStore } from '@/stores'
 import {
   Table2,
@@ -19,7 +20,8 @@ type Props = {
 
 export const TableHeader: FC<Props> = ({ data }) => {
   const name = data.table.name
-  const { showMode } = useUserEditingStore()
+  const { showMode: _showMode } = useUserEditingStore()
+  const showMode = data.showMode ?? _showMode
 
   const isTarget = data.targetColumnCardinalities !== undefined
   const isSource = data.sourceColumnName !== undefined

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableHeader/TableHeader.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableHeader/TableHeader.tsx
@@ -1,5 +1,4 @@
 import type { TableNodeData } from '@/features/erd/types'
-import type { ShowMode } from '@/schemas'
 import { useUserEditingStore } from '@/stores'
 import {
   Table2,

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableNode.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableNode.tsx
@@ -10,7 +10,8 @@ import styles from './TableNode.module.css'
 type Props = NodeProps<TableNodeType>
 
 export const TableNode: FC<Props> = ({ data }) => {
-  const { showMode } = useUserEditingStore()
+  const { showMode: _showMode } = useUserEditingStore()
+  const showMode = data.showMode ?? _showMode
 
   return (
     <div

--- a/frontend/packages/erd-core/src/features/erd/types.ts
+++ b/frontend/packages/erd-core/src/features/erd/types.ts
@@ -1,3 +1,4 @@
+import type { ShowMode } from '@/schemas/showMode/types'
 import type { Cardinality, Table } from '@liam-hq/db-structure'
 import type { Node } from '@xyflow/react'
 
@@ -9,6 +10,7 @@ export type TableNodeData = {
   targetColumnCardinalities?:
     | Record<string, Cardinality | undefined>
     | undefined
+  showMode?: ShowMode | undefined
 }
 
 export type TableNodeType = Node<TableNodeData, 'table'>


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/334

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

The related tables should be shown with "TABLE_NAME" only.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

Please check if it's appropriate to add `showMode` property in `TableNodeData` type. 
I understand that the type includes not only the table information read from the schema (`table` property) but also application state, such as whether the table is highlighted (`isActiveHighlighted` property). Therefore, I believe the change is fine.

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

1. copy schema from [here](https://raw.githubusercontent.com/liam-hq/liam/b7b9228de8840eb4ac3ca8342ebbda6d611d7ae5/frontend/packages/db-structure/src/parser/schemarb/input/schema1.in.rb?showMode=ALL_FIELDS&active=users) and save as "schema.in.rb"
1. run `pnpm run build --filter @liam-hq/cli` to build cli
1. run `node frontend/packages/cli/dist-cli/bin/cli.js erd build --format schemarb --input schema.in.rb` to generate scripts
1. run `npx http-server dist` to run the application and go to http://localhost:8080/
1. open related tables by clicking any table and switch show mode in the toolbar. You will see the tables in the main view will change their show mode but ones in the related tables don't change.

![Screenshot 0007-03-16 at 13 30 46](https://github.com/user-attachments/assets/58b9e648-ea5d-4ff7-951e-6f3c78542ad6)


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 5058a6505948f35ecf792c5ce07cdd02232f08a3

- Added `showMode` property to `TableNodeData` for better table display control.
- Updated related tables to always display in `TABLE_NAME` mode.
- Adjusted `TableHeader` and `TableNode` components to prioritize node-specific `showMode`.
- Introduced a changeset for versioning and documentation of changes.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add `showMode` property to `TableNodeData` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/types.ts

<li>Added <code>showMode</code> property to <code>TableNodeData</code> type.<br> <li> Enhanced type definition for table display customization.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/909/files#diff-cbb5899fbeb6c98ed51b9d4d0e820e9bba6edc737c871997cf2b4758b383211d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ERDContent.tsx</strong><dd><code>Set `TABLE_NAME` mode for related table nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx

<li>Updated nodes initialization to set <code>showMode</code> for related tables.<br> <li> Applied <code>TABLE_NAME</code> mode for nodes in <code>relatedTables</code> display area.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/909/files#diff-e9e03ebb0f0cb84d4dcfbdc7e83aa0e2d017125d8e543ad30f3cb249da85c916">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableHeader.tsx</strong><dd><code>Update `TableHeader` to prioritize node-specific `showMode`</code></dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableHeader/TableHeader.tsx

<li>Modified <code>TableHeader</code> to use node-specific <code>showMode</code> if available.<br> <li> Enhanced flexibility in determining table display mode.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/909/files#diff-aab7e870069bae0a9418c12213eb8e9eb6cd4bd892d751587f0e91dcd64b314d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableNode.tsx</strong><dd><code>Update `TableNode` to use node-specific `showMode`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableNode.tsx

<li>Adjusted <code>TableNode</code> to prioritize node-specific <code>showMode</code>.<br> <li> Improved consistency in table display behavior.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/909/files#diff-048a95bf95ec6d76676681d7c05ffa5fc6565181d848174f5de9e7f6688cce7c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wicked-feet-jog.md</strong><dd><code>Add changeset for table show mode update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/wicked-feet-jog.md

<li>Added changeset to document and version the update.<br> <li> Described the patch for setting table show mode.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/909/files#diff-1aafe6214f9a927964120fb5923edc350edcb1d8b540c202038e1611b44c1a05">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

> Please check if it's appropriate to add `showMode` property in `TableNodeData` type. 

If it's not appropriate, I have another plan to resolve this.
It will add `showMode?: ShowMode | undefined` property to the props of `TableNode` and `TableHeader` component and let them get the actual show modes by the similar way with this change. This requires to update [`nodeTypes` object of `ERDContentInner`](https://github.com/tnyo43/liam/blob/e166450b0b8dc805aa944f47cd364d524c6fab39/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx#L32-L35), like:

```tsx
export const ERDContentInner: FC<Props> = ({ displayArea, ... })  => {
  ...

  // defined in the `ERDContentInner` component and depends on `displayArea`
  const nodeTypes = useMemo(() => ({
    table: displayArea === 'relatedTables' ? (props) => <TableNode showMode="TABLE_NAME" {...props} /> : TableNode,
    nonRelatedTableGroup: NonRelatedTableGroupNode,
  }), [displayArea]);

  return <ReactFlow ... nodeTypes={nodeTypes} />;
};
```

I don't have a strong opinion, both look fine to me.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>