### PR TITLE
Use stable ref for erd-sample build script

### DIFF
--- a/frontend/apps/app/app/page.tsx
+++ b/frontend/apps/app/app/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from 'next/navigation'
 
 export default function Page() {
-  redirect('/erd/p/github.com/mastodon/mastodon/blob/main/db/schema.rb')
+  redirect(
+    '/erd/p/github.com/mastodon/mastodon/blob/1bc28709ccde4106ab7d654ad5888a14c6bb1724/db/schema.rb',
+  )
 }

--- a/frontend/apps/erd-sample/package.json
+++ b/frontend/apps/erd-sample/package.json
@@ -6,7 +6,7 @@
     "@liam-hq/cli": "workspace:*"
   },
   "scripts": {
-    "build": "node ../../packages/cli/dist-cli/bin/cli.js erd build --input https://github.com/mastodon/mastodon/blob/main/db/schema.rb --format schemarb",
+    "build": "node ../../packages/cli/dist-cli/bin/cli.js erd build --input https://github.com/mastodon/mastodon/blob/1bc28709ccde4106ab7d654ad5888a14c6bb1724/db/schema.rb --format schemarb",
     "update_dist_content": "node ./scripts/update_dist_content.mjs"
   }
 }


### PR DESCRIPTION
for e2e stability

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at dac509c68d3ae96dd8dbc477f2fbaf08753530e6

- Updated `build` script to use a stable reference for schema input.
- Ensures e2e stability by pinning schema reference.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Pin schema input to a stable commit reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/erd-sample/package.json

<li>Updated the <code>build</code> script to use a specific commit reference for the <br>schema input URL.<br> <li> Replaced the <code>main</code> branch reference with a stable commit hash.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1044/files#diff-29dc714fce3ad3bd1fe1a0ba9b8357ddf2d3c0bc8fa6100c02d62aa34f372c99">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>