### PR TITLE
🔧 Remove ReviewScore table; derive review scores from ReviewIssue

### DIFF
--- a/frontend/apps/app/features/migrations/components/MigrationHealthClient/MigrationHealthClient.module.css
+++ b/frontend/apps/app/features/migrations/components/MigrationHealthClient/MigrationHealthClient.module.css
@@ -1,0 +1,12 @@
+.radarChartContainer {
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.noScores {
+  text-align: center;
+  color: #666;
+  font-style: italic;
+  padding: 20px;
+}

--- a/frontend/apps/app/features/migrations/components/MigrationHealthClient/MigrationHealthClient.tsx
+++ b/frontend/apps/app/features/migrations/components/MigrationHealthClient/MigrationHealthClient.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useReviewIssues } from '../../contexts/ReviewIssuesContext'
+import { calculateScoresFromIssues } from '../../utils/calculateScores'
+import { RadarChart } from '../RadarChart/RadarChart'
+import styles from './MigrationHealthClient.module.css'
+
+type MigrationHealthClientProps = {
+  className?: string
+}
+
+export const MigrationHealthClient = ({
+  className,
+}: MigrationHealthClientProps) => {
+  // Use the shared context instead of local state
+  const { issues } = useReviewIssues()
+
+  // Calculate scores from issues
+  const scores = calculateScoresFromIssues(issues)
+
+  return (
+    <div className={className}>
+      {issues && issues.length > 0 ? (
+        <div className={styles.radarChartContainer}>
+          <RadarChart scores={scores} />
+        </div>
+      ) : (
+        <p className={styles.noScores}>No review issues found.</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/apps/app/features/migrations/contexts/ReviewIssuesContext.tsx
+++ b/frontend/apps/app/features/migrations/contexts/ReviewIssuesContext.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+
+type ReviewIssue = {
+  id: number
+  category: string
+  severity: string
+  resolvedAt?: string | null
+  resolutionComment?: string | null
+  description?: string
+  suggestion?: string
+  overallReviewId?: number
+  createdAt?: string
+  updatedAt?: string
+  suggestionSnippets?: Array<{
+    id: number
+    filename: string
+    snippet: string
+  }>
+}
+
+type ReviewIssuesContextType = {
+  issues: ReviewIssue[]
+  updateIssue: (issueId: number, updates: Partial<ReviewIssue>) => void
+}
+
+const ReviewIssuesContext = createContext<ReviewIssuesContextType | undefined>(
+  undefined,
+)
+
+export const useReviewIssues = () => {
+  const context = useContext(ReviewIssuesContext)
+  if (!context) {
+    throw new Error(
+      'useReviewIssues must be used within a ReviewIssuesProvider',
+    )
+  }
+  return context
+}
+
+type ReviewIssuesProviderProps = {
+  initialIssues: ReviewIssue[]
+  children: ReactNode
+}
+
+export const ReviewIssuesProvider = ({
+  initialIssues,
+  children,
+}: ReviewIssuesProviderProps) => {
+  const [issues, setIssues] = useState<ReviewIssue[]>(initialIssues)
+
+  // Update issues when initialIssues changes
+  useEffect(() => {
+    setIssues(initialIssues)
+  }, [initialIssues])
+
+  const updateIssue = (issueId: number, updates: Partial<ReviewIssue>) => {
+    setIssues((prevIssues) =>
+      prevIssues.map((issue) =>
+        issue.id === issueId ? { ...issue, ...updates } : issue,
+      ),
+    )
+  }
+
+  return (
+    <ReviewIssuesContext.Provider value={{ issues, updateIssue }}>
+      {children}
+    </ReviewIssuesContext.Provider>
+  )
+}

--- a/frontend/apps/app/features/migrations/utils/calculateScores.ts
+++ b/frontend/apps/app/features/migrations/utils/calculateScores.ts
@@ -1,0 +1,65 @@
+'use client'
+
+import type { CategoryEnum } from '../components/RadarChart/RadarChart'
+
+export type ReviewIssueForScore = {
+  category: string
+  severity: string
+  resolvedAt?: string | null
+}
+
+export type CalculatedScore = {
+  id: number
+  overallReviewId: number
+  overallScore: number
+  category: CategoryEnum
+}
+
+/**
+ * Calculates scores from review issues, excluding resolved issues
+ */
+export const calculateScoresFromIssues = (
+  issues: ReviewIssueForScore[],
+): CalculatedScore[] => {
+  // Group issues by category
+  const issuesByCategory = issues.reduce<
+    Record<string, Array<{ severity: string; resolvedAt?: string | null }>>
+  >((acc, issue) => {
+    if (!acc[issue.category]) {
+      acc[issue.category] = []
+    }
+    acc[issue.category].push({
+      severity: issue.severity,
+      resolvedAt: issue.resolvedAt,
+    })
+    return acc
+  }, {})
+
+  // Calculate scores for each category
+  return Object.entries(issuesByCategory).map(([category, categoryIssues]) => {
+    // Start with 10 points
+    let score = 10
+
+    // Calculate deductions based on issue severity (only for unresolved issues)
+    for (const issue of categoryIssues) {
+      if (issue.resolvedAt) continue // Skip resolved issues
+
+      if (issue.severity === 'CRITICAL') {
+        score -= 3
+      } else if (issue.severity === 'WARNING') {
+        score -= 1
+      }
+      // No deduction for POSITIVE feedback
+    }
+
+    // Ensure minimum score is 0
+    score = Math.max(0, score)
+
+    return {
+      id: Number.parseInt(category, 10), // Use category as ID
+      overallReviewId: 0, // Not needed anymore
+      overallScore: score,
+      category: category as CategoryEnum,
+    }
+  })
+}

--- a/frontend/apps/app/features/migrations/utils/calculateScoresServer.ts
+++ b/frontend/apps/app/features/migrations/utils/calculateScoresServer.ts
@@ -1,0 +1,65 @@
+// Server-side version of the score calculation logic (no 'use client' directive)
+
+import type { CategoryEnum } from '../components/RadarChart/RadarChart'
+
+export type ReviewIssueForScore = {
+  category: string
+  severity: string
+  resolvedAt?: string | null
+}
+
+export type CalculatedScore = {
+  id: number
+  overallReviewId: number
+  overallScore: number
+  category: CategoryEnum
+}
+
+/**
+ * Calculates scores from review issues, excluding resolved issues
+ */
+export const calculateScoresFromIssues = (
+  issues: ReviewIssueForScore[],
+): CalculatedScore[] => {
+  // Group issues by category
+  const issuesByCategory = issues.reduce<
+    Record<string, Array<{ severity: string; resolvedAt?: string | null }>>
+  >((acc, issue) => {
+    if (!acc[issue.category]) {
+      acc[issue.category] = []
+    }
+    acc[issue.category].push({
+      severity: issue.severity,
+      resolvedAt: issue.resolvedAt,
+    })
+    return acc
+  }, {})
+
+  // Calculate scores for each category
+  return Object.entries(issuesByCategory).map(([category, categoryIssues]) => {
+    // Start with 10 points
+    let score = 10
+
+    // Calculate deductions based on issue severity (only for unresolved issues)
+    for (const issue of categoryIssues) {
+      if (issue.resolvedAt) continue // Skip resolved issues
+
+      if (issue.severity === 'CRITICAL') {
+        score -= 3
+      } else if (issue.severity === 'WARNING') {
+        score -= 1
+      }
+      // No deduction for POSITIVE feedback
+    }
+
+    // Ensure minimum score is 0
+    score = Math.max(0, score)
+
+    return {
+      id: Number.parseInt(category, 10), // Use category as ID
+      overallReviewId: 0, // Not needed anymore
+      overallScore: score,
+      category: category as CategoryEnum,
+    }
+  })
+}

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -548,35 +548,6 @@ ALTER SEQUENCE "public"."ReviewIssue_id_seq" OWNED BY "public"."ReviewIssue"."id
 
 
 
-CREATE TABLE IF NOT EXISTS "public"."ReviewScore" (
-    "id" integer NOT NULL,
-    "overallReviewId" integer NOT NULL,
-    "overallScore" integer NOT NULL,
-    "category" "public"."CategoryEnum" NOT NULL,
-    "reason" "text" NOT NULL,
-    "createdAt" timestamp(3) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    "updatedAt" timestamp(3) without time zone NOT NULL
-);
-
-
-ALTER TABLE "public"."ReviewScore" OWNER TO "postgres";
-
-
-CREATE SEQUENCE IF NOT EXISTS "public"."ReviewScore_id_seq"
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE "public"."ReviewScore_id_seq" OWNER TO "postgres";
-
-
-ALTER SEQUENCE "public"."ReviewScore_id_seq" OWNED BY "public"."ReviewScore"."id";
-
-
-
 CREATE SEQUENCE IF NOT EXISTS "public"."ReviewSuggestionSnippet_id_seq"
     START WITH 1
     INCREMENT BY 1
@@ -674,10 +645,6 @@ ALTER TABLE ONLY "public"."ReviewIssue" ALTER COLUMN "id" SET DEFAULT "nextval"(
 
 
 
-ALTER TABLE ONLY "public"."ReviewScore" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."ReviewScore_id_seq"'::"regclass");
-
-
-
 ALTER TABLE ONLY "public"."GitHubDocFilePath"
     ADD CONSTRAINT "GitHubDocFilePath_pkey" PRIMARY KEY ("id");
 
@@ -760,11 +727,6 @@ ALTER TABLE ONLY "public"."Repository"
 
 ALTER TABLE ONLY "public"."ReviewIssue"
     ADD CONSTRAINT "ReviewIssue_pkey" PRIMARY KEY ("id");
-
-
-
-ALTER TABLE ONLY "public"."ReviewScore"
-    ADD CONSTRAINT "ReviewScore_pkey" PRIMARY KEY ("id");
 
 
 
@@ -919,11 +881,6 @@ ALTER TABLE ONLY "public"."PullRequest"
 
 ALTER TABLE ONLY "public"."ReviewIssue"
     ADD CONSTRAINT "ReviewIssue_overallReviewId_fkey" FOREIGN KEY ("overallReviewId") REFERENCES "public"."OverallReview"("id") ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
-
-ALTER TABLE ONLY "public"."ReviewScore"
-    ADD CONSTRAINT "ReviewScore_overallReviewId_fkey" FOREIGN KEY ("overallReviewId") REFERENCES "public"."OverallReview"("id") ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 
@@ -1325,18 +1282,6 @@ GRANT ALL ON TABLE "public"."ReviewIssue" TO "service_role";
 GRANT ALL ON SEQUENCE "public"."ReviewIssue_id_seq" TO "anon";
 GRANT ALL ON SEQUENCE "public"."ReviewIssue_id_seq" TO "authenticated";
 GRANT ALL ON SEQUENCE "public"."ReviewIssue_id_seq" TO "service_role";
-
-
-
-GRANT ALL ON TABLE "public"."ReviewScore" TO "anon";
-GRANT ALL ON TABLE "public"."ReviewScore" TO "authenticated";
-GRANT ALL ON TABLE "public"."ReviewScore" TO "service_role";
-
-
-
-GRANT ALL ON SEQUENCE "public"."ReviewScore_id_seq" TO "anon";
-GRANT ALL ON SEQUENCE "public"."ReviewScore_id_seq" TO "authenticated";
-GRANT ALL ON SEQUENCE "public"."ReviewScore_id_seq" TO "service_role";
 
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -616,44 +616,6 @@ export type Database = {
           },
         ]
       }
-      ReviewScore: {
-        Row: {
-          category: Database['public']['Enums']['CategoryEnum']
-          createdAt: string
-          id: number
-          overallReviewId: number
-          overallScore: number
-          reason: string
-          updatedAt: string
-        }
-        Insert: {
-          category: Database['public']['Enums']['CategoryEnum']
-          createdAt?: string
-          id?: number
-          overallReviewId: number
-          overallScore: number
-          reason: string
-          updatedAt: string
-        }
-        Update: {
-          category?: Database['public']['Enums']['CategoryEnum']
-          createdAt?: string
-          id?: number
-          overallReviewId?: number
-          overallScore?: number
-          reason?: string
-          updatedAt?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'ReviewScore_overallReviewId_fkey'
-            columns: ['overallReviewId']
-            isOneToOne: false
-            referencedRelation: 'OverallReview'
-            referencedColumns: ['id']
-          },
-        ]
-      }
       ReviewSuggestionSnippet: {
         Row: {
           createdAt: string

--- a/frontend/packages/db/supabase/migrations/20250410174005_remove_review_score.sql
+++ b/frontend/packages/db/supabase/migrations/20250410174005_remove_review_score.sql
@@ -1,0 +1,8 @@
+-- Migration to remove the ReviewScore table
+-- The score can be calculated from the ReviewIssue's Severity and category
+
+-- Drop the foreign key constraint first
+ALTER TABLE "public"."ReviewScore" DROP CONSTRAINT "ReviewScore_overallReviewId_fkey";
+
+-- Drop the table
+DROP TABLE "public"."ReviewScore";

--- a/frontend/packages/jobs/src/functions/__tests__/processSaveReview.test.ts
+++ b/frontend/packages/jobs/src/functions/__tests__/processSaveReview.test.ts
@@ -55,11 +55,7 @@ describe.skip('processSaveReview', () => {
 
     if (reviews && reviews.length > 0) {
       const reviewIds = reviews.map((r) => r.id)
-      // Delete associated ReviewScores and ReviewIssues
-      await supabase
-        .from('ReviewScore')
-        .delete()
-        .in('overallReviewId', reviewIds)
+      // Delete associated ReviewIssues
       await supabase
         .from('ReviewIssue')
         .delete()
@@ -82,12 +78,6 @@ describe.skip('processSaveReview', () => {
       traceId: 'test-trace-id-123',
       review: {
         bodyMarkdown: 'Test review comment',
-        scores: [
-          {
-            kind: 'Migration Safety',
-            reason: 'Good migration safety',
-          },
-        ],
         feedbacks: [
           {
             kind: 'Migration Safety',
@@ -113,14 +103,6 @@ describe.skip('processSaveReview', () => {
     expect(review).toBeTruthy()
     expect(review.projectId).toBe(testProject.id)
 
-    const { data: scores, error: scoresError } = await supabase
-      .from('ReviewScore')
-      .select('*')
-      .eq('overallReviewId', review.id)
-    if (scoresError) throw scoresError
-    expect(scores).toBeTruthy()
-    expect(scores.length).toBeGreaterThanOrEqual(1)
-
     const { data: issues, error: issuesError } = await supabase
       .from('ReviewIssue')
       .select('*')
@@ -139,7 +121,6 @@ describe.skip('processSaveReview', () => {
       traceId: 'test-trace-id-123',
       review: {
         bodyMarkdown: 'Test review',
-        scores: [],
         feedbacks: [],
       },
     }
@@ -158,7 +139,6 @@ describe.skip('processSaveReview', () => {
       traceId: 'test-trace-id-123',
       review: {
         bodyMarkdown: 'Test review',
-        scores: [],
         feedbacks: [],
       },
     }

--- a/frontend/packages/jobs/src/prompts/generateReview/generateReview.ts
+++ b/frontend/packages/jobs/src/prompts/generateReview/generateReview.ts
@@ -17,17 +17,13 @@ When analyzing the changes, consider:
 
 Your JSON-formatted response must contain:
 
-- An array of scores for each feedback kind in the "scores" field, each including:
-  - "kind": One of the feedback categories listed below:
+- An array of identified feedback in the "feedbacks" field. Each feedback item must include:
+  - "kind": The feedback category, which must be one of the following:
     - Migration Safety
     - Data Integrity
     - Performance Impact
     - Project Rules Consistency
     - Security or Scalability
-  - "reason": An explanation justifying the score provided, including an overview of identified issues.
-
-- Based on the findings, create an array of identified feedback in the "feedbacks" field. Each feedback item must include:
-  - "kind": The feedback category, matching one of the categories used in the scores.
   - "severity": Assign a severity value:
     - Use "CRITICAL" for major issues.
     - Use "WARNING" for minor issues.

--- a/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
+++ b/frontend/packages/jobs/src/prompts/generateReview/reviewSchema.ts
@@ -30,10 +30,4 @@ export const reviewSchema = strictObject({
       ),
     }),
   ),
-  scores: array(
-    strictObject({
-      kind: KindEnum,
-      reason: string(),
-    }),
-  ),
 })

--- a/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1105/fixture.yaml
+++ b/frontend/packages/prompt-test/src/fixtures/github.com/liam-hq/liam/pull/1105/fixture.yaml
@@ -408,35 +408,6 @@ vars:
       
       
       
-      CREATE TABLE IF NOT EXISTS "public"."ReviewScore" (
-          "id" integer NOT NULL,
-          "overallReviewId" integer NOT NULL,
-          "overallScore" integer NOT NULL,
-          "category" "public"."CategoryEnum" NOT NULL,
-          "reason" "text" NOT NULL,
-          "createdAt" timestamp(3) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-          "updatedAt" timestamp(3) without time zone NOT NULL
-      );
-      
-      
-      ALTER TABLE "public"."ReviewScore" OWNER TO "postgres";
-      
-      
-      CREATE SEQUENCE IF NOT EXISTS "public"."ReviewScore_id_seq"
-          START WITH 1
-          INCREMENT BY 1
-          NO MINVALUE
-          NO MAXVALUE
-          CACHE 1;
-      
-      
-      ALTER TABLE "public"."ReviewScore_id_seq" OWNER TO "postgres";
-      
-      
-      ALTER SEQUENCE "public"."ReviewScore_id_seq" OWNED BY "public"."ReviewScore"."id";
-      
-      
-      
       CREATE TABLE IF NOT EXISTS "public"."_prisma_migrations" (
           "id" character varying(36) NOT NULL,
           "checksum" character varying(64) NOT NULL,
@@ -492,9 +463,6 @@ vars:
       
       
       
-      ALTER TABLE ONLY "public"."ReviewScore" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."ReviewScore_id_seq"'::"regclass");
-      
-      
       
       ALTER TABLE ONLY "public"."GitHubDocFilePath"
           ADD CONSTRAINT "GitHubDocFilePath_pkey" PRIMARY KEY ("id");
@@ -548,11 +516,6 @@ vars:
       
       ALTER TABLE ONLY "public"."ReviewIssue"
           ADD CONSTRAINT "ReviewIssue_pkey" PRIMARY KEY ("id");
-      
-      
-      
-      ALTER TABLE ONLY "public"."ReviewScore"
-          ADD CONSTRAINT "ReviewScore_pkey" PRIMARY KEY ("id");
       
       
       
@@ -628,13 +591,6 @@ vars:
       
       ALTER TABLE ONLY "public"."ReviewIssue"
           ADD CONSTRAINT "ReviewIssue_overallReviewId_fkey" FOREIGN KEY ("overallReviewId") REFERENCES "public"."OverallReview"("id") ON UPDATE CASCADE ON DELETE RESTRICT;
-      
-      
-      
-      ALTER TABLE ONLY "public"."ReviewScore"
-          ADD CONSTRAINT "ReviewScore_overallReviewId_fkey" FOREIGN KEY ("overallReviewId") REFERENCES "public"."OverallReview"("id") ON UPDATE CASCADE ON DELETE RESTRICT;
-      
-      
       
       
       
@@ -966,18 +922,6 @@ vars:
       GRANT ALL ON SEQUENCE "public"."ReviewIssue_id_seq" TO "anon";
       GRANT ALL ON SEQUENCE "public"."ReviewIssue_id_seq" TO "authenticated";
       GRANT ALL ON SEQUENCE "public"."ReviewIssue_id_seq" TO "service_role";
-      
-      
-      
-      GRANT ALL ON TABLE "public"."ReviewScore" TO "anon";
-      GRANT ALL ON TABLE "public"."ReviewScore" TO "authenticated";
-      GRANT ALL ON TABLE "public"."ReviewScore" TO "service_role";
-      
-      
-      
-      GRANT ALL ON SEQUENCE "public"."ReviewScore_id_seq" TO "anon";
-      GRANT ALL ON SEQUENCE "public"."ReviewScore_id_seq" TO "authenticated";
-      GRANT ALL ON SEQUENCE "public"."ReviewScore_id_seq" TO "service_role";
       
       
       


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


The `ReviewScore` points are calculated from the `Severity` and `Category` of `ReviewIssue` and currently do not have much of a role. Therefore, the `ReviewScore` table was deleted so that it can be calculated and displayed based on `ReviewIssue`.

🔧 Removed ReviewScore table and related code
📝 Removed score section from the review prompt
📊 Added MigrationHealthClient component to display a radar chart based on ReviewIssue

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->



https://github.com/user-attachments/assets/0f5ebbb4-004a-4692-93bd-b4291f7ab2ad

I also tested the job, no problem.
![ss 3113](https://github.com/user-attachments/assets/60255b20-51d1-412e-af58-197536ced961)


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at b79733e78a22a6b0e839a1ebdc937034561c5219

- Removed `ReviewScore` table and related logic:
  - Updated database schema and migrations to drop `ReviewScore`.
  - Refactored backend logic to calculate scores dynamically from `ReviewIssue`.
- Introduced `MigrationHealthClient` component:
  - Displays radar chart based on dynamically calculated scores.
  - Integrated with `ReviewIssuesContext` for shared state management.
- Refactored `ReviewIssuesList` to use shared context:
  - Improved issue resolution handling with server-side updates.
- Updated tests and fixtures:
  - Removed references to `ReviewScore`.
  - Adjusted test cases to align with new scoring logic.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>calculateScores.ts</strong><dd><code>Add client-side utility for dynamic score calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-fa740c6f3fcf899812e8a30598cd2933ed513d45670aa65f36d00f46fb863a8b">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>calculateScoresServer.ts</strong><dd><code>Add server-side utility for dynamic score calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-c8f791c74574118440ee8dc3cdf43c51cd5e993bf2a03445d870ef60f6be5671">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>processSaveReview.ts</strong><dd><code>Refactor review save logic to exclude `ReviewScore`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-79d3de5007a5d073d01c220caa60a46b00eedc32994413db8fc47c213e72e459">+2/-66</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generateReview.ts</strong><dd><code>Remove `scores` field from review generation prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-bc327c5835be24c334bb5b64878901f0a7a7f7aab54d96897cb8f0a326d9aa6b">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reviewSchema.ts</strong><dd><code>Remove `scores` schema definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-67f415413057cfc6db882bf55d5978df834ba9ffe9a6faa798ac62e45813d6a8">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MigrationHealthClient.module.css</strong><dd><code>Add styles for `MigrationHealthClient` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-fe6b6fa48afdcc1c393966d18745aca94be50ab46821c4693422e632d5e8696a">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MigrationHealthClient.tsx</strong><dd><code>Add `MigrationHealthClient` component for radar chart visualization</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-1415d74e3d55c186fa1a168bc4872643cd47601f1bc7d58c2c1af5d24763dd9d">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReviewIssuesList.tsx</strong><dd><code>Refactor `ReviewIssuesList` to use shared context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-0de4ad14eb89dec89ab884d62071c8df70957745fe168308643f96fc32f98ecf">+30/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ReviewIssuesContext.tsx</strong><dd><code>Add context for managing review issues state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-5b3fe7d23d7b0c4ed1c782fb1364b25dd4c81f726289daec3713ef11a7c1da69">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MigrationDetailPage.tsx</strong><dd><code>Integrate <code>MigrationHealthClient</code> and <code>ReviewIssuesContext</code> into detail <br>page</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-011aa266ad74dd462ae2261a203611dc29967eab240dc4131cc80042c6eb5f70">+45/-64</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>database.types.ts</strong><dd><code>Remove `ReviewScore` table references from database types</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+0/-38</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.sql</strong><dd><code>Remove `ReviewScore` table from database schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+0/-55</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>20250410174005_remove_review_score.sql</strong><dd><code>Add migration to drop `ReviewScore` table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-2b583140295efbf66c82a65b14b37c4344ae295778aba2824e99093e664abf12">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>processSaveReview.test.ts</strong><dd><code>Update tests to remove `ReviewScore` references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-00402fa9adcafe30e7d5d468d2c72832312f688998d1bd36bc07ba72f60060c1">+1/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fixture.yaml</strong><dd><code>Update test fixtures to remove `ReviewScore` references</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1300/files#diff-048fed0575a5fc61f5a0943a26b8805343404221ee50f58d17734f94a87a2648">+0/-56</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>