### PR TITLE
🔧 Refactor E2E test conditions

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -29,22 +29,18 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
+          EVENT_NAME="${{ github.event_name }}"
+          EVENT_STATE="${{ github.event.deployment_status.state }}"
           ENVIRONMENT="${{ github.event.deployment.environment }}"
           TARGET_URL="${{ github.event.deployment_status.target_url }}"
-          if [[ "${{ github.event_name }}" == "deployment_status" && \
-                "${{ github.event.deployment_status.state }}" == "success" && \
-                ( \
-                  ( \
-                    [[ "$ENVIRONMENT" == *"Production"* ]] && \
-                    [[ "$TARGET_URL" == *"liam-app-git-main"* ]] \
-                  ) || \
-                  ( \
-                    [[ "$ENVIRONMENT" == *"Preview"* ]] && \
-                    [[ "$TARGET_URL" != *"liam-erd-sample"* ]] && \
-                    [[ "$TARGET_URL" != *"liam-docs"* ]] \
-                  ) \
-                ) ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+
+          if [ "$EVENT_NAME" = "deployment_status" ] && [ "$EVENT_STATE" = "success" ]; then
+            if { [ "$ENVIRONMENT" = *"Production"* ] && [ "$TARGET_URL" = *"liam-app-git-main"* ]; } || \
+               { [ "$ENVIRONMENT" = *"Preview"* ] && [ "$TARGET_URL" != *"liam-erd-sample"* ] && [ "$TARGET_URL" != *"liam-docs"* ]; }; then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+            else
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,20 +5,6 @@ on:
 
 jobs:
   e2e-tests:
-    if: |
-      github.event_name == 'deployment_status' &&
-      github.event.deployment_status.state == 'success' &&
-      (
-        (
-          contains(github.event.deployment.environment, 'Production') &&
-          contains(github.event.deployment_status.target_url, 'liam-app-git-main')
-        ) ||
-        (
-          contains(github.event.deployment.environment, 'Preview') &&
-          !contains(github.event.deployment_status.target_url, 'liam-erd-sample') &&
-          !contains(github.event.deployment_status.target_url, 'liam-docs')
-        )
-      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -41,61 +27,23 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/pnpm-setup
 
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', '**/playwright.config.ts') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps
-
-      - name: Install system dependencies for WebKit
-        # Some WebKit dependencies seem to lay outside the cache and will need to be installed separately
-        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
-        run: pnpm exec playwright install-deps webkit
-
+      # This workflow is triggered for all deployments (liam-app, liam-erd-sample, liam-docs),
+      # but E2E tests are executed only for liam-app deployments now.
       - name: Run e2e tests
+        if: |
+          github.event_name == 'deployment_status' &&
+          github.event.deployment_status.state == 'success' &&
+          (
+            (
+              contains(github.event.deployment.environment, 'Production') &&
+              contains(github.event.deployment_status.target_url, 'liam-app-git-main')
+            ) ||
+            (
+              contains(github.event.deployment.environment, 'Preview') &&
+              !contains(github.event.deployment_status.target_url, 'liam-erd-sample') &&
+              !contains(github.event.deployment_status.target_url, 'liam-docs')
+            )
+          )
         run: pnpm exec playwright test --project="${{ matrix.browser }}"
         env:
           URL: ${{ env.URL }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: test-results-${{ matrix.browser }}
-          path: frontend/packages/e2e/test-results/
-          retention-days: 30
-
-      - name: Slack Notification on Failure
-        if: ${{ env.ENVIRONMENT == 'Production – liam-app' && failure() }}
-        uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
-        env:
-          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CI_WEBHOOK_URL }}
-        with:
-          text: "E2E Test Failure"
-          attachments: |
-            [
-              {
-                "color": "bad",
-                "fields": [
-                  {
-                    "title": "Browser",
-                    "value": "${{ matrix.browser }}"
-                  },
-                  {
-                    "title": "Result",
-                    "value": "failure"
-                  },
-                  {
-                    "title": "Job URL",
-                    "value": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-                ]
-              }
-            ]

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -27,6 +27,24 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/pnpm-setup
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', '**/playwright.config.ts') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps
+
+      - name: Install system dependencies for WebKit
+        # Some WebKit dependencies seem to lay outside the cache and will need to be installed separately
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+        run: pnpm exec playwright install-deps webkit
+
       # This workflow is triggered for all deployments (liam-app, liam-erd-sample, liam-docs),
       # but E2E tests are executed only for liam-app deployments now.
       - name: Run e2e tests

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -19,15 +19,39 @@ jobs:
       URL: ${{ github.event.deployment_status.target_url }}
       ENVIRONMENT: ${{ github.event.deployment.environment }}
     steps:
+      - name: Check deployment conditions
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "deployment_status" && \
+                "${{ github.event.deployment_status.state }}" == "success" && \
+                ( \
+                  ( \
+                    "$GITHUB_ENVIRONMENT" == *"Production"* && \
+                    "$GITHUB_TARGET_URL" == *"liam-app-git-main"* \
+                  ) || \
+                  ( \
+                    "$GITHUB_ENVIRONMENT" == *"Preview"* && \
+                    "$GITHUB_TARGET_URL" != *"liam-erd-sample"* && \
+                    "$GITHUB_TARGET_URL" != *"liam-docs"* \
+                  ) \
+                ) ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
+        if: steps.check.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.deployment.sha }}
 
       - name: Setup pnpm
+        if: steps.check.outputs.should_run == 'true'
         uses: ./.github/actions/pnpm-setup
 
       - name: Cache Playwright browsers
+        if: steps.check.outputs.should_run == 'true'
         id: playwright-cache
         uses: actions/cache@v4
         with:
@@ -37,46 +61,33 @@ jobs:
             playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.check.outputs.should_run == 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: pnpm exec playwright install --with-deps
 
       - name: Install system dependencies for WebKit
         # Some WebKit dependencies seem to lay outside the cache and will need to be installed separately
-        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+        if: ${{ steps.check.outputs.should_run == 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
         run: pnpm exec playwright install-deps webkit
 
       # This workflow is triggered for all deployments (liam-app, liam-erd-sample, liam-docs),
       # but E2E tests are executed only for liam-app deployments now.
       - name: Run e2e tests
-        if: |
-          github.event_name == 'deployment_status' &&
-          github.event.deployment_status.state == 'success' &&
-          (
-            (
-              contains(github.event.deployment.environment, 'Production') &&
-              contains(github.event.deployment_status.target_url, 'liam-app-git-main')
-            ) ||
-            (
-              contains(github.event.deployment.environment, 'Preview') &&
-              !contains(github.event.deployment_status.target_url, 'liam-erd-sample') &&
-              !contains(github.event.deployment_status.target_url, 'liam-docs')
-            )
-          )
+        if: steps.check.outputs.should_run == 'true'
         run: pnpm exec playwright test --project="${{ matrix.browser }}"
         env:
           URL: ${{ env.URL }}
 
       # FIXME: This step is not working well. All environments seem to be Preview.
       - name: Upload test results
+        if: ${{ steps.check.outputs.should_run == 'true' && failure() }}
         uses: actions/upload-artifact@v4
-        if: failure()
         with:
           name: test-results-${{ matrix.browser }}
           path: frontend/packages/e2e/test-results/
           retention-days: 30
 
       - name: Slack Notification on Failure
-        if: ${{ env.ENVIRONMENT == 'Production – liam-app' && failure() }}
+        if: ${{ steps.check.outputs.should_run == 'true' && env.ENVIRONMENT == 'Production – liam-app' && failure() }}
         uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
         env:
           INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CI_WEBHOOK_URL }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -19,32 +19,35 @@ jobs:
       URL: ${{ github.event.deployment_status.target_url }}
       ENVIRONMENT: ${{ github.event.deployment.environment }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
       - name: Check deployment conditions
         id: check
+        shell: bash
+        working-directory: ${{ github.workspace }}
         run: |
+          ENVIRONMENT="${{ github.event.deployment.environment }}"
+          TARGET_URL="${{ github.event.deployment_status.target_url }}"
           if [[ "${{ github.event_name }}" == "deployment_status" && \
                 "${{ github.event.deployment_status.state }}" == "success" && \
                 ( \
                   ( \
-                    "$GITHUB_ENVIRONMENT" == *"Production"* && \
-                    "$GITHUB_TARGET_URL" == *"liam-app-git-main"* \
+                    [[ "$ENVIRONMENT" == *"Production"* ]] && \
+                    [[ "$TARGET_URL" == *"liam-app-git-main"* ]] \
                   ) || \
                   ( \
-                    "$GITHUB_ENVIRONMENT" == *"Preview"* && \
-                    "$GITHUB_TARGET_URL" != *"liam-erd-sample"* && \
-                    "$GITHUB_TARGET_URL" != *"liam-docs"* \
+                    [[ "$ENVIRONMENT" == *"Preview"* ]] && \
+                    [[ "$TARGET_URL" != *"liam-erd-sample"* ]] && \
+                    [[ "$TARGET_URL" != *"liam-docs"* ]] \
                   ) \
                 ) ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Checkout repository
-        if: steps.check.outputs.should_run == 'true'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.deployment.sha }}
 
       - name: Setup pnpm
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -47,3 +47,40 @@ jobs:
         run: pnpm exec playwright test --project="${{ matrix.browser }}"
         env:
           URL: ${{ env.URL }}
+
+      # FIXME: This step is not working well. All environments seem to be Preview.
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results-${{ matrix.browser }}
+          path: frontend/packages/e2e/test-results/
+          retention-days: 30
+
+      - name: Slack Notification on Failure
+        if: ${{ env.ENVIRONMENT == 'Production – liam-app' && failure() }}
+        uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0
+        env:
+          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CI_WEBHOOK_URL }}
+        with:
+          text: "E2E Test Failure"
+          attachments: |
+            [
+              {
+                "color": "bad",
+                "fields": [
+                  {
+                    "title": "Browser",
+                    "value": "${{ matrix.browser }}"
+                  },
+                  {
+                    "title": "Result",
+                    "value": "failure"
+                  },
+                  {
+                    "title": "Job URL",
+                    "value": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                ]
+              }
+            ]


### PR DESCRIPTION
The current e2e test is as follows

<img width="600" src="https://github.com/user-attachments/assets/c48405bd-5ee5-4b67-b114-87fad2819638">

There was a problem that the checks in the pull request did not show the results of all jobs.

For example, the following only shows the skip of the ``liam-erd-sample``, and we are not aware that the e2e test of the ``liam-app`` is actually failing.
<img width="400" src="https://github.com/user-attachments/assets/bf83041f-955f-4651-b091-35b3e55bbd21">

Therefore, I made it so that it is included in the checks of the pull request by conditional branching in steps instead of managing it in GitHub Action's jobs.

![ss 3013](https://github.com/user-attachments/assets/5402719f-dd69-4cda-88f9-638cbb361cee)


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 9e9270da6d1ae2e765bcd127a1a5c72dbf0f56b1

- Refactored E2E test conditions to improve visibility in PR checks.
- Simplified workflow by removing unnecessary steps and caching logic.
- Ensured E2E tests are executed only for `liam-app` deployments.
- Improved conditional branching for deployment-based test execution.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_tests.yml</strong><dd><code>Refactored E2E test workflow for clarity and efficiency</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e_tests.yml

<li>Removed redundant caching and setup steps for Playwright.<br> <li> Added conditional branching to run tests only for <code>liam-app</code> <br>deployments.<br> <li> Simplified workflow by removing Slack notifications and artifact <br>uploads.<br> <li> Improved clarity by documenting test execution conditions.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1053/files#diff-37aed4ad4a8c3a4220c5e3c2eee33093073b8d64f480cc742b63764c859b6c72">+16/-68</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>