### PR TITLE
🔧 Match `next-config` settings with docs so that `sourcemap` can be sent.

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -99,12 +99,6 @@ export default withSentryConfig(nextConfig, {
   // side errors will fail.
   // tunnelRoute: "/monitoring",
 
-  // Hides source maps from generated client bundles
-  sourcemaps: {
-    disable: false,
-    assets: '.next',
-  },
-
   hideSourceMaps: true,
 
   // Automatically tree-shake Sentry logger statements to reduce bundle size


### PR DESCRIPTION
## Issue

Recently in ``liam-app``, sourcemap was not being sent to sentry.

![ss 2974](https://github.com/user-attachments/assets/c2bf04ed-c17a-4356-80b1-e874d99ad961)

I thought I needed ``sourcemap.assets`` as per the warning, but I was able to send sourcemap without setting assets in **docs**, so I changed the settings as in docs. (I removed the assets setting)

docs sentry setting is here:
https://github.com/liam-hq/liam/blob/82a536523f68b062d3f65d0bae064c56bfe620e6/frontend/apps/docs/next.config.mjs#L18-L56

I confirmed that the sourcemap was successfully sent.✅
vercel: https://vercel.com/route-06-core/liam-app/Hhoy2UgTWSZNk8ZXBzTwLAwwUqn7
sentry: https://route06cojp.sentry.io/settings/projects/liam-erd-web/source-maps/

![ss 2975](https://github.com/user-attachments/assets/fab784d4-e9fa-48a3-8170-4a299d993b18)
![ss 2976](https://github.com/user-attachments/assets/6a0184e9-fbf8-461f-9c83-6dbc49f28e5a)


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at fc06bcd10884faae114121ac807b3c1b74e1277a

- Removed incorrect `sourcemaps` settings from `next.config.ts`.
- Ensured compatibility with Sentry documentation for sourcemap handling.
- Simplified configuration by relying on `hideSourceMaps` for source map management.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Removed incorrect sourcemap settings in `next.config.ts`</code>&nbsp; </dd></summary>
<hr>

frontend/apps/app/next.config.ts

<li>Removed the <code>sourcemaps</code> configuration block.<br> <li> Retained <code>hideSourceMaps</code> for managing source map visibility.<br> <li> Simplified the configuration for better alignment with Sentry <br>documentation.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/977/files#diff-348e0567151afb47012b01ebd1bc6c1cc67663fe10f10ba6314a9e781ffd6313">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>