### PR TITLE
fix: change init prompt text from "postgresql" to "postgres"

### DIFF
--- a/.changeset/short-turtles-admire.md
+++ b/.changeset/short-turtles-admire.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/cli": patch
+---
+
+:bug fixed prompt text postgres for init

--- a/frontend/apps/docs/content/docs/cli/index.mdx
+++ b/frontend/apps/docs/content/docs/cli/index.mdx
@@ -47,11 +47,11 @@ You can use any hosting service of your choice to serve the generated files.
 You can directly specify URLs to schema files stored in public GitHub repositories. Using raw URLs allows you to generate ERDs directly from remote schema files.
 
 ```package-install
-npx @liam-hq/cli erd build --input https://github.com/user/repo/blob/main/examples/schema.sql --format postgresql
+npx @liam-hq/cli erd build --input https://github.com/user/repo/blob/main/examples/schema.sql --format postgres
 ```
 
 ```package-install
-npx @liam-hq/cli erd build --input https://raw.githubusercontent.com/user/repo/main/examples/schema.sql --format postgresql
+npx @liam-hq/cli erd build --input https://raw.githubusercontent.com/user/repo/main/examples/schema.sql --format postgres
 ```
 
 

--- a/frontend/packages/cli/src/cli/initCommand/index.ts
+++ b/frontend/packages/cli/src/cli/initCommand/index.ts
@@ -17,10 +17,10 @@ const initCommand = new Command('init').description(
 
 // Map user-friendly selections to the correct --format value
 const formatMap: Record<string, string> = {
-  PostgreSQL: 'postgresql',
+  PostgreSQL: 'postgres',
   'Ruby on Rails (schema.rb)': 'schemarb',
   'Prisma (schema.prisma)': 'prisma',
-  Drizzle: 'postgresql', // Drizzle also uses --format postgres
+  Drizzle: 'postgres', // Drizzle also uses --format postgres
   'MySQL (via tbls)': 'tbls',
   'SQLite (via tbls)': 'tbls',
   'BigQuery (via tbls)': 'tbls',
@@ -120,7 +120,7 @@ ${yocto.yellow(
       // Show Drizzle-specific guidance
       console.info(`
 ${yocto.yellow(
-  `For Drizzle, please run your DB migrations, then use 'pg_dump --schema-only' to generate a dump file. You can then use it with --format postgresql.`,
+  `For Drizzle, please run your DB migrations, then use 'pg_dump --schema-only' to generate a dump file. You can then use it with --format postgres.`,
 )}
 `)
     } else {
@@ -209,7 +209,7 @@ ${yocto.blueBright(DocsUrl)}
   //
   // Determine the --format value based on user selection
   //
-  const selectedFormat = formatMap[dbOrOrm] || 'postgresql'
+  const selectedFormat = formatMap[dbOrOrm] || 'postgres'
 
   //
   // Show docs link
@@ -242,7 +242,7 @@ ${yocto.blueBright(DocsUrl)}
     stepNum++
     console.info(
       yocto.blueBright(
-        '   $ npx @liam-hq/cli erd build --input <schema.sql> --format postgresql',
+        '   $ npx @liam-hq/cli erd build --input <schema.sql> --format postgres',
       ),
     )
   } else if (inputFilePath) {
@@ -263,7 +263,7 @@ ${yocto.blueBright(DocsUrl)}
     stepNum++
     console.info(
       yocto.blueBright(
-        '   $ npx @liam-hq/cli erd build --input <schema.sql> --format postgresql',
+        '   $ npx @liam-hq/cli erd build --input <schema.sql> --format postgres',
       ),
     )
   }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/1047

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

`--fomat postgresql` will fail, actually `--format postgres` is correct.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 5214a096f1bed5312b28aba7e020d1138efb8e5d

- Updated `--format` value from `postgresql` to `postgres` in CLI commands.
- Adjusted Drizzle-specific guidance to align with the new `--format` value.
- Updated documentation examples to reflect the `--format` change.
- Added a changeset file to document the patch update.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update `--format` value and Drizzle guidance in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/initCommand/index.ts

<li>Changed <code>--format</code> value from <code>postgresql</code> to <code>postgres</code> in multiple <br>locations.<br> <li> Updated Drizzle-specific guidance to match the new <code>--format</code> value.<br> <li> Adjusted default <code>--format</code> fallback to <code>postgres</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1048/files#diff-927569ca321915530a5c635f660996e7ea7da3e1c89046324e4cab2acb5e55c7">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>short-turtles-admire.md</strong><dd><code>Add changeset for CLI patch update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/short-turtles-admire.md

- Added a changeset file documenting the patch update for the CLI.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1048/files#diff-4e3a59976f82741367ec2ca964c90a851324b7b4a61dfac64f536e7f8956a08e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.mdx</strong><dd><code>Update CLI documentation examples for `--format` change</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/docs/content/docs/cli/index.mdx

<li>Updated documentation examples to use <code>--format postgres</code> instead of <br><code>--format postgresql</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1048/files#diff-e7c5208ef5297be5455cc6b1b141ccfb2cb3b53dc05e5c33ef4d743c1cf7dbed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>