### PR TITLE
🔧 Add Sentry authToken configuration to Next.js config files

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -95,8 +95,11 @@ export default withSentryConfig(nextConfig, {
 
   // Hides source maps from generated client bundles
   sourcemaps: {
-    disable: true,
+    disable: false,
+    assets: '.next',
   },
+
+  hideSourceMaps: true,
 
   // Automatically tree-shake Sentry logger statements to reduce bundle size
   disableLogger: true,

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "gen"],
-      "outputs": ["dist", "dist-cli"]
+      "outputs": ["dist", "dist-cli"],
+      "env": ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"]
     },
     "@liam-hq/docs#build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Issue
There were two problems.
1. the ``No auth token provided.`` warning when deploying the erd-web(liam-app) package (on Vercel)
    https://github.com/liam-hq/liam/pull/930/commits/e981bd8d509017b3ab0d318664e2a41e20ecc434 ... Include env in turbo.json so that it is read at build time
2. not being able to send SourceMap to Sentry from before.
    https://github.com/liam-hq/liam/pull/930/commits/147789a082b6491ab8d57a44424f629f0720176f ... change setting disable: true to false 


Checked
``No auth token provided.``  gone.
https://vercel.com/route-06-core/liam-app/Hhoy2UgTWSZNk8ZXBzTwLAwwUqn7?filter=warnings

The sourcemap was sent.
![ss 2951](https://github.com/user-attachments/assets/dac4ecef-ee5f-4907-b7ce-38ec541a2dd8)


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 147789a082b6491ab8d57a44424f629f0720176f

- Enabled source maps in `next.config.ts` for better debugging.
- Added environment variables for Sentry in `turbo.json` build task.
- Configured hiding of source maps in client bundles.
- Improved Sentry integration by updating configuration settings.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Update Sentry source map and hiding configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/next.config.ts

<li>Enabled source maps by setting <code>disable</code> to <code>false</code>.<br> <li> Added <code>assets</code> property to specify source map location.<br> <li> Introduced <code>hideSourceMaps</code> to hide source maps in client bundles.<br> <li> Retained automatic logger statement tree-shaking.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/930/files#diff-348e0567151afb47012b01ebd1bc6c1cc67663fe10f10ba6314a9e781ffd6313">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>turbo.json</strong><dd><code>Include Sentry environment variables in build task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

turbo.json

<li>Added <code>env</code> property to include Sentry-related environment variables.<br> <li> Ensured <code>SENTRY_AUTH_TOKEN</code>, <code>SENTRY_ORG</code>, and <code>SENTRY_PROJECT</code> are <br>available during build.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/930/files#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>