### PR TITLE
fix/The hidden & active query parameter is not reflected in the ER diagram during back/forward navigation

### DIFF
--- a/frontend/packages/e2e/tests/e2e/navigation.test.ts
+++ b/frontend/packages/e2e/tests/e2e/navigation.test.ts
@@ -92,7 +92,7 @@ test.describe('Navigation and URL Parameters', () => {
     })
 
     // FIXME: Browser back on hidden table is not working properly
-    test.skip('should handle back/forward navigation with table hiding', async ({
+    test('should handle back/forward navigation with table hiding', async ({
       page,
     }) => {
       // Initial state

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
@@ -70,7 +70,7 @@ export const ERDContentInner: FC<Props> = ({
     nodes,
     displayArea,
   })
-  usePopStateListener({ nodes, displayArea })
+  usePopStateListener({ displayArea })
 
   const { version } = useVersion()
   const isTouchDevice = useIsTouchDevice()

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
@@ -70,7 +70,7 @@ export const ERDContentInner: FC<Props> = ({
     nodes,
     displayArea,
   })
-  usePopStateListener()
+  usePopStateListener({ nodes, displayArea })
 
   const { version } = useVersion()
   const isTouchDevice = useIsTouchDevice()

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
@@ -17,23 +17,21 @@ import { useCallback, useEffect } from 'react'
 import { hasNonRelatedChildNodes, updateNodesHiddenState } from '../utils'
 
 type Params = {
-  
   displayArea: DisplayArea
 }
 
 export const usePopStateListener = ({ displayArea }: Params) => {
-  const { getEdges, setNodes, setEdges, fitView, getNodes } = useCustomReactflow()
-
+  const { getEdges, setNodes, setEdges, fitView, getNodes } =
+    useCustomReactflow()
 
   const handlePopState = useCallback(async () => {
     const nodes: Node[] = getNodes()
     const tableName = getActiveTableNameFromUrl()
     const showMode = getShowModeFromUrl()
     const hiddenNodeIds = await getHiddenNodeIdsFromUrl()
-    
 
     updateIsPopstateInProgress(true)
-    
+
     await Promise.all([
       new Promise<void>((resolve) => {
         updateActiveTableName(tableName ?? undefined)

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
@@ -24,20 +24,17 @@ type Params = {
 export const usePopStateListener = ({ nodes, displayArea }: Params) => {
   const { getEdges, setNodes, setEdges, fitView } = useCustomReactflow()
 
+
   const handlePopState = useCallback(async () => {
+ 
+    const tableName = getActiveTableNameFromUrl()
+    const showMode = getShowModeFromUrl()
+    const hiddenNodeIds = await getHiddenNodeIdsFromUrl()
+
     updateIsPopstateInProgress(true)
-
-    const [tableName, showMode, hiddenNodeIds] = await Promise.all([
-      getActiveTableNameFromUrl(),
-      getShowModeFromUrl(),
-      getHiddenNodeIdsFromUrl(),
-    ])
-
-    const updatedNodes = updateNodesHiddenState({
-      nodes,
-      hiddenNodeIds,
-      shouldHideGroupNodeId: !hasNonRelatedChildNodes(nodes),
-    })
+    
+    
+    
 
     await Promise.all([
       new Promise<void>((resolve) => {
@@ -50,6 +47,12 @@ export const usePopStateListener = ({ nodes, displayArea }: Params) => {
         setTimeout(resolve, 1)
       }),
     ])
+
+    const updatedNodes = updateNodesHiddenState({
+      nodes,
+      hiddenNodeIds,
+      shouldHideGroupNodeId: !hasNonRelatedChildNodes(nodes),
+    })
 
     const { nodes: highlightedNodes, edges: highlightedEdges } =
       highlightNodesAndEdges(updatedNodes, getEdges(), {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
@@ -1,3 +1,6 @@
+import type { DisplayArea } from '@/features/erd/types'
+import { computeAutoLayout, highlightNodesAndEdges } from '@/features/erd/utils'
+import { useCustomReactflow } from '@/features/reactflow/hooks'
 import {
   replaceHiddenNodeIds,
   updateActiveTableName,
@@ -9,35 +12,69 @@ import {
   getHiddenNodeIdsFromUrl,
   getShowModeFromUrl,
 } from '@/utils'
-import { useEffect } from 'react'
+import type { Node } from '@xyflow/react'
+import { useCallback, useEffect } from 'react'
+import { hasNonRelatedChildNodes, updateNodesHiddenState } from '../utils'
 
-export const usePopStateListener = () => {
-  useEffect(() => {
-    const handlePopState = async () => {
-      const tableName = getActiveTableNameFromUrl()
-      const showMode = getShowModeFromUrl()
-      const hiddenNodeIds = await getHiddenNodeIdsFromUrl()
+type Params = {
+  nodes: Node[]
+  displayArea: DisplayArea
+}
 
-      updateIsPopstateInProgress(true)
+export const usePopStateListener = ({ nodes, displayArea }: Params) => {
+  const { getEdges, setNodes, setEdges, fitView } = useCustomReactflow()
 
-      await new Promise<void>((resolve) => {
+  const handlePopState = useCallback(async () => {
+    updateIsPopstateInProgress(true)
+
+    const [tableName, showMode, hiddenNodeIds] = await Promise.all([
+      getActiveTableNameFromUrl(),
+      getShowModeFromUrl(),
+      getHiddenNodeIdsFromUrl(),
+    ])
+
+    const updatedNodes = updateNodesHiddenState({
+      nodes,
+      hiddenNodeIds,
+      shouldHideGroupNodeId: !hasNonRelatedChildNodes(nodes),
+    })
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
         updateActiveTableName(tableName ?? undefined)
         updateShowMode(showMode)
         setTimeout(resolve, 1)
-      })
-
-      await new Promise<void>((resolve) => {
+      }),
+      new Promise<void>((resolve) => {
         replaceHiddenNodeIds(hiddenNodeIds)
         setTimeout(resolve, 1)
+      }),
+    ])
+
+    const { nodes: highlightedNodes, edges: highlightedEdges } =
+      highlightNodesAndEdges(updatedNodes, getEdges(), {
+        activeTableName: tableName,
       })
 
-      updateIsPopstateInProgress(false)
-    }
+    const { nodes: layoutedNodes, edges: layoutedEdges } =
+      await computeAutoLayout(highlightedNodes, highlightedEdges)
 
+    setNodes(layoutedNodes)
+    setEdges(layoutedEdges)
+
+    const fitViewOptions =
+      displayArea === 'main' && tableName
+        ? { maxZoom: 1, duration: 300, nodes: [{ id: tableName }] }
+        : { duration: 0 }
+    await fitView(fitViewOptions)
+
+    updateIsPopstateInProgress(false)
+  }, [nodes, displayArea, getEdges, setNodes, setEdges, fitView])
+  useEffect(() => {
     window.addEventListener('popstate', handlePopState)
 
     return () => {
       window.removeEventListener('popstate', handlePopState)
     }
-  }, [])
+  }, [handlePopState])
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts
@@ -17,25 +17,23 @@ import { useCallback, useEffect } from 'react'
 import { hasNonRelatedChildNodes, updateNodesHiddenState } from '../utils'
 
 type Params = {
-  nodes: Node[]
+  
   displayArea: DisplayArea
 }
 
-export const usePopStateListener = ({ nodes, displayArea }: Params) => {
-  const { getEdges, setNodes, setEdges, fitView } = useCustomReactflow()
+export const usePopStateListener = ({ displayArea }: Params) => {
+  const { getEdges, setNodes, setEdges, fitView, getNodes } = useCustomReactflow()
 
 
   const handlePopState = useCallback(async () => {
- 
+    const nodes: Node[] = getNodes()
     const tableName = getActiveTableNameFromUrl()
     const showMode = getShowModeFromUrl()
     const hiddenNodeIds = await getHiddenNodeIdsFromUrl()
+    
 
     updateIsPopstateInProgress(true)
     
-    
-    
-
     await Promise.all([
       new Promise<void>((resolve) => {
         updateActiveTableName(tableName ?? undefined)
@@ -72,7 +70,7 @@ export const usePopStateListener = ({ nodes, displayArea }: Params) => {
     await fitView(fitViewOptions)
 
     updateIsPopstateInProgress(false)
-  }, [nodes, displayArea, getEdges, setNodes, setEdges, fitView])
+  }, [displayArea, getEdges, setNodes, setEdges, fitView, getNodes])
   useEffect(() => {
     window.addEventListener('popstate', handlePopState)
 


### PR DESCRIPTION
… the active nodes and edges from the url

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 4b6947eba979aa3a4a886d59fe9cc11102b3d896

- Enhanced `usePopStateListener` to handle nodes and display area.
- Improved popstate handling with async updates and layout adjustments.
- Integrated `usePopStateListener` with `ERDContentInner` component.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePopStateListener.ts</strong><dd><code>Refactor and enhance `usePopStateListener` hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/hooks/usePopStateListener.ts

<li>Refactored <code>usePopStateListener</code> to accept <code>nodes</code> and <code>displayArea</code> as <br>parameters.<br> <li> Added async handling for popstate updates, including node and edge <br>highlighting.<br> <li> Integrated auto-layout computation and view fitting based on display <br>area.<br> <li> Improved state updates for active table name, show mode, and hidden <br>nodes.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1091/files#diff-19c28f30d58088ef6dabc968599bb38f5488e54654264e668ca20c58cabadf1c">+52/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ERDContent.tsx</strong><dd><code>Update `ERDContentInner` to use enhanced `usePopStateListener`</code></dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx

<li>Updated <code>usePopStateListener</code> usage to pass <code>nodes</code> and <code>displayArea</code>.<br> <li> Improved integration with <code>ERDContentInner</code> for better popstate <br>handling.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1091/files#diff-e9e03ebb0f0cb84d4dcfbdc7e83aa0e2d017125d8e543ad30f3cb249da85c916">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>