### PR TITLE
feat: Add suggestionSnippets field to review schema and prompts

### DIFF
--- a/frontend/packages/jobs/src/functions/__tests__/processSaveReview.test.ts
+++ b/frontend/packages/jobs/src/functions/__tests__/processSaveReview.test.ts
@@ -96,6 +96,7 @@ describe.skip('processSaveReview', () => {
             severity: 'CRITICAL',
             description: 'Test issue',
             suggestion: 'Fix the issue',
+            suggestionSnippets: [],
           },
         ],
       },

--- a/frontend/packages/jobs/src/prompts/generateReview/generateReview.ts
+++ b/frontend/packages/jobs/src/prompts/generateReview/generateReview.ts
@@ -32,6 +32,10 @@ Your JSON-formatted response must contain:
     - If the severity is "POSITIVE", do not set "suggestion" to null.
       - Instead, write a brief sentence indicating that no improvement is needed.
       - For example, "No suggestions needed", "Nothing to improve", "Keep up the good work", etc.
+  - "suggestionSnippets": An array of suggestion snippets for each issue kind in the "suggestions" field, each including:
+    - "filename": The filename of the file that needs to be applied.
+    - "snippet": The snippet of the file that needs to be applied.
+      - For example, if DEFAULT value is needed for a column, the snippet should include the statement with the DEFAULT value.
 - An array of scores for each issue kind in the "scores" field, each including:
   - "kind": One of the issue categories listed above.
   - "value": A numeric score from 0 to 10, using a deduction-based approach:

--- a/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
+++ b/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
@@ -34,7 +34,7 @@ export const reviewSchema = object({
       suggestionSnippets: array(
         object({
           filename: string(),
-          patch: string(),
+          snippet: string(),
         }),
       ),
     }),

--- a/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
+++ b/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
@@ -31,6 +31,12 @@ export const reviewSchema = object({
       severity: SeverityEnum,
       description: string(),
       suggestion: string(),
+      suggestionSnippets: array(
+        object({
+          filename: string(),
+          patch: string(),
+        }),
+      ),
     }),
   ),
   scores: array(

--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml
@@ -4,6 +4,14 @@ assert:
   value: The report mentions about ensuring that this table is empty before the migration
 - type: is-json
 - type: javascript
+  # Test 1: Check if the snippet has the exact correct file path
+  value: |
+    JSON.parse(output).issues.find(issue => issue.kind === "Migration Safety").suggestionSnippets[0].filename === "frontend/packages/db/prisma/migrations/20250328105323_add_branch_name_to_knowledge_suggestion/migration.sql"
+- type: javascript
+  # Test 2: Check if the snippet suggests setting a DEFAULT value for the branchName column
+  value: |
+    JSON.parse(output).issues.find(issue => issue.kind === "Migration Safety").suggestionSnippets[0].snippet.includes("ALTER TABLE \"KnowledgeSuggestion\" ADD COLUMN \"branchName\" TEXT NOT NULL DEFAULT '")
+- type: javascript
   value: JSON.parse(output).scores[0].value >= 1
 - type: cost
   threshold: 0.008


### PR DESCRIPTION
- Update tests in processSaveReview to include an empty suggestionSnippets array.
- Enhance generateReview prompt documentation to define suggestionSnippets with filename and patch properties.
- Extend reviewSchema to validate suggestionSnippets as an array of objects.
- Update test fixtures to assert that suggestionSnippets are correctly included in the review report.

## Issue

- resolve:

## Why is this change needed?
This change introduces the `suggestionSnippets` field to provide patch-level details for each suggestion in the review report. By including this field, reviewers can now receive specific file patch information along with general suggestions, enhancing the clarity and actionability of the feedback. (Note: The UI to display this information is not yet implemented.)

## What would you like reviewers to focus on?
- Verify that the new `suggestionSnippets` field is correctly integrated in the review schema and reflected in both tests and documentation.
- Confirm that the schema validation correctly enforces the structure of `suggestionSnippets` (i.e., an array of objects containing `filename` and `patch`).
- Ensure that test fixtures accurately assert the presence and format of `suggestionSnippets` in the review report.

## Testing Verification

https://github.com/liam-hq/liam/pull/1101#issuecomment-2777287248

Some tests are failed, but are not relevant to this PR.

<img width="711" alt="スクリーンショット 2025-04-04 18 29 45" src="https://github.com/user-attachments/assets/70550dd9-dbdb-40f6-a26c-e7b9298bf3a0" />



## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at b8bfc8ef3c19191fd836af8f06e8f37f91630249

- Introduced `suggestionSnippets` field in review schema for detailed suggestions.
- Updated tests to validate `suggestionSnippets` integration and structure.
- Enhanced prompt documentation to define `suggestionSnippets` usage.
- Added test fixtures to assert `suggestionSnippets` correctness in reports.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>processSaveReview.test.ts</strong><dd><code>Update tests to include `suggestionSnippets` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/jobs/src/functions/__tests__/processSaveReview.test.ts

<li>Added <code>suggestionSnippets</code> field to test data for issues.<br> <li> Ensured compatibility with the updated review schema.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1101/files#diff-00402fa9adcafe30e7d5d468d2c72832312f688998d1bd36bc07ba72f60060c1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fixture.yaml</strong><dd><code>Add test fixtures for `suggestionSnippets` validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml

<li>Added test cases to validate <code>suggestionSnippets</code> field.<br> <li> Verified file paths and snippet content in test assertions.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1101/files#diff-d3df1eef347cf425af2cd48eac3674e5e45a04d026413f7adb6be07b4c9843c4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generateReview.ts</strong><dd><code>Enhance prompt documentation for `suggestionSnippets`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/jobs/src/prompts/generateReview/generateReview.ts

<li>Documented <code>suggestionSnippets</code> field in the prompt structure.<br> <li> Explained its purpose and format for actionable suggestions.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1101/files#diff-bc327c5835be24c334bb5b64878901f0a7a7f7aab54d96897cb8f0a326d9aa6b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reviewSchema.ts</strong><dd><code>Extend review schema to include `suggestionSnippets`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts

<li>Added <code>suggestionSnippets</code> field to the review schema.<br> <li> Defined it as an array of objects with <code>filename</code> and <code>patch</code>.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1101/files#diff-67f415413057cfc6db882bf55d5978df834ba9ffe9a6faa798ac62e45813d6a8">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>