### PR TITLE
🛠️(schema): Store schema file format in database

### DIFF
--- a/frontend/apps/app/app/(app)/app/projects/[projectId]/ref/[branchOrCommit]/schema/[...schemaFilePath]/page.tsx
+++ b/frontend/apps/app/app/(app)/app/projects/[projectId]/ref/[branchOrCommit]/schema/[...schemaFilePath]/page.tsx
@@ -7,13 +7,7 @@ import {
   applyOverrides,
   dbOverrideSchema,
 } from '@liam-hq/db-structure'
-import {
-  type SupportedFormat,
-  detectFormat,
-  parse,
-  setPrismWasmUrl,
-  supportedFormatSchema,
-} from '@liam-hq/db-structure/parser'
+import { parse, setPrismWasmUrl } from '@liam-hq/db-structure/parser'
 import { getFileContent } from '@liam-hq/github'
 import * as Sentry from '@sentry/nextjs'
 import { cookies } from 'next/headers'
@@ -71,14 +65,7 @@ const paramsSchema = v.object({
   schemaFilePath: v.array(v.string()),
 })
 
-const searchParamsSchema = v.object({
-  format: v.optional(supportedFormatSchema),
-})
-
-export default async function Page({
-  params,
-  searchParams: _searchParams,
-}: PageProps) {
+export default async function Page({ params }: PageProps) {
   const parsedParams = v.safeParse(paramsSchema, await params)
   if (!parsedParams.success) throw notFound()
 
@@ -101,6 +88,13 @@ export default async function Page({
         )
       `)
       .eq('id', Number(projectId))
+      .single()
+
+    const { data: gitHubSchemaFilePath } = await supabase
+      .from('GitHubSchemaFilePath')
+      .select('path, format')
+      .eq('projectId', Number(projectId))
+      .eq('path', filePath)
       .single()
 
     const repository = project?.ProjectRepositoryMapping[0].Repository
@@ -137,17 +131,7 @@ export default async function Page({
 
     setPrismWasmUrl(path.resolve(process.cwd(), 'prism.wasm'))
 
-    let format: SupportedFormat | undefined
-    const searchParams = await _searchParams
-
-    if (v.is(searchParamsSchema, searchParams)) {
-      format = searchParams.format
-    }
-    if (!format) {
-      format = detectFormat(filePath)
-    }
-
-    if (!format) {
+    if (!gitHubSchemaFilePath?.format) {
       return (
         <ERDViewer
           dbStructure={blankDbStructure}
@@ -155,14 +139,16 @@ export default async function Page({
           errorObjects={[
             {
               name: 'FormatError',
-              message: 'Could not detect the file format.',
+              message: 'Format not found in database.',
               instruction:
-                'Please specify the format in the URL query parameter `format`',
+                'Please ensure the schema file path has a format specified in the database.',
             },
           ]}
         />
       )
     }
+
+    const format = gitHubSchemaFilePath.format
 
     const { value: dbStructure, errors } = await parse(content, format)
 

--- a/frontend/apps/app/app/(app)/app/projects/[projectId]/ref/[branchOrCommit]/schema/[...schemaFilePath]/page.tsx
+++ b/frontend/apps/app/app/(app)/app/projects/[projectId]/ref/[branchOrCommit]/schema/[...schemaFilePath]/page.tsx
@@ -139,9 +139,8 @@ export default async function Page({ params }: PageProps) {
           errorObjects={[
             {
               name: 'FormatError',
-              message: 'Format not found in database.',
-              instruction:
-                'Please ensure the schema file path has a format specified in the database.',
+              message: 'Record not found',
+              instruction: 'Please make sure that the schema file exists.',
             },
           ]}
         />

--- a/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
+++ b/frontend/apps/app/app/api/webhook/github/utils/__tests__/checkSchemaChanges.test.ts
@@ -98,6 +98,7 @@ describe('checkSchemaChanges', () => {
         .insert({
           path: 'migrations/2024_update.sql',
           projectId: project.id,
+          format: 'postgres',
           updatedAt: now,
         })
         .select()

--- a/frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/ContentForSchema.tsx
+++ b/frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/ContentForSchema.tsx
@@ -1,9 +1,5 @@
 import { createClient } from '@/libs/db/server'
-import {
-  type SupportedFormat,
-  detectFormat,
-  parse,
-} from '@liam-hq/db-structure/parser'
+import { type SupportedFormat, parse } from '@liam-hq/db-structure/parser'
 import { getFileContent } from '@liam-hq/github'
 import { notFound } from 'next/navigation'
 import type { FC } from 'react'
@@ -52,6 +48,7 @@ export const ContentForSchema: FC<Props> = async ({
 
   const githubSchemaFilePath = await getGithubSchemaFilePath(projectId)
   const filePath = githubSchemaFilePath.path
+  const format = githubSchemaFilePath.format
 
   const { content } = await getFileContent(
     repositoryFullName,
@@ -60,10 +57,9 @@ export const ContentForSchema: FC<Props> = async ({
     Number(repository.installationId),
   )
 
-  const format = detectFormat(filePath)
   const { value: dbStructure, errors } =
     content !== null && format !== undefined
-      ? await parse(content, format as SupportedFormat)
+      ? await parse(content, format)
       : { value: undefined, errors: [] }
 
   const { result } = dbStructure
@@ -85,7 +81,6 @@ export const ContentForSchema: FC<Props> = async ({
       }
       isApproved={!!suggestion.approvedAt}
       dbStructure={dbStructure}
-      format={format as SupportedFormat | undefined}
       content={content}
       errors={errors || []}
       tableGroups={result?.tableGroups || {}}

--- a/frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/ContentForSchemaSection.tsx
+++ b/frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/ContentForSchemaSection.tsx
@@ -25,7 +25,6 @@ type Props = {
   originalContent: string | null
   isApproved: boolean
   dbStructure: DBStructure | undefined
-  format: SupportedFormat | undefined
   content: string | null
   errors: ErrorObject[]
   tableGroups: Record<string, TableGroup>
@@ -37,7 +36,6 @@ export const ContentForSchemaSection: FC<Props> = ({
   originalContent,
   isApproved,
   dbStructure,
-  format,
   content,
   errors,
   tableGroups: initialTableGroups,
@@ -111,7 +109,7 @@ export const ContentForSchemaSection: FC<Props> = ({
         />
       </div>
 
-      {content !== null && format !== undefined && dbStructure && (
+      {content !== null && dbStructure && (
         <ErdViewer
           key={JSON.stringify(
             processedResult?.tableGroups || initialTableGroups,

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -86,6 +86,17 @@ CREATE TYPE "public"."KnowledgeType" AS ENUM (
 ALTER TYPE "public"."KnowledgeType" OWNER TO "postgres";
 
 
+CREATE TYPE "public"."SchemaFormatEnum" AS ENUM (
+    'schemarb',
+    'postgres',
+    'prisma',
+    'tbls'
+);
+
+
+ALTER TYPE "public"."SchemaFormatEnum" OWNER TO "postgres";
+
+
 CREATE TYPE "public"."SeverityEnum" AS ENUM (
     'CRITICAL',
     'WARNING',
@@ -171,7 +182,8 @@ CREATE TABLE IF NOT EXISTS "public"."GitHubSchemaFilePath" (
     "path" "text" NOT NULL,
     "projectId" integer NOT NULL,
     "createdAt" timestamp(3) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    "updatedAt" timestamp(3) without time zone NOT NULL
+    "updatedAt" timestamp(3) without time zone NOT NULL,
+    "format" "public"."SchemaFormatEnum" NOT NULL
 );
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -105,6 +105,7 @@ export type Database = {
       GitHubSchemaFilePath: {
         Row: {
           createdAt: string
+          format: Database['public']['Enums']['SchemaFormatEnum']
           id: number
           path: string
           projectId: number
@@ -112,6 +113,7 @@ export type Database = {
         }
         Insert: {
           createdAt?: string
+          format: Database['public']['Enums']['SchemaFormatEnum']
           id?: number
           path: string
           projectId: number
@@ -119,6 +121,7 @@ export type Database = {
         }
         Update: {
           createdAt?: string
+          format?: Database['public']['Enums']['SchemaFormatEnum']
           id?: number
           path?: string
           projectId?: number
@@ -725,6 +728,7 @@ export type Database = {
         | 'PROJECT_RULES_CONSISTENCY'
         | 'SECURITY_OR_SCALABILITY'
       KnowledgeType: 'SCHEMA' | 'DOCS'
+      SchemaFormatEnum: 'schemarb' | 'postgres' | 'prisma' | 'tbls'
       SeverityEnum: 'CRITICAL' | 'WARNING' | 'POSITIVE'
     }
     CompositeTypes: {
@@ -852,6 +856,7 @@ export const Constants = {
         'SECURITY_OR_SCALABILITY',
       ],
       KnowledgeType: ['SCHEMA', 'DOCS'],
+      SchemaFormatEnum: ['schemarb', 'postgres', 'prisma', 'tbls'],
       SeverityEnum: ['CRITICAL', 'WARNING', 'POSITIVE'],
     },
   },

--- a/frontend/packages/db/supabase/migrations/20250410093421_add_format_to_github_schema_file_path.sql
+++ b/frontend/packages/db/supabase/migrations/20250410093421_add_format_to_github_schema_file_path.sql
@@ -1,0 +1,25 @@
+-- Start transaction to ensure all operations succeed or fail together
+BEGIN;
+
+-- Step 1: Create a new ENUM type for supported formats
+CREATE TYPE "public"."SchemaFormatEnum" AS ENUM (
+    'schemarb',
+    'postgres',
+    'prisma',
+    'tbls'
+);
+
+-- Step 2: Add format column as nullable initially
+ALTER TABLE "public"."GitHubSchemaFilePath"
+ADD COLUMN "format" "public"."SchemaFormatEnum";
+
+-- Step 3: Update all existing records to 'postgres'
+UPDATE "public"."GitHubSchemaFilePath"
+SET "format" = 'postgres';
+
+-- Step 4: Add NOT NULL constraint after all records have been updated
+ALTER TABLE "public"."GitHubSchemaFilePath"
+ALTER COLUMN "format" SET NOT NULL;
+
+-- Commit the transaction
+COMMIT;


### PR DESCRIPTION
## Issue

- resolve: Fix schema file format detection

## Why is this change needed?
Currently, the system tries to detect the schema file format based on the file extension, which can be unreliable. This change stores the format explicitly in the database, making it more reliable and allowing for more flexibility.

## What would you like reviewers to focus on?
- The new database migration adding the 'format' field to GitHubSchemaFilePath
- The changes to schema file format handling in page.tsx
- Whether the approach is robust enough for all schema formats

## Testing Verification
Tested with various schema files formats, confirming that the ERD viewer correctly loads and displays schema data based on the stored format rather than detection.

## What was done
### 🤖 Generated by PR Agent at 17833d11c3a754cfe382680d7929d113242cb03f

- Added `format` column to `GitHubSchemaFilePath` table for schema format storage.
- Introduced `SchemaFormatEnum` ENUM type with predefined schema formats.
- Updated schema handling logic to use database-stored format instead of detection.
- Enhanced error handling for missing schema format in database.


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.types.ts</strong><dd><code>Added schema format field and ENUM type in database types</code></dd></summary>
<hr>

frontend/packages/db/supabase/database.types.ts

<li>Added <code>format</code> field to <code>GitHubSchemaFilePath</code> table types.<br> <li> Introduced <code>SchemaFormatEnum</code> ENUM type for schema formats.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1301/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactored schema page to use database-stored format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/projects/[projectId]/ref/[branchOrCommit]/schema/[...schemaFilePath]/page.tsx

<li>Removed format detection logic and unused imports.<br> <li> Integrated database query to fetch schema format.<br> <li> Updated error handling for missing format in database.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1301/files#diff-01d6f7610cdf43c347df62ee69061c589d535235cfc60e43ab3cbcbda2d6c4da">+14/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContentForSchema.tsx</strong><dd><code>Updated schema content handling to use database format</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/ContentForSchema.tsx

<li>Removed format detection logic.<br> <li> Used database-stored format for schema parsing.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1301/files#diff-f1c3ae155718b30924699df1fb73e497dc26db4a50e1da7c863715ea52dbd342">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContentForSchemaSection.tsx</strong><dd><code>Simplified schema section logic by removing format prop</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/pages/KnowledgeSuggestionDetailPage/ContentForSchemaSection.tsx

<li>Removed format parameter from component props.<br> <li> Simplified logic for rendering ERD viewer.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1301/files#diff-4a5bc1754e814eb76c7c96c9a37dce34b57e6eed6a9c87eb62107d32aa82b141">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Added schema format ENUM and updated table schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Added <code>SchemaFormatEnum</code> ENUM type for schema formats.<br> <li> Updated <code>GitHubSchemaFilePath</code> table to include <code>format</code> column.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1301/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250410093421_add_format_to_github_schema_file_path.sql</strong><dd><code>Migration to add and populate schema format column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250410093421_add_format_to_github_schema_file_path.sql

<li>Created migration to add <code>format</code> column to <code>GitHubSchemaFilePath</code>.<br> <li> Populated existing records with default format <code>postgres</code>.<br> <li> Enforced <code>NOT NULL</code> constraint on <code>format</code> column.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1301/files#diff-2a4069496b1a26acf09bc9e93e0d869d09ce7d42ca0d082c8e0d8e08ee4dd8bb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
All existing schema file paths will be updated to 'postgres' format by default during migration.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>