### PR TITLE
🐛 Fix/install-id-pr-files

### DIFF
--- a/frontend/apps/app/app/api/webhook/github/route.ts
+++ b/frontend/apps/app/app/api/webhook/github/route.ts
@@ -62,6 +62,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
           case 'reopened': {
             // Perform pre-check
             const checkResult = await checkSchemaChanges({
+              installationId: data.installation.id,
               pullRequestNumber: pullRequest.number,
               pullRequestTitle: pullRequest.title,
               projectId,

--- a/frontend/apps/app/app/api/webhook/github/route.ts
+++ b/frontend/apps/app/app/api/webhook/github/route.ts
@@ -68,7 +68,6 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
               projectId,
               owner: data.repository.owner.login,
               name: data.repository.name,
-              repositoryId: repository.id,
             })
 
             // Determine whether to continue processing based on the check results

--- a/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
+++ b/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
@@ -41,6 +41,11 @@ describe('checkSchemaChanges', () => {
     repositoryId: 200,
   }
 
+  const mockSchemaParams = {
+    ...mockParams,
+    installationId: 1,
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -48,7 +53,7 @@ describe('checkSchemaChanges', () => {
   it('should return false if project has no watchSchemaFilePatterns', async () => {
     vi.mocked(prisma.watchSchemaFilePattern.findMany).mockResolvedValue([])
 
-    const result = await checkSchemaChanges(mockParams)
+    const result = await checkSchemaChanges(mockSchemaParams)
     expect(result).toEqual({ shouldContinue: false })
   })
 
@@ -82,7 +87,7 @@ describe('checkSchemaChanges', () => {
       },
     ])
 
-    const result = await checkSchemaChanges(mockParams)
+    const result = await checkSchemaChanges(mockSchemaParams)
     expect(result).toEqual({ shouldContinue: false })
   })
 
@@ -116,7 +121,7 @@ describe('checkSchemaChanges', () => {
       },
     ])
 
-    const result = await checkSchemaChanges(mockParams)
+    const result = await checkSchemaChanges(mockSchemaParams)
     expect(result).toEqual({ shouldContinue: true })
     expect(savePullRequestTask.trigger).toHaveBeenCalledWith(mockParams)
   })

--- a/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
+++ b/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
@@ -32,7 +32,7 @@ vi.mock('@liam-hq/db', () => ({
 }))
 
 describe('checkSchemaChanges', () => {
-  const mockParams = {
+  const _mockParams = {
     pullRequestNumber: 1,
     pullRequestTitle: 'Update schema',
     projectId: 100,
@@ -42,7 +42,11 @@ describe('checkSchemaChanges', () => {
   }
 
   const mockSchemaParams = {
-    ...mockParams,
+    pullRequestNumber: 1,
+    pullRequestTitle: 'Update schema',
+    projectId: 100,
+    owner: 'user',
+    name: 'repo',
     installationId: 1,
   }
 
@@ -123,6 +127,5 @@ describe('checkSchemaChanges', () => {
 
     const result = await checkSchemaChanges(mockSchemaParams)
     expect(result).toEqual({ shouldContinue: true })
-    expect(savePullRequestTask.trigger).toHaveBeenCalledWith(mockParams)
   })
 })

--- a/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
+++ b/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
@@ -32,15 +32,6 @@ vi.mock('@liam-hq/db', () => ({
 }))
 
 describe('checkSchemaChanges', () => {
-  const _mockParams = {
-    pullRequestNumber: 1,
-    pullRequestTitle: 'Update schema',
-    projectId: 100,
-    owner: 'user',
-    name: 'repo',
-    repositoryId: 200,
-  }
-
   const mockSchemaParams = {
     pullRequestNumber: 1,
     pullRequestTitle: 'Update schema',

--- a/frontend/apps/app/app/api/webhook/github/utils/checkSchemaChanges.ts
+++ b/frontend/apps/app/app/api/webhook/github/utils/checkSchemaChanges.ts
@@ -10,20 +10,12 @@ type CheckSchemaChangesParams = {
   projectId: number
   owner: string
   name: string
-  repositoryId: number
 }
 
 export const checkSchemaChanges = async (
   params: CheckSchemaChangesParams,
 ): Promise<{ shouldContinue: boolean }> => {
-  const {
-    pullRequestNumber,
-    projectId,
-    owner,
-    name,
-    repositoryId,
-    installationId,
-  } = params
+  const { pullRequestNumber, projectId, owner, name, installationId } = params
 
   // Get changed files from pull request
   const files = await getPullRequestFiles(
@@ -50,16 +42,6 @@ export const checkSchemaChanges = async (
   if (matchedFiles.length === 0) {
     return { shouldContinue: false }
   }
-
-  // If schema changes are detected, trigger the task
-  await savePullRequestTask.trigger({
-    pullRequestNumber,
-    pullRequestTitle: params.pullRequestTitle,
-    projectId,
-    owner,
-    name,
-    repositoryId,
-  })
 
   return { shouldContinue: true }
 }

--- a/frontend/apps/app/app/api/webhook/github/utils/checkSchemaChanges.ts
+++ b/frontend/apps/app/app/api/webhook/github/utils/checkSchemaChanges.ts
@@ -4,6 +4,7 @@ import { prisma } from '@liam-hq/db'
 import { minimatch } from 'minimatch'
 
 type CheckSchemaChangesParams = {
+  installationId: number
   pullRequestNumber: number
   pullRequestTitle: string
   projectId: number
@@ -15,11 +16,18 @@ type CheckSchemaChangesParams = {
 export const checkSchemaChanges = async (
   params: CheckSchemaChangesParams,
 ): Promise<{ shouldContinue: boolean }> => {
-  const { pullRequestNumber, projectId, owner, name, repositoryId } = params
+  const {
+    pullRequestNumber,
+    projectId,
+    owner,
+    name,
+    repositoryId,
+    installationId,
+  } = params
 
   // Get changed files from pull request
   const files = await getPullRequestFiles(
-    repositoryId,
+    installationId,
     owner,
     name,
     pullRequestNumber,


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
The getPullRequestFiles function requires an installationId to fetch the list of changed files from a pull request. However, in some cases, the installationId was missing when calling this function, leading to failures when processing pull request events, such as pull_request.reopened. This resulted in a 500 Internal Server Error with the response {"error":"Failed to process pull_request.reopened event"}.

To fix this, we ensured that the installationId is properly passed to getPullRequestFiles when handling pull request events. This ensures that schema change detection and related tasks execute correctly without errors.

Additionally, we removed a redundant call to savePullRequestTask.trigger in checkSchemaChanges, preventing duplicate task executions.



## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->


<img width="443" alt="スクリーンショット 2025-03-18 11 59 48" src="https://github.com/user-attachments/assets/fefec595-71a4-4d80-bc5a-2c53e621052f" />

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 85911f6daec47cfe514686f0e98dce85d794d55e

- Fixed missing `installationId` in `getPullRequestFiles` calls to prevent errors.
- Updated `checkSchemaChanges` to use `installationId` instead of `repositoryId`.
- Removed redundant `savePullRequestTask.trigger` call in `checkSchemaChanges`.
- Adjusted test cases to reflect updated `checkSchemaChanges` parameters.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Pass installationId to checkSchemaChanges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/api/webhook/github/route.ts

<li>Added <code>installationId</code> parameter to <code>checkSchemaChanges</code> call.<br> <li> Removed unused <code>repositoryId</code> parameter.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/926/files#diff-464de4a7c52e1e250548beef86570df8e8208e96dfccbd5dd62053a4e4c61ca3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>checkSchemaChanges.ts</strong><dd><code>Refactor checkSchemaChanges to use installationId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/api/webhook/github/utils/checkSchemaChanges.ts

<li>Replaced <code>repositoryId</code> with <code>installationId</code> in parameters.<br> <li> Removed redundant <code>savePullRequestTask.trigger</code> call.<br> <li> Adjusted logic to fetch files using <code>installationId</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/926/files#diff-5f0f997d268c4bcd2c05e34ea0dfd7b3f26d22ef6639bb1c780c613ee8bd44fc">+3/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>checkSchemaChanges.test.ts</strong><dd><code>Update tests for checkSchemaChanges parameter changes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts

<li>Updated test cases to use <code>installationId</code> instead of <code>repositoryId</code>.<br> <li> Replaced <code>mockParams</code> with <code>mockSchemaParams</code> in tests.<br> <li> Removed assertions for redundant <code>savePullRequestTask.trigger</code> call.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/926/files#diff-b01dbe373c3b2d2028fd711b13bf3289461c92697cbc2290ea866c0b3ccede8a">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>