### PR TITLE
🔧 Update database connection URL in Prisma schema to use POSTGRES_URL

### DIFF
--- a/frontend/packages/db/prisma/schema.prisma
+++ b/frontend/packages/db/prisma/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("POSTGRES_URL")
 }
 
 generator client {


### PR DESCRIPTION
The environment variables for connecting to Supabase Branching are now automatically registered in Vercel Preview. The list of environment variables to be registered is as follows:

```
POSTGRES_URL
POSTGRES_PRISMA_URL
POSTGRES_URL_NON_POOLING
POSTGRES_USER
POSTGRES_HOST
POSTGRES_PASSWORD
POSTGRES_DATABASE
SUPABASE_SERVICE_ROLE_KEY
SUPABASE_ANON_KEY
SUPABASE_URL
SUPABASE_JWT_SECRET
NEXT_PUBLIC_SUPABASE_ANON_KEY
NEXT_PUBLIC_SUPABASE_URL
```

The environment variable referenced by Prisma Client is `DATABASE_URL`, which is not a registered environment variable. `POSTGRES_URL` is like `postgres://postgres.xxx:xxx@aws-0-us-east-1.pooler.supabase.com:6543/postgres?sslmode=require&supa=base-pooler.x` and can be used for Prisma connections.

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 8f2c94b91c9e16fb748c8ff8f6f037ede47a0355

- Updated Prisma schema to use `POSTGRES_URL` for database connection.
- Replaced `DATABASE_URL` with `POSTGRES_URL` in the datasource configuration.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update datasource URL to use POSTGRES_URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/prisma/schema.prisma

<li>Changed the <code>url</code> in the <code>datasource db</code> block to use <code>POSTGRES_URL</code>.<br> <li> Replaced the environment variable <code>DATABASE_URL</code> with <code>POSTGRES_URL</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/919/files#diff-4db42f5f6ccb9d136f2dacd9f88bda16ba12ebc00fb74fd219d4383f4de52bba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>