### PR TITLE
Separating License Report updates from the License Compliance workflow

### DIFF
--- a/.github/workflows/license-report-update.yml
+++ b/.github/workflows/license-report-update.yml
@@ -1,0 +1,58 @@
+name: License Report Update
+
+# ## Summary
+#
+# This workflow updates $LICENSE_REPORT using license_finder CLI
+# and automatically create a pull request if any changes are detected.
+
+on:
+  schedule:
+    - cron: "00 0 * * 1" # every monday 9:00 JST
+  workflow_dispatch:
+
+jobs:
+  license_report_update:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    timeout-minutes: 10
+    env:
+      LICENSE_REPORT: docs/packages-license.md
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/pnpm-setup
+      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
+        with:
+          ruby-version: '3.3'
+      - name: Install License Finder
+        run: gem install -N license_finder
+      - name: Generate license report
+        run: |
+          mkdir -p "$(dirname "$LICENSE_REPORT")"
+          license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
+          # Delete the timestamp line because there will be a difference even if there is no change in licenses
+          sed -e '/^As of /d' -i "$LICENSE_REPORT"
+      - name: Create pull request if license report changes
+        run: |
+          if git diff --quiet; then
+            echo 'No changes to commit'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          BRANCH_NAME="license-report-update-$(date +'%Y%m%d%H%M%S')"
+          git checkout -b "$BRANCH_NAME"
+          git add "$LICENSE_REPORT"
+          git commit -m "Update $LICENSE_REPORT"
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --title "[$(date +'%Y/%m/%d')] License Report Update" \
+            --body "This pull request automatically updates the license report."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/license-report-update.yml
+++ b/.github/workflows/license-report-update.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup
       - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
       - name: Install License Finder
         run: gem install -N license_finder
       - name: Generate license report

--- a/.github/workflows/license-report-update.yml
+++ b/.github/workflows/license-report-update.yml
@@ -22,8 +22,16 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ vars.LICENSE_CI_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.LICENSE_CI_TRIGGER_APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/pnpm-setup
       - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
         with:
@@ -55,4 +63,4 @@ jobs:
             --title "[$(date +'%Y/%m/%d')] License Report Update" \
             --body "This pull request automatically updates the license report."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -3,10 +3,6 @@ name: License Compliance
 # ## Summary
 #
 # This workflow runs the license_finder CLI only when it detects an update to files related to the License Finder.
-# It also updates $LICENSE_REPORT and git commit.
-#
-# When triggered by a PR from a forked repository, $LICENSE_REPORT is not updated.
-# When triggered by a merge_group event, $LICENSE_REPORT is not updated either.
 
 on:
   pull_request:
@@ -18,29 +14,8 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     timeout-minutes: 10
-    env:
-      LICENSE_REPORT: docs/packages-license.md
-    permissions:
-      contents: write
     steps:
-      - name: Check if running in a fork
-        id: fork-check
-        run: echo "is_fork=${{ github.event.pull_request.head.repo.fork }}" >> "$GITHUB_OUTPUT"
-      - name: Create GitHub App Token for non-fork PRs
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-        if: steps.fork-check.outputs.is_fork != 'true'
-        id: app-token
-        with:
-          app-id: ${{ vars.LICENSE_CI_TRIGGER_APP_ID }}
-          private-key: ${{ secrets.LICENSE_CI_TRIGGER_APP_PRIVATE_KEY }}
-      - name: Checkout code for non-fork PRs
-        if: steps.fork-check.outputs.is_fork != 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Checkout code for forked PRs
-        if: steps.fork-check.outputs.is_fork == 'true'
+      - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # To make the success of this job a prerequisite for merging into the main branch,
       # set a filter here instead of on: to determine whether or not to proceed to the next step.
@@ -75,35 +50,3 @@ jobs:
       - name: Run License Finder
         if: steps.determine.outputs.files_changed == 'true'
         run: license_finder
-
-      # Commit the License Finder report as docs/packages-license.md
-      - name: Generate license report
-        if: |
-          steps.fork-check.outputs.is_fork != 'true'
-          && steps.determine.outputs.files_changed == 'true'
-          && github.ref_name != github.event.repository.default_branch
-          && github.event_name != 'merge_group'
-        run: |
-          mkdir -p "$(dirname "$LICENSE_REPORT")"
-          license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
-          # Delete the timestamp line because there will be a difference even if there is no change in licenses
-          sed -e '/^As of /d' -i "$LICENSE_REPORT"
-      - name: Commit license report and push
-        if: |
-          steps.fork-check.outputs.is_fork != 'true'
-          && steps.determine.outputs.files_changed == 'true'
-          && github.ref_name != github.event.repository.default_branch
-          && github.event_name != 'merge_group'
-        run: |
-          if git diff --quiet; then
-            echo 'No changes to commit'
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add "$LICENSE_REPORT"
-          git commit -m "Update $LICENSE_REPORT"
-          git push origin "$BRANCH_NAME"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
         if: steps.determine.outputs.files_changed == 'true'
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
       - name: Install License Finder
         if: steps.determine.outputs.files_changed == 'true'
         run: gem install -N license_finder


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
* Even pull requests generated by Renovate include a commit that updates `docs/packages-license.md`
    * For example: https://github.com/liam-hq/liam/pull/1116/commits
* Because Renovate creates multiple pull requests, merging them often results in conflicts in pnpm-lock.yaml across different PRs
* When conflicts occur, Renovate automatically rebases and force pushes. However, if someone else (for example, GitHub App) has committed changes, Renovate refrains from force pushing

For these reasons, updating `docs/packages-license.md` with every PR would incur high maintenance costs. Therefore, we have decided to update it once a week on a scheduled basis.

As always, package licenses will be monitored on a PR-by-PR basis.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->
Is it okay to update `docs/packages-license.md` once a week?

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->
* .github/workflows/license.yml
    * ✅ https://github.com/liam-hq/liam/actions/runs/14328505668
* .github/workflows/license-report-update.yml
    * I haven't been able to test it. I'll run it manually and check it when this PR is merged

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 96aa299ba8f29b6894bcecf9723cb98544c20f2b

- Introduced a new GitHub Actions workflow for weekly license report updates.
- Removed license report update steps from the License Compliance workflow.
- Updated Ruby version to 3.4 in workflows for consistency.
- Improved CI token handling with GitHub App for PR creation.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>license-report-update.yml</strong><dd><code>Added a new scheduled workflow for license report updates</code></dd></summary>
<hr>

.github/workflows/license-report-update.yml

<li>Added a new workflow for weekly license report updates.<br> <li> Configured GitHub App token for CI operations.<br> <li> Automated PR creation for license report changes.<br> <li> Scheduled workflow to run every Monday at 9:00 JST.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1237/files#diff-27fd71a6aeaabc8f293b834e461226de4dd2ddc7d46bba203ea41eefad831ac9">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>license.yml</strong><dd><code>Simplified License Compliance workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/license.yml

<li>Removed license report update steps from the workflow.<br> <li> Simplified code checkout logic for forked and non-forked PRs.<br> <li> Updated Ruby version to 3.4 for consistency.<br> <li> Streamlined the workflow to focus on license compliance checks.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1237/files#diff-c24fd68dc9cdef9206805d2b129cc11ed4625d9cc30e582d905cc3a6d483d556">+2/-59</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>