### PR TITLE
🔧 Fix SourceMaps asset path

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -73,8 +73,8 @@ export default withSentryConfig(nextConfig, {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+  // Only print logs for uploading source maps in preview or production environments
+  silent: process.env.NEXT_PUBLIC_ENV_NAME === 'development',
 
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
@@ -96,7 +96,21 @@ export default withSentryConfig(nextConfig, {
   // Hides source maps from generated client bundles
   sourcemaps: {
     disable: false,
-    assets: '.next',
+    assets: [
+      '.next/**/*.js',
+      '.next/**/*.js.map',
+      '.next/static/chunks/**/*.js',
+      '.next/static/chunks/**/*.js.map',
+      '.next/static/runtime/*.js',
+      '.next/static/runtime/*.js.map',
+      '.next/server/pages/**/*.js',
+      '.next/server/pages/**/*.js.map',
+      '.next/server/chunks/*.js',
+      '.next/server/chunks/*.js.map',
+      '.next/app-build-manifest.json',
+      '.next/build-manifest.json',
+    ],
+    ignore: ['node_modules/**/*'],
   },
 
   hideSourceMaps: true,

--- a/frontend/apps/docs/next.config.mjs
+++ b/frontend/apps/docs/next.config.mjs
@@ -16,8 +16,8 @@ export default withSentryConfig(withMDX(config), {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+  // Only print logs for uploading source maps in preview or production environments
+  silent: process.env.NEXT_PUBLIC_ENV_NAME === 'development',
 
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/


### PR DESCRIPTION
## Issue

I have addressed the following warning issue and the issue of not sending ``Sourcemap`` to Sentry.

https://vercel.com/route-06-core/liam-app/5QheJCH5EJZdxQjDyBPi28ugASyz?filter=warnings

![ss 2957](https://github.com/user-attachments/assets/065582fe-51c2-4b76-b0c2-186dd56cd463)

I also confirmed that the source map was sent correctly.✅

![ss 2963](https://github.com/user-attachments/assets/cbebf023-3ea8-4105-a442-56e1a835eabe)


https://route06cojp.sentry.io/settings/projects/liam-erd-web/source-maps/


However, I have been getting another warning and have not been able to find a solution. I would like to address this at a later date.🙏

![ss 2961](https://github.com/user-attachments/assets/b8b4c114-2fd4-4b2b-a23f-fa22abdb778b)

（There seems to be a pattern where there are only `.js` files and no `.js.map` files.）

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at c32e4b73adb72d6420997585834e9b16b00eb885

- Updated Next.js configuration to refine sourcemap asset paths.
- Adjusted `silent` setting for better environment-specific logging.
- Enhanced sourcemap handling with detailed asset path specifications.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Refine sourcemap configuration and logging for app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/next.config.ts

<li>Updated <code>silent</code> setting to depend on <code>NEXT_PUBLIC_ENV_NAME</code>.<br> <li> Refined sourcemap asset paths with detailed specifications.<br> <li> Added <code>ignore</code> option to exclude <code>node_modules</code> from sourcemaps.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/958/files#diff-348e0567151afb47012b01ebd1bc6c1cc67663fe10f10ba6314a9e781ffd6313">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>next.config.mjs</strong><dd><code>Adjust logging configuration for docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/docs/next.config.mjs

- Updated `silent` setting to depend on `NEXT_PUBLIC_ENV_NAME`.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/958/files#diff-8d1bb072f159cd130316b0f39f7e6c77b9907a921d671d96c0f9272bd3e09c5f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>