### PR TITLE
🧪(tests): Remove score threshold assertions from test fixtures

### DIFF
--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml
@@ -12,8 +12,6 @@ assert:
   value: |
     !!output.feedbacks.flatMap(feedback => feedback.suggestionSnippets).find(snippet => snippet.snippet.includes("ALTER TABLE \"KnowledgeSuggestion\" ADD COLUMN \"branchName\" TEXT NOT NULL DEFAULT '"))
 - type: javascript
-  value: output.scores[0].value >= 1
-- type: javascript
   # `bodyMarkdown` Test 1: Check if the bodyMarkdown sentence is less than or equal to 3
   value: |
     output.bodyMarkdown.split(". ").length <= 3

--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1055/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1055/fixture.yaml
@@ -11,8 +11,6 @@ assert:
   # `bodyMarkdown` Test 2: Check if the bodyMarkdown word count is approximately less than or equal to 80
   value: |
     output.bodyMarkdown.split(" ").length <= 80
-- type: javascript
-  value: output.scores[0].value >= 1
 - type: cost
   threshold: 0.008
 

--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1105/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1105/fixture.yaml
@@ -3,8 +3,6 @@ assert:
 - type: javascript
   value: output.feedbacks.filter(feedback => feedback.severity === "POSITIVE").length > 0
 - type: is-json
-- type: javascript
-  value: output.scores[0].value >= 1
 - type: cost
   threshold: 0.008
 


### PR DESCRIPTION
## Issue

- https://github.com/liam-hq/liam/pull/1265#issuecomment-2788743064

## Why is this change needed?

This change removes unnecessary score threshold assertions from multiple test fixtures, making the tests more focused and maintainable.

## What would you like reviewers to focus on?

- Correctness of test assertions after removal
- Impact on test reliability
- Are there other similar assertions that should be removed for consistency?

## Testing Verification

Verified that test fixtures still pass with the removed assertions.
https://github.com/liam-hq/liam/pull/1271#issuecomment-2788870510

## What was done

### 🤖 Generated by PR Agent at 288a31925927932afe6e4f7eedfb5a0265885c75

- Removed redundant JavaScript score threshold assertions from test fixtures.
- Simplified test fixtures to improve maintainability and focus.
- Verified that all test fixtures pass after the changes.


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fixture.yaml</strong><dd><code>Removed JavaScript score assertion from fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1033/fixture.yaml

<li>Removed a JavaScript score threshold assertion.<br> <li> Retained other assertions for test validation.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1271/files#diff-d3df1eef347cf425af2cd48eac3674e5e45a04d026413f7adb6be07b4c9843c4">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fixture.yaml</strong><dd><code>Removed JavaScript score assertion from fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1055/fixture.yaml

<li>Removed a JavaScript score threshold assertion.<br> <li> Kept other assertions intact for test coverage.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1271/files#diff-54e178220b96f8c6ad0fa05273ae841d29af8d46c812e8dc1280ae29c3f35baf">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fixture.yaml</strong><dd><code>Removed JavaScript score assertion from fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1105/fixture.yaml

<li>Removed a JavaScript score threshold assertion.<br> <li> Ensured other test validations remain unchanged.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1271/files#diff-048fed0575a5fc61f5a0943a26b8805343404221ee50f58d17734f94a87a2648">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This is a non-functional change that only affects test fixtures.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>