### PR TITLE
🔧 Update instrumentation.ts to validate environment variables

### DIFF
--- a/frontend/apps/app/instrumentation.ts
+++ b/frontend/apps/app/instrumentation.ts
@@ -10,11 +10,13 @@ export async function register() {
     await import('./sentry.edge.config')
   }
 
-  const { valid, missing } = validateConfig()
-  if (!valid) {
-    throw new Error(
-      `Missing required environment variables: ${missing.join(', ')}`,
-    )
+  if (process.env.VERCEL === '1') {
+    const { valid, missing } = validateConfig()
+    if (!valid) {
+      throw new Error(
+        `Missing required environment variables: ${missing.join(', ')}`,
+      )
+    }
   }
 }
 


### PR DESCRIPTION
The new feature in development needs several environment variables and can not run local server without them now.
ref: https://github.com/liam-hq/liam/issues/609#issuecomment-2731622520 

Added the condition to check the environment variables on Vercel only.

Unfortunately, [Feature Flags](https://vercel.com/docs/feature-flags) can not used outside a request scope.

```
│ Error: `headers` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
│     at async Module.register (instrumentation.ts:14:27)
│   12 |   }
│   13 |
│ > 14 |   const migrationEnabled = await migrationFlag()
│      |                           ^
│   15 |
│   16 |   if (migrationEnabled) {
│   17 |     const { valid, missing } = validateConfig()
```

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at e9fb77e3e763a818146fd9667970f2ca1dacccd9

- Added a condition to validate environment variables only on Vercel.
- Prevented unnecessary validation errors in non-Vercel environments.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>instrumentation.ts</strong><dd><code>Conditional environment variable validation for Vercel</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/instrumentation.ts

<li>Added a check for <code>process.env.VERCEL</code> before validating environment <br>variables.<br> <li> Moved the <code>validateConfig</code> logic inside the Vercel-specific condition.<br> <li> Prevented errors from missing environment variables in non-Vercel <br>environments.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/923/files#diff-24fafc351fbb5b26d3302cd447fad5a850f815d2c2b7a37cbdae825bf4504100">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>