### PR TITLE
feat(jobs): Migrate from Prisma to Supabase

### DIFF
--- a/frontend/packages/jobs/src/functions/getInstallationIdFromRepositoryId.ts
+++ b/frontend/packages/jobs/src/functions/getInstallationIdFromRepositoryId.ts
@@ -1,19 +1,19 @@
-import { prisma } from '@liam-hq/db'
+import { createClient } from '../libs/supabase'
 
 export const getInstallationIdFromRepositoryId = async (
   repositoryId: number,
 ): Promise<number> => {
-  const repository = await prisma.repository.findUnique({
-    where: {
-      id: repositoryId,
-    },
-    select: {
-      installationId: true,
-    },
-  })
+  const supabase = createClient()
+  const { data: repository, error } = await supabase
+    .from('Repository')
+    .select('installationId')
+    .eq('id', repositoryId)
+    .single()
 
-  if (!repository) {
-    throw new Error(`Repository with ID ${repositoryId} not found`)
+  if (error || !repository) {
+    throw new Error(
+      `Repository with ID ${repositoryId} not found: ${JSON.stringify(error)}`,
+    )
   }
 
   return Number(repository.installationId)

--- a/frontend/packages/jobs/src/functions/processSavePullRequest.ts
+++ b/frontend/packages/jobs/src/functions/processSavePullRequest.ts
@@ -1,10 +1,10 @@
-import { prisma } from '@liam-hq/db'
 import {
   getFileContent,
   getPullRequestDetails,
   getPullRequestFiles,
 } from '@liam-hq/github'
 import { minimatch } from 'minimatch'
+import { createClient } from '../libs/supabase'
 
 import type { SavePullRequestPayload } from '../types'
 
@@ -34,17 +34,18 @@ export type SavePullRequestResult = {
 export async function processSavePullRequest(
   payload: SavePullRequestPayload,
 ): Promise<SavePullRequestResult> {
-  const repository = await prisma.repository.findUnique({
-    where: {
-      owner_name: {
-        owner: payload.owner,
-        name: payload.name,
-      },
-    },
-  })
+  const supabase = createClient()
 
-  if (!repository) {
-    throw new Error('Repository not found')
+  // Find repository by owner and name
+  const { data: repository, error: repositoryError } = await supabase
+    .from('Repository')
+    .select('*')
+    .eq('owner', payload.owner)
+    .eq('name', payload.name)
+    .single()
+
+  if (repositoryError || !repository) {
+    throw new Error(`Repository not found: ${JSON.stringify(repositoryError)}`)
   }
 
   const fileChanges = await getPullRequestFiles(
@@ -55,18 +56,23 @@ export async function processSavePullRequest(
     payload.prNumber,
   )
 
-  const projectMappings = await prisma.projectRepositoryMapping.findMany({
-    where: {
-      repositoryId: repository.id,
-    },
-    include: {
-      project: {
-        include: {
-          watchSchemaFilePatterns: true,
-        },
-      },
-    },
-  })
+  // Get project mappings with nested project and schema file patterns
+  const { data: projectMappings, error: mappingsError } = await supabase
+    .from('ProjectRepositoryMapping')
+    .select(`
+      *,
+      project:Project(
+        *,
+        watchSchemaFilePatterns:WatchSchemaFilePattern(*)
+      )
+    `)
+    .eq('repositoryId', repository.id)
+
+  if (mappingsError) {
+    throw new Error(
+      `Failed to get project mappings: ${JSON.stringify(mappingsError)}`,
+    )
+  }
 
   const allPatterns = projectMappings.flatMap(
     (mapping) => mapping.project.watchSchemaFilePatterns,
@@ -118,32 +124,80 @@ export async function processSavePullRequest(
     }
   })
 
-  // Save or update PR record
-  const prRecord = await prisma.pullRequest.upsert({
-    where: {
-      repositoryId_pullNumber: {
+  // Save or update PR record using Supabase
+  // First check if PR record exists
+  const { data: existingPR } = await supabase
+    .from('PullRequest')
+    .select('id')
+    .eq('repositoryId', repository.id)
+    .eq('pullNumber', payload.prNumber)
+    .maybeSingle()
+
+  let prRecord: { id: number }
+  if (existingPR) {
+    // PR exists, no need to update anything in this case
+    prRecord = existingPR
+  } else {
+    // Create new PR record
+    const now = new Date().toISOString()
+    const { data: newPR, error: createPRError } = await supabase
+      .from('PullRequest')
+      .insert({
         repositoryId: repository.id,
-        pullNumber: BigInt(payload.prNumber),
-      },
-    },
-    update: {},
-    create: {
-      repositoryId: repository.id,
-      pullNumber: BigInt(payload.prNumber),
-    },
-  })
-  await prisma.migration.upsert({
-    where: {
-      pullRequestId: prRecord.id,
-    },
-    update: {
-      title: payload.pullRequestTitle,
-    },
-    create: {
-      pullRequestId: prRecord.id,
-      title: payload.pullRequestTitle,
-    },
-  })
+        pullNumber: payload.prNumber,
+        updatedAt: now,
+      })
+      .select()
+      .single()
+
+    if (createPRError || !newPR) {
+      throw new Error(
+        `Failed to create PR record: ${JSON.stringify(createPRError)}`,
+      )
+    }
+
+    prRecord = newPR
+  }
+
+  // Check if migration record exists
+  const { data: existingMigration } = await supabase
+    .from('Migration')
+    .select('id')
+    .eq('pullRequestId', prRecord.id)
+    .maybeSingle()
+
+  if (existingMigration) {
+    // Update existing migration
+    const { error: updateMigrationError } = await supabase
+      .from('Migration')
+      .update({
+        title: payload.pullRequestTitle,
+        updatedAt: new Date().toISOString(),
+      })
+      .eq('id', existingMigration.id)
+
+    if (updateMigrationError) {
+      throw new Error(
+        `Failed to update migration: ${JSON.stringify(updateMigrationError)}`,
+      )
+    }
+  } else {
+    // Create new migration
+    const now = new Date().toISOString()
+    const { error: createMigrationError } = await supabase
+      .from('Migration')
+      .insert({
+        pullRequestId: prRecord.id,
+        title: payload.pullRequestTitle,
+        updatedAt: now,
+      })
+
+    if (createMigrationError) {
+      throw new Error(
+        `Failed to create migration: ${JSON.stringify(createMigrationError)}`,
+      )
+    }
+  }
 
   return {
     success: true,


### PR DESCRIPTION
## Related Issue
N/A

## What does this PR do?
This PR migrates database operations in the jobs package from Prisma to Supabase client. It replaces all Prisma query patterns with equivalent Supabase query patterns across multiple files in the frontend/packages/jobs directory.

## What should reviewers focus on?
- Correct implementation of Supabase queries as replacements for Prisma queries
- Proper error handling for Supabase operations
- Timestamp handling additions for Supabase operations
- Nested relation queries in Supabase format

## How has this been tested?
N/A

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 8f02dcedc6a3cea49f76d17f040dd781fc183c47

- Migrated database operations from Prisma to Supabase across multiple functions.
  - Replaced Prisma queries with equivalent Supabase queries.
  - Improved error handling for Supabase operations.
- Enhanced timestamp handling and nested relation queries for Supabase.
- Updated logic for creating and updating records in Supabase.
- Refactored functions to use a unified `createClient` for Supabase initialization.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>getInstallationIdFromRepositoryId.ts</strong><dd><code>Replace Prisma query with Supabase for repository installation ID </code><br><code>retrieval</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-3026e68b83f9234f5eb2e4ebd6abee20e587bd18e1926f9bf34a28c646a53f5a">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>processCreateKnowledgeSuggestion.ts</strong><dd><code>Migrate project and knowledge suggestion creation to Supabase</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-42b4e172218b49fb066627de45063f285bd9a671548eaf877948fb5091ab4e41">+30/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>processGenerateDocsSuggestion.ts</strong><dd><code>Update repository information retrieval to use Supabase</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-10c60001333c9d55d7add7074d371aafbfe3e3881ca19693266a3e274246ed40">+14/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>processGenerateReview.ts</strong><dd><code>Replace Prisma queries with Supabase for reviews and doc paths</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-8870a35e490c543620cb7f6374537cff61e788b836b5b1205010245edda00979">+23/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>processGenerateSchemaMeta.ts</strong><dd><code>Migrate overall review and nested relations to Supabase</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-8b50893146e3d842b3fc41c2bbf66a949e40cb326f5dcdd3ee4f3ffb85be016c">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>processSavePullRequest.ts</strong><dd><code>Refactor pull request and project mapping logic to Supabase</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-5b86c2054b946bd643a9eff45931e3f84e789e3325c42f8a8ffa1e645d1ce77e">+102/-48</a></td>

</tr>

<tr>
  <td><strong>jobs.ts</strong><dd><code>Update task logic to use Supabase for reviews and project mappings</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1096/files#diff-2058cacc0f2a83e932ddde6ece0f30766b197a7f2d42b3506be73b24adf87c4c">+26/-20</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>
## Additional Notes
This change is part of the effort to standardize on Supabase across the codebase.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>