### PR TITLE
 🐛 Enhance tests for long SQL statements and fix errorOffset handling

### DIFF
--- a/.changeset/large-ligers-warn.md
+++ b/.changeset/large-ligers-warn.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/db-structure": patch
+---
+
+🐛 Enhance tests for long SQL statements and fix errorOffset handling. ref. https://github.com/liam-hq/liam/issues/874

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -255,7 +255,7 @@ describe(processor, () => {
     })
   })
 
-  describe('Long statement (exceeds 500 lines, surpassing CHUNK_SIZE)', () => {
+  describe('Long "create table" statement (exceeds 500 lines, surpassing CHUNK_SIZE)', () => {
     it('parses without errors', async () => {
       const _500Lines = '\n'.repeat(500)
       const { value, errors } = await processor(/* sql */ `
@@ -266,6 +266,28 @@ describe(processor, () => {
         );
       `)
 
+      expect(value).toEqual(parserTestCases.normal)
+      expect(errors).toEqual([])
+    })
+  }, 30000)
+
+  describe('Long "create function" statement (exceeds 500 lines, surpassing CHUNK_SIZE)', () => {
+    it('parses without errors', async () => {
+      const _500Lines = '\n'.repeat(500)
+      const { value, errors } = await processor(/* sql */ `
+        CREATE TABLE users (
+          id BIGSERIAL PRIMARY KEY,
+          name VARCHAR(255) NOT NULL
+        );
+
+        CREATE OR REPLACE FUNCTION test_proc(p_id integer)
+        RETURNS void AS $$
+        BEGIN
+            RAISE NOTICE 'Stored procedure called with parameter: %', p_id;
+            ${_500Lines}
+        END;
+        $$ LANGUAGE plpgsql;
+      `)
       expect(value).toEqual(parserTestCases.normal)
       expect(errors).toEqual([])
     })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
@@ -33,7 +33,9 @@ export const processor: Processor = async (sql: string) => {
     const { parse_tree, error: parseError } = await parse(chunk)
 
     if (parse_tree.stmts.length > 0 && parseError !== null) {
-      throw new Error('UnexpectedCondition')
+      throw new Error(
+        'UnexpectedCondition. parse_tree.stmts.length > 0 && parseError !== null',
+      )
     }
 
     if (parseError !== null) {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
@@ -45,7 +45,8 @@ export const processor: Processor = async (sql: string) => {
       if (lastStmt?.stmt_len === undefined) {
         isLastStatementComplete = false
         if (lastStmt?.stmt_location === undefined) {
-          throw new Error('UnexpectedCondition')
+          errorOffset = 0 // no error, but the statement is not complete
+          return [errorOffset, readOffset, errors]
         }
         readOffset = lastStmt?.stmt_location - 1
       }

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
@@ -21,6 +21,11 @@ export const processor: Processor = async (sql: string) => {
   const parseErrors: ProcessError[] = []
 
   const errors = await processSQLInChunks(sql, CHUNK_SIZE, async (chunk) => {
+    // Offset markers for chunk processing control:
+    // - readOffset: Tracks the position after the last complete statement,
+    //   used when a statement is partially processed and needs continuation
+    // - retryOffset: Indicates where parsing failed and/or should be retried
+    //   with a different chunk size (used in shrinking/expanding modes)
     let readOffset: number | null = null
     let retryOffset: number | null = null
     const errors: ProcessError[] = []

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
@@ -70,7 +70,7 @@ export const processSQLInChunks = async (
       } else if (readOffset !== null) {
         const lineNumber = getLineNumber(chunk, readOffset)
         if (lineNumber === null) {
-          throw new Error('UnexpectedCondition')
+          throw new Error('UnexpectedCondition. lineNumber === null')
         }
         i += lineNumber
         break

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
@@ -6,6 +6,10 @@ import type { ProcessError } from '../../errors.js'
  * @param sqlInput - The SQL input string to be processed.
  * @param chunkSize - The number of lines per chunk (e.g., 500).
  * @param callback - An asynchronous function to process each chunk.
+ * @returns A tuple of [retryOffset, readOffset, errors] where:
+ *   - retryOffset: Position where parsing failed, indicating where to retry from with a different chunk size
+ *   - readOffset: Position of the last successfully parsed statement, used for partial chunk processing
+ *   - errors: Array of parsing errors encountered during processing
  */
 export const processSQLInChunks = async (
   sqlInput: string,

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts
@@ -32,7 +32,7 @@ export const processSQLInChunks = async (
 
     while (true) {
       // NOTE: To minimize unnecessary retries, avoid increasing currentChunkSize excessively,
-      //       especially when errorOffset is present.
+      //       especially when retryOffset is present.
       if (retryDirection === retryDirectionValues.decrease) {
         if (i + currentChunkSize > lines.length) {
           currentChunkSize = lines.length - i
@@ -40,9 +40,9 @@ export const processSQLInChunks = async (
       }
 
       const chunk = lines.slice(i, i + currentChunkSize).join('\n')
-      const [errorOffset, readOffset, errors] = await callback(chunk)
+      const [retryOffset, readOffset, errors] = await callback(chunk)
 
-      if (errorOffset !== null) {
+      if (retryOffset !== null) {
         if (retryDirection === retryDirectionValues.decrease) {
           currentChunkSize--
           if (currentChunkSize === 0) {


### PR DESCRIPTION
The main commit of this PR is 28fe282dc60fc420efc9e766b8f747f9d4681f2b.


## Issue

- resolve: https://github.com/liam-hq/liam/issues/874

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

manually tested on 

-  https://github.com/mastodon/mastodon/blob/v4.3.2/db/schema.rb 
-  https://gitlab.com/gitlab-org/gitlab-foss/-/raw/b94eb57589bd639078b783c296642e68dfb91780/db/structure.sql

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 62537214d68d8f242b8a20860a1bd66cddeb8b7f

- Fixed parsing issues for long SQL statements exceeding CHUNK_SIZE.
- Enhanced error handling with improved retryOffset logic.
- Added tests for long "create function" SQL statements.
- Improved error messages for unexpected conditions in SQL parser.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add and enhance tests for long SQL statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts

<li>Updated test description for long "create table" statements.<br> <li> Added a new test for long "create function" statements.<br> <li> Ensured tests validate parsing without errors for statements exceeding <br>CHUNK_SIZE.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/957/files#diff-2ffdcf3d84e15e4ef7dd163c02f09c80bd750fb31b3effe125fc475c73bdf936">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>processSQLInChunks.test.ts</strong><dd><code>Update tests for processSQLInChunks with retryOffset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.test.ts

<li>Updated test cases to use <code>retryOffset</code> instead of <code>errorOffset</code>.<br> <li> Enhanced test descriptions for chunk processing scenarios.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/957/files#diff-b0a570b2552f3849086fb8c57c299f62e2230d05760ce33275f0c95831d9438c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Refactor error handling and improve SQL parser logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/index.ts

<li>Replaced <code>errorOffset</code> with <code>retryOffset</code> for better error handling.<br> <li> Improved error messaging for unexpected conditions.<br> <li> Added comments explaining <code>readOffset</code> and <code>retryOffset</code> usage.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/957/files#diff-e947976bc36e479c39dfed57edcc5c82e7e189f08fe1bf6b4e7f4bffbc19aa04">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>processSQLInChunks.ts</strong><dd><code>Refactor chunk processing logic with retryOffset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/processSQLInChunks.ts

<li>Replaced <code>errorOffset</code> with <code>retryOffset</code> in chunk processing logic.<br> <li> Added detailed comments for return values and retry logic.<br> <li> Improved error handling for incomplete SQL statements.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/957/files#diff-123f912cbc8ea0932b882e5d595faf78c689c22279147d43b3debd4e9cd49650">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>large-ligers-warn.md</strong><dd><code>Add changeset for SQL parsing bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/large-ligers-warn.md

<li>Added changeset entry for fixing long SQL statement parsing.<br> <li> Referenced issue #874 in the changeset.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/957/files#diff-7d027bf2eecd91daccae8bee9f14fe551b1f15b82246f07fe59bd181fe7966fc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>