### PR TITLE
🔧 Fix e2e test execution conditions in production

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: "frontend/packages/e2e"
     env:
       CI: true
-      URL: ${{ github.event.deployment.environment == 'Production' && 'https://liam-erd-web.vercel.app' || github.event.deployment_status.target_url }}
+      URL: ${{ github.event.deployment.environment == 'Production – liam-app' && 'https://liam-erd-web.vercel.app' || github.event.deployment_status.target_url }}
       ENVIRONMENT: ${{ github.event.deployment.environment }}
     steps:
       - name: Checkout repository
@@ -73,7 +73,7 @@ jobs:
           retention-days: 30
 
       - name: Slack Notification on Failure
-        if: ${{ env.ENVIRONMENT == 'production' && failure() }}
+        if: ${{ env.ENVIRONMENT == 'Production – liam-app' && failure() }}
         uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
         env:
           INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CI_WEBHOOK_URL }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: "frontend/packages/e2e"
     env:
       CI: true
-      URL: ${{ github.event.deployment.environment == 'Production – liam-app' && 'https://liam-erd-web.vercel.app' || github.event.deployment_status.target_url }}
+      URL: ${{ github.event.deployment_status.target_url }}
       ENVIRONMENT: ${{ github.event.deployment.environment }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -11,7 +11,7 @@ jobs:
       (
         (
           contains(github.event.deployment.environment, 'Production') &&
-          contains(github.event.deployment_status.target_url, 'liam-erd-web')
+          contains(github.event.deployment_status.target_url, 'liam-app-git-main')
         ) ||
         (
           contains(github.event.deployment.environment, 'Preview') &&
@@ -30,7 +30,7 @@ jobs:
         working-directory: "frontend/packages/e2e"
     env:
       CI: true
-      URL: ${{ github.event.deployment_status.target_url }}
+      URL: ${{ github.event.deployment.environment == 'Production' && 'https://liam-erd-web.vercel.app' || github.event.deployment_status.target_url }}
       ENVIRONMENT: ${{ github.event.deployment.environment }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Issue

I have confirmed that the e2e test is skipped in the production environment.😞
![ss 2940](https://github.com/user-attachments/assets/e420a0fa-763c-41cb-92fb-dd0a9711ac7c)

The condition for running the e2e test was that the ``github.event.deployment_status.target_url`` should contain ``liam-erd-web``, but the actual URL is ``liam-app-git-main-route-06-core.vercel.app``.

I have modified the e2e test run condition so that the actual test is tested with a URL at the custom domain of https://liam-erd-web.vercel.app.


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at b612e581cfd4b56cb3263dc246bd839a6f4a4556

- Fixed e2e test execution conditions for production environment.
- Updated URL logic to handle production and preview environments.
- Ensured compatibility with the correct deployment target URLs.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_tests.yml</strong><dd><code>Update e2e test workflow conditions and environment URL</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e_tests.yml

<li>Adjusted condition to check for 'liam-app-git-main' in target URL.<br> <li> Updated URL environment variable to use a custom domain for <br>production.<br> <li> Improved logic for handling production and preview environments.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/924/files#diff-37aed4ad4a8c3a4220c5e3c2eee33093073b8d64f480cc742b63764c859b6c72">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>