### PR TITLE
Fix review schema strictness and update test fixtures

### DIFF
--- a/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
+++ b/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
@@ -1,13 +1,4 @@
-import {
-  array,
-  enum as enumType,
-  maxValue,
-  minValue,
-  number,
-  object,
-  pipe,
-  string,
-} from 'valibot'
+import { array, enum as enumType, number, strictObject, string } from 'valibot'
 
 const KindEnum = enumType({
   'Migration Safety': 'Migration Safety',
@@ -23,16 +14,16 @@ const SeverityEnum = enumType({
   POSITIVE: 'POSITIVE',
 })
 
-export const reviewSchema = object({
+export const reviewSchema = strictObject({
   bodyMarkdown: string(),
   issues: array(
-    object({
+    strictObject({
       kind: KindEnum,
       severity: SeverityEnum,
       description: string(),
       suggestion: string(),
       suggestionSnippets: array(
-        object({
+        strictObject({
           filename: string(),
           snippet: string(),
         }),
@@ -40,9 +31,9 @@ export const reviewSchema = object({
     }),
   ),
   scores: array(
-    object({
+    strictObject({
       kind: KindEnum,
-      value: pipe(number(), minValue(0), maxValue(10)),
+      value: number(),
       reason: string(),
     }),
   ),

--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml
@@ -6,13 +6,13 @@ assert:
 - type: javascript
   # Test 1: Check if the snippet has the exact correct file path
   value: |
-    JSON.parse(output).issues.find(issue => issue.kind === "Migration Safety").suggestionSnippets[0].filename === "frontend/packages/db/prisma/migrations/20250328105323_add_branch_name_to_knowledge_suggestion/migration.sql"
+    !!output.issues.flatMap(issue => issue.suggestionSnippets).find(snippet => snippet.filename === "frontend/packages/db/prisma/migrations/20250328105323_add_branch_name_to_knowledge_suggestion/migration.sql")
 - type: javascript
   # Test 2: Check if the snippet suggests setting a DEFAULT value for the branchName column
   value: |
-    JSON.parse(output).issues.find(issue => issue.kind === "Migration Safety").suggestionSnippets[0].snippet.includes("ALTER TABLE \"KnowledgeSuggestion\" ADD COLUMN \"branchName\" TEXT NOT NULL DEFAULT '")
+    !!output.issues.flatMap(issue => issue.suggestionSnippets).find(snippet => snippet.snippet.includes("ALTER TABLE \"KnowledgeSuggestion\" ADD COLUMN \"branchName\" TEXT NOT NULL DEFAULT '"))
 - type: javascript
-  value: JSON.parse(output).scores[0].value >= 1
+  value: output.scores[0].value >= 1
 - type: cost
   threshold: 0.008
 

--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1055/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1055/fixture.yaml
@@ -4,7 +4,7 @@ assert:
   value: The report evaluates the **risk of data loss**.
 - type: is-json
 - type: javascript
-  value: JSON.parse(output).scores[0].value >= 1
+  value: output.scores[0].value >= 1
 - type: cost
   threshold: 0.008
 

--- a/frontend/packages/prompt-test/src/index.ts
+++ b/frontend/packages/prompt-test/src/index.ts
@@ -71,12 +71,16 @@ async function main() {
         {
           id: 'openai:gpt-4o-mini',
           config: {
-            responseFormat: {
+            response_format: {
               type: 'json_schema',
-              schema: reviewJsonSchema,
-              strict: true,
+              json_schema: {
+                name: 'review',
+                schema: reviewJsonSchema,
+                strict: true,
+              },
             },
             temperature: 0.7,
+            max_tokens: 16384, // gpt-4o-mini max tokens
           },
         },
       ],


### PR DESCRIPTION
This commit refines the review JSON schema by:

- Replacing `object` with `strictObject` from valibot to enforce `additionalProperties: false` in the root object as well as in nested objects for issues and scores.
- Removing the min/max constraints on the scores' value to simplify the validation.
- Updating test fixtures to match the new output structure by eliminating the need for `JSON.parse` in javascript assertions.
- Adjusting the configuration for the `gpt-4o-mini` response format to correctly wrap the JSON schema under `json_schema`.

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

In promptfoo test, the previous configuration structure was incorrect. 🙇  

To properly set the JSON schema, you need to configure it as follows:

```javascript
          config: {
            response_format: {
              type: 'json_schema',
              strict: true,
              json_schema: {
                name: 'review',
                schema: reviewJsonSchema,
                strict: true,
              },
            },
```

Accordingly, we are making the following changes:

- The use of `JSON.parse(output)` was incorrect; simply use `output` instead.
- Replace `object` with `strictObject`.
  - This ensures that the JSON schema is configured with `additionalProperties: false`, which is the desired behavior.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

https://github.com/liam-hq/liam/pull/1162#issuecomment-2778652487

<img width="714" alt="スクリーンショット 2025-04-07 8 41 36" src="https://github.com/user-attachments/assets/bab6c182-7223-469a-bb3b-98013289db87" />


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at d25d1d1b4e72a9b688ec07aa80194bd07e45e2ac

- Enforced strict validation in `reviewSchema` using `strictObject`.
- Simplified score validation by removing min/max constraints.
- Updated test fixtures to remove `JSON.parse` usage in assertions.
- Adjusted response format configuration for `gpt-4o-mini`.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reviewSchema.ts</strong><dd><code>Enforced stricter validation in `reviewSchema`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts

<li>Replaced <code>object</code> with <code>strictObject</code> for stricter validation.<br> <li> Removed min/max constraints on score values.<br> <li> Simplified schema structure for issues and scores.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1162/files#diff-67f415413057cfc6db882bf55d5978df834ba9ffe9a6faa798ac62e45813d6a8">+6/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Adjusted `gpt-4o-mini` response format configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/index.ts

<li>Updated response format configuration for <code>gpt-4o-mini</code>.<br> <li> Added <code>max_tokens</code> configuration for the provider.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1162/files#diff-d34cfd9d3e20b3bdf6c10852633314fd74a5250fdd5d96940ba889b61134a0f7">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fixture.yaml</strong><dd><code>Updated test fixture for simpler assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml

<li>Removed <code>JSON.parse</code> in JavaScript test assertions.<br> <li> Simplified test logic for file path and snippet checks.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1162/files#diff-d3df1eef347cf425af2cd48eac3674e5e45a04d026413f7adb6be07b4c9843c4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fixture.yaml</strong><dd><code>Simplified test fixture assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1055/fixture.yaml

<li>Removed <code>JSON.parse</code> in JavaScript test assertions.<br> <li> Simplified test logic for score validation.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1162/files#diff-54e178220b96f8c6ad0fa05273ae841d29af8d46c812e8dc1280ae29c3f35baf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>