### PR TITLE
✨ Update ERD display when content is saved

### DIFF
--- a/frontend/apps/app/features/projects/actions/processOverrideContent.ts
+++ b/frontend/apps/app/features/projects/actions/processOverrideContent.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import type { DBStructure } from '@liam-hq/db-structure'
+import { applyOverrides, dbOverrideSchema } from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+export async function processOverrideContent(
+  content: string,
+  dbStructure: DBStructure,
+) {
+  const parsedOverrideContent = safeParse(dbOverrideSchema, JSON.parse(content))
+
+  if (!parsedOverrideContent.success) {
+    return {
+      result: null,
+      error: {
+        name: 'ValidationError',
+        message: 'Failed to validate schema override file.',
+        instruction:
+          'Please ensure the override file is in the correct format.',
+      },
+    }
+  }
+
+  return {
+    result: applyOverrides(dbStructure, parsedOverrideContent.output),
+    error: null,
+  }
+}

--- a/frontend/apps/app/features/projects/components/EditableContent/EditableContent.tsx
+++ b/frontend/apps/app/features/projects/components/EditableContent/EditableContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { type ReactNode, useState } from 'react'
+import React, { useState } from 'react'
 import { updateKnowledgeSuggestionContent } from '../../actions/updateKnowledgeSuggestionContent'
 import { DiffDisplay } from '../DiffDisplay/DiffDisplay'
 import styles from './EditableContent.module.css'
@@ -11,6 +11,7 @@ type EditableContentProps = {
   className?: string
   originalContent: string | null
   isApproved: boolean
+  onContentSaved?: (savedContent: string) => void
 }
 
 export const EditableContent = ({
@@ -19,6 +20,7 @@ export const EditableContent = ({
   className,
   originalContent,
   isApproved,
+  onContentSaved,
 }: EditableContentProps) => {
   const [isEditing, setIsEditing] = useState(false)
   const [editedContent, setEditedContent] = useState(content)
@@ -40,6 +42,10 @@ export const EditableContent = ({
       await updateKnowledgeSuggestionContent(formData)
       setSavedContent(editedContent)
       setIsEditing(false)
+
+      if (onContentSaved) {
+        onContentSaved(editedContent)
+      }
     } catch (error) {
       console.error('Error saving content:', error)
     } finally {

--- a/frontend/apps/app/features/projects/components/EditableContent/index.ts
+++ b/frontend/apps/app/features/projects/components/EditableContent/index.ts
@@ -1,0 +1,1 @@
+export * from './EditableContent'

--- a/frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/KnowledgeContentSection.tsx
+++ b/frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/KnowledgeContentSection.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { processOverrideContent } from '@/features/projects/actions/processOverrideContent'
+import { EditableContent } from '@/features/projects/components/EditableContent'
+import type { DBStructure, TableGroup } from '@liam-hq/db-structure'
+import type { SupportedFormat } from '@liam-hq/db-structure/parser'
+import { type FC, useState } from 'react'
+import { ErdViewer } from './ErdViewer'
+import styles from './KnowledgeSuggestionDetailPage.module.css'
+
+type ErrorObject = {
+  name: string
+  message: string
+  instruction?: string
+}
+
+type ProcessedResult = {
+  tableGroups: Record<string, TableGroup>
+}
+
+type Props = {
+  suggestionContent: string
+  suggestionId: number
+  originalContent: string | null
+  isApproved: boolean
+  dbStructure: DBStructure | undefined
+  format: SupportedFormat | undefined
+  content: string | null
+  errors: ErrorObject[]
+  tableGroups: Record<string, TableGroup>
+}
+
+export const KnowledgeContentSection: FC<Props> = ({
+  suggestionContent,
+  suggestionId,
+  originalContent,
+  isApproved,
+  dbStructure,
+  format,
+  content,
+  errors,
+  tableGroups: initialTableGroups,
+}) => {
+  const [currentContent, setCurrentContent] = useState(suggestionContent)
+  const [processedResult, setProcessedResult] =
+    useState<ProcessedResult | null>(null)
+
+  const handleContentSaved = async (savedContent: string) => {
+    setCurrentContent(savedContent)
+
+    // Update ErdViewer data with the saved content using server action
+    if (dbStructure) {
+      const { result } = await processOverrideContent(savedContent, dbStructure)
+      setProcessedResult(result)
+    }
+  }
+
+  return (
+    <div className={styles.columns}>
+      <div className={styles.contentSection}>
+        <div className={styles.header}>
+          <h2 className={styles.sectionTitle}>Content</h2>
+        </div>
+
+        <EditableContent
+          content={currentContent}
+          suggestionId={suggestionId}
+          className={styles.codeContent}
+          originalContent={originalContent}
+          isApproved={isApproved}
+          onContentSaved={handleContentSaved}
+        />
+      </div>
+
+      {content !== null && format !== undefined && dbStructure && (
+        <ErdViewer
+          key={JSON.stringify(
+            processedResult?.tableGroups || initialTableGroups,
+          )}
+          dbStructure={dbStructure}
+          tableGroups={processedResult?.tableGroups || initialTableGroups || {}}
+          errorObjects={errors || []}
+          defaultSidebarOpen={false}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

Even after updating the diff editor and clicking the Save button, the changes were not reflected in the ERD until the page was reloaded.
Now, the ERD is updated immediately when the diff editor is updated and the Save button is clicked.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e4121cae-932f-404c-89bf-a2a3bce54496" /> | <video src="https://github.com/user-attachments/assets/45d5fa07-50a7-4694-93e0-66739a6f7961" /> | 


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at de9cbfdc49bcbb31f2e30fc0ab82cb5971517c5a

- Added immediate ERD updates when content is saved.
- Refactored `EditableContent` to support a callback for saved content.
- Introduced `KnowledgeContentSection` for modular content and ERD handling.
- Replaced redundant logic with reusable server-side `processOverrideContent`.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>processOverrideContent.ts</strong><dd><code>Add server-side schema override processing function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/actions/processOverrideContent.ts

<li>Added a new server-side function <code>processOverrideContent</code>.<br> <li> Validates and applies schema overrides to the database structure.<br> <li> Returns processed results or validation errors.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1273/files#diff-82a7878bebd0dfc3830f4d7cd6897be1fd0b4238d9bafb9581013dc9c364ba76">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export EditableContent component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/components/EditableContent/index.ts

- Exported `EditableContent` component for broader usage.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1273/files#diff-7f7c55d33b13025b90d1e85b82457db65a184a31efeacb313ad22a2af97fcb2e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EditableContent.tsx</strong><dd><code>Add callback for content save in EditableContent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/components/EditableContent/EditableContent.tsx

<li>Added <code>onContentSaved</code> callback prop to <code>EditableContent</code>.<br> <li> Triggered callback after successful content save.<br> <li> Removed unused <code>ReactNode</code> import.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1273/files#diff-f1798d1dc4ffc341cb90f4d94caa0697fae5c0029a0d259e08ac044924942bd5">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>KnowledgeContentSection.tsx</strong><dd><code>Add KnowledgeContentSection for modular content and ERD handling</code></dd></summary>
<hr>

frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/KnowledgeContentSection.tsx

<li>Introduced <code>KnowledgeContentSection</code> component for modular content <br>handling.<br> <li> Integrated <code>EditableContent</code> with <code>onContentSaved</code> callback.<br> <li> Updated ERD viewer dynamically based on saved content.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1273/files#diff-5c3b701988ad44070527d42c5f332dc7b0f47a23d60c21f9fbebfa694884a116">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>KnowledgeSuggestionDetailPage.tsx</strong><dd><code>Refactor KnowledgeSuggestionDetailPage to use KnowledgeContentSection</code></dd></summary>
<hr>

frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/KnowledgeSuggestionDetailPage.tsx

<li>Replaced inline content and ERD logic with <code>KnowledgeContentSection</code>.<br> <li> Removed redundant <code>processOverrideFile</code> function.<br> <li> Integrated <code>processOverrideContent</code> for server-side processing.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1273/files#diff-c10c10838858e9ad3cd72831121c9df90fffb02d921f4b12a1eb6ad2b57f1f0b">+23/-65</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>