### PR TITLE
✨(organizations): Add organization settings pages with tabbed navigation

### DIFF
--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/billing/page.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/billing/page.tsx
@@ -1,0 +1,8 @@
+export default async function BillingPage() {
+  return (
+    <div>
+      <h2>Billing Settings</h2>
+      <p>Billing and subscription settings will be available here.</p>
+    </div>
+  )
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.module.css
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.module.css
@@ -1,0 +1,32 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-4) 0;
+  border-bottom: 1px solid var(--global-border);
+}
+
+.tabsList {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.tabsTrigger {
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--font-size-4);
+  color: var(--global-mute-text);
+  background: transparent;
+  border: none;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tabsTrigger:hover {
+  color: var(--global-foreground);
+  background-color: var(--global-muted-background);
+}
+
+.tabsTrigger[data-state='active'] {
+  color: var(--global-foreground);
+  background-color: var(--global-muted-background);
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { TabsList, TabsTrigger } from '@liam-hq/ui'
+import type { FC } from 'react'
+import { SETTINGS_TABS } from '../../constants'
+import styles from './SettingsHeader.module.css'
+
+export const SettingsHeader: FC = () => {
+  return (
+    <div className={styles.wrapper}>
+      <TabsList className={styles.tabsList}>
+        {SETTINGS_TABS.map((tab) => (
+          <TabsTrigger
+            key={tab.value}
+            value={tab.value}
+            className={styles.tabsTrigger}
+          >
+            {tab.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </div>
+  )
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/index.ts
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingsHeader'

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/constants.ts
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/constants.ts
@@ -1,0 +1,20 @@
+export const SETTINGS_TAB = {
+  GENERAL: 'general',
+  MEMBERS: 'members',
+  BILLING: 'billing',
+  PROJECTS: 'projects',
+} as const
+
+export type SettingsTabValue = (typeof SETTINGS_TAB)[keyof typeof SETTINGS_TAB]
+
+export interface SettingsTab {
+  value: SettingsTabValue
+  label: string
+}
+
+export const SETTINGS_TABS: SettingsTab[] = [
+  { value: SETTINGS_TAB.GENERAL, label: 'General' },
+  { value: SETTINGS_TAB.MEMBERS, label: 'Members' },
+  { value: SETTINGS_TAB.BILLING, label: 'Billing' },
+  { value: SETTINGS_TAB.PROJECTS, label: 'Projects' },
+]

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/general/page.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/general/page.tsx
@@ -1,0 +1,8 @@
+export default async function GeneralPage() {
+  return (
+    <div>
+      <h2>General Settings</h2>
+      <p>General organization settings will be available here.</p>
+    </div>
+  )
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.module.css
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.module.css
@@ -1,0 +1,31 @@
+.container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  padding: var(--spacing-20) var(--spacing-4);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-20);
+  margin: 0 auto;
+}
+
+.heading {
+  font-size: var(--font-size-8);
+  font-weight: 500;
+  color: var(--global-foreground);
+  line-height: 100%;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-7);
+  width: 100%;
+  height: 100%;
+  max-width: 1080px;
+}
+
+.tabContent {
+  width: 100%;
+  padding-top: var(--spacing-4);
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx
@@ -1,0 +1,52 @@
+import { TabsContent, TabsRoot } from '@liam-hq/ui'
+import type { ReactNode } from 'react'
+import { SettingsHeader } from './components/SettingsHeader'
+import { SETTINGS_TAB } from './constants'
+import styles from './layout.module.css'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+export default async function OrganizationSettingsLayout({
+  children,
+}: LayoutProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.contentContainer}>
+        <h1 className={styles.heading}>Settings</h1>
+
+        <TabsRoot
+          // TODO: Make it possible to retrieve it from the current path
+          defaultValue={SETTINGS_TAB.GENERAL}
+        >
+          <SettingsHeader />
+          <TabsContent
+            value={SETTINGS_TAB.GENERAL}
+            className={styles.tabContent}
+          >
+            {children}
+          </TabsContent>
+          <TabsContent
+            value={SETTINGS_TAB.MEMBERS}
+            className={styles.tabContent}
+          >
+            {children}
+          </TabsContent>
+          <TabsContent
+            value={SETTINGS_TAB.BILLING}
+            className={styles.tabContent}
+          >
+            {children}
+          </TabsContent>
+          <TabsContent
+            value={SETTINGS_TAB.PROJECTS}
+            className={styles.tabContent}
+          >
+            {children}
+          </TabsContent>
+        </TabsRoot>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/members/page.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/members/page.tsx
@@ -1,0 +1,30 @@
+import type { PageProps } from '@/app/types'
+import { OrganizationMembersPage } from '@/features/organizations/pages/OrganizationMembersPage'
+import { createClient } from '@/libs/db/server'
+import { notFound } from 'next/navigation'
+import * as v from 'valibot'
+
+const paramsSchema = v.object({
+  organizationId: v.string(),
+})
+
+export default async function MembersPage({ params }: PageProps) {
+  const parsedParams = v.safeParse(paramsSchema, await params)
+  if (!parsedParams.success) return notFound()
+  const { organizationId } = parsedParams.output
+
+  const supabase = await createClient()
+
+  const { data: organization, error } = await supabase
+    .from('organizations')
+    .select('id, name')
+    .eq('id', organizationId)
+    .single()
+
+  if (error || !organization) {
+    console.error('Error fetching organization:', error)
+    notFound()
+  }
+
+  return <OrganizationMembersPage organization={organization} />
+}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/projects/page.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/projects/page.tsx
@@ -1,0 +1,8 @@
+export default async function ProjectsPage() {
+  return (
+    <div>
+      <h2>Projects Settings</h2>
+      <p>Organization projects settings will be available here.</p>
+    </div>
+  )
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/ClientSearchWrapper.module.css
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/ClientSearchWrapper.module.css
@@ -1,0 +1,48 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5);
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-4);
+  width: 100%;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  width: 100%;
+}
+
+.sectionTitle {
+  font-size: var(--font-size-5);
+  font-weight: 500;
+  color: var(--global-foreground);
+  margin: 0;
+}
+
+.membersList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  width: 100%;
+}
+
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-10);
+  background-color: var(--pane-background);
+  border: 1px solid var(--global-border);
+  border-radius: var(--border-radius-md);
+  color: var(--global-mute-text);
+  text-align: center;
+  margin: 0;
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/ClientSearchWrapper.tsx
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/ClientSearchWrapper.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { Button } from '@liam-hq/ui'
+import { type FC, useState } from 'react'
+import styles from './ClientSearchWrapper.module.css'
+import { MemberItem } from './MemberItem'
+import { SearchInput } from './SearchInput'
+
+interface Member {
+  id: string
+  joinedAt: string | null
+  user: {
+    id: string
+    name: string
+    email: string
+  }
+}
+
+interface Invite {
+  id: string
+  email: string
+  invitedAt: string | null
+  inviteBy: {
+    id: string
+    name: string
+    email: string
+  }
+}
+
+interface ClientSearchWrapperProps {
+  members: Member[]
+  invites: Invite[]
+  organizationId: string
+}
+
+export const ClientSearchWrapper: FC<ClientSearchWrapperProps> = ({
+  members = [],
+  invites = [],
+}) => {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  // Filter members based on search query
+  const filteredMembers = members?.filter(
+    (member) =>
+      member.user?.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      member.user?.email.toLowerCase().includes(searchQuery.toLowerCase()),
+  )
+
+  // Filter invites based on search query
+  const filteredInvites = invites?.filter(
+    (invite) =>
+      invite.email.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      invite.inviteBy?.name?.toLowerCase().includes(searchQuery.toLowerCase()),
+  )
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query)
+  }
+
+  // TODO: Implement invite functionality
+  const handleInvite = () => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 500)
+  }
+
+  // TODO: Implement manage access functionality
+  const handleManageAccess = (_id: string) => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 300)
+  }
+
+  // TODO: Implement more options functionality
+  const handleMoreOptions = (_id: string) => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 300)
+  }
+
+  // Generate a deterministic avatar color based on user ID or email
+  const getAvatarColor = (id: string | number) => {
+    const stringId = id.toString()
+    let hash = 0
+    for (let i = 0; i < stringId.length; i++) {
+      hash = stringId.charCodeAt(i) + ((hash << 5) - hash)
+    }
+    return (Math.abs(hash) % 7) + 1 // Return a number between 1 and 7
+  }
+
+  // Get initial from name
+  const getInitial = (name: string) => {
+    return name ? name.charAt(0).toUpperCase() : '?'
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <SearchInput
+          onSearch={handleSearch}
+          loading={loading}
+          placeholder="Search Members.."
+        />
+        <Button onClick={handleInvite}>Invite</Button>
+      </div>
+
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Organization Members</h2>
+        <div className={styles.membersList}>
+          {filteredMembers && filteredMembers.length > 0 ? (
+            filteredMembers.map((member) => (
+              <MemberItem
+                key={member.id}
+                name={member.user.name}
+                email={member.user.email}
+                initial={getInitial(member.user.name)}
+                avatarColor={getAvatarColor(member.user.id)}
+                onManageAccess={() => handleManageAccess(member.id)}
+                onMoreOptions={() => handleMoreOptions(member.id)}
+              />
+            ))
+          ) : (
+            <p className={styles.emptyState}>No members found.</p>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Pending Invitations</h2>
+        <div className={styles.membersList}>
+          {filteredInvites && filteredInvites.length > 0 ? (
+            filteredInvites.map((invite) => (
+              <MemberItem
+                key={invite.id}
+                name={invite.email.split('@')[0]}
+                email={invite.email}
+                initial={invite.email.charAt(0).toUpperCase()}
+                avatarColor={getAvatarColor(invite.email)}
+                onManageAccess={() => handleManageAccess(invite.id)}
+                onMoreOptions={() => handleMoreOptions(invite.id)}
+              />
+            ))
+          ) : (
+            <p className={styles.emptyState}>No pending invitations.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/MemberItem.module.css
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/MemberItem.module.css
@@ -1,0 +1,63 @@
+.memberItem {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background-color: var(--global-muted-background);
+  border: 1px solid var(--global-border);
+  border-radius: var(--border-radius-lg);
+  width: 100%;
+}
+
+.memberBody {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.memberInfo {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--spacing-10);
+}
+
+.nameEmail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.name {
+  font-size: var(--font-size-4);
+  font-weight: 400;
+  color: var(--global-foreground);
+}
+
+.email {
+  font-size: var(--font-size-4);
+  font-weight: 400;
+  color: var(--overlay-60);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.roleLabel {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--font-size-3);
+  color: var(--global-foreground);
+  white-space: nowrap;
+}
+
+.manageButton {
+  white-space: nowrap;
+}
+
+.moreButton {
+  display: flex;
+  align-items: center;
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/MemberItem.tsx
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/MemberItem.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import {
+  Avatar,
+  Button,
+  Ellipsis,
+  IconButton,
+  getAvatarUserFromColor,
+} from '@liam-hq/ui'
+import type { FC } from 'react'
+import styles from './MemberItem.module.css'
+
+interface MemberItemProps {
+  name: string
+  email: string
+  initial: string
+  avatarColor?: number
+  onManageAccess?: () => void
+  onMoreOptions?: () => void
+}
+
+export const MemberItem: FC<MemberItemProps> = ({
+  name,
+  email,
+  initial,
+  avatarColor = 1,
+  onManageAccess,
+  onMoreOptions,
+}) => {
+  return (
+    <div className={styles.memberItem}>
+      <Avatar
+        initial={initial}
+        size="lg"
+        user={getAvatarUserFromColor(avatarColor)}
+      />
+      <div className={styles.memberBody}>
+        <div className={styles.memberInfo}>
+          <div className={styles.nameEmail}>
+            <span className={styles.name}>{name}</span>
+            <span className={styles.email}>{email}</span>
+          </div>
+          <div className={styles.spacer} />
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={onManageAccess}
+            className={styles.manageButton}
+          >
+            Manage Access
+          </Button>
+          <div className={styles.moreButton}>
+            <IconButton
+              icon={<Ellipsis />}
+              tooltipContent="More options"
+              onClick={onMoreOptions}
+              size="sm"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/OrganizationMembersPage.tsx
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/OrganizationMembersPage.tsx
@@ -1,0 +1,28 @@
+import { ClientSearchWrapper } from '@/features/organizations/pages/OrganizationMembersPage/ClientSearchWrapper'
+import {
+  getOrganizationInvites,
+  getOrganizationMembers,
+} from '@/features/organizations/pages/OrganizationMembersPage/getMembersAndInvites'
+import type { FC } from 'react'
+
+interface OrganizationMembersPageProps {
+  organization: {
+    id: string
+    name: string
+  }
+}
+
+export const OrganizationMembersPage: FC<
+  OrganizationMembersPageProps
+> = async ({ organization }) => {
+  const members = await getOrganizationMembers(organization.id)
+  const invites = await getOrganizationInvites(organization.id)
+
+  return (
+    <ClientSearchWrapper
+      members={members}
+      invites={invites}
+      organizationId={organization.id}
+    />
+  )
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/SearchInput.module.css
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/SearchInput.module.css
@@ -1,0 +1,43 @@
+.container {
+  flex: 1;
+}
+
+.searchInput {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: var(--spacing-2) var(--spacing-3);
+  background-color: var(--global-background);
+  border: 1px solid var(--global-border);
+  border-radius: var(--border-radius-md);
+  flex: 1;
+  height: 36px;
+  position: relative;
+}
+
+.searchInput > input {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--global-foreground);
+  font-size: var(--font-size-4);
+  width: 100%;
+}
+
+.searchInput > input::placeholder {
+  color: var(--overlay-30);
+}
+
+.searchIcon {
+  color: var(--overlay-50);
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.loading {
+  position: absolute;
+  right: var(--spacing-3);
+  font-size: 12px;
+  color: var(--global-mute-text);
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/SearchInput.tsx
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/SearchInput.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { Search } from '@liam-hq/ui'
+import type { ChangeEvent, FC, FormEvent } from 'react'
+import { useState } from 'react'
+import styles from './SearchInput.module.css'
+
+interface SearchInputProps {
+  onSearch: (query: string) => void
+  loading?: boolean
+  placeholder?: string
+}
+
+export const SearchInput: FC<SearchInputProps> = ({
+  onSearch,
+  loading = false,
+  placeholder = 'Search...',
+}) => {
+  const [query, setQuery] = useState('')
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    setQuery(newValue)
+
+    if (newValue === '') {
+      onSearch('')
+    }
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    onSearch(query)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.container}>
+      <div className={styles.searchInput}>
+        <Search className={styles.searchIcon} />
+        <input
+          type="text"
+          value={query}
+          onChange={handleChange}
+          placeholder={placeholder}
+          disabled={loading}
+        />
+        {
+          // TODO: Add loading indicator
+          loading && <span className={styles.loading}>Loading...</span>
+        }
+      </div>
+    </form>
+  )
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/getMembersAndInvites.ts
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/getMembersAndInvites.ts
@@ -1,0 +1,66 @@
+import { createClient } from '@/libs/db/server'
+
+export const getOrganizationMembers = async (organizationId: string) => {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('organization_members')
+    .select(`
+      id,
+      joined_at,
+
+      users(
+        id,
+        name,
+        email
+      )
+    `)
+    .eq('organization_id', organizationId)
+
+  if (error) {
+    console.error('Error fetching organization members:', error)
+    return []
+  }
+
+  const members = data.map((member) => ({
+    id: member.id,
+    joinedAt: member.joined_at,
+    user: member.users,
+  }))
+
+  return members
+}
+
+export const getOrganizationInvites = async (organizationId: string) => {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('membership_invites')
+    .select(`
+      id,
+      email,
+      invited_at,
+
+      invite_by:invite_by_user_id(
+        id,
+        name,
+        email
+      )
+    `)
+    .eq('organization_id', organizationId)
+
+  if (error) {
+    console.error('Error fetching organization invites:', error)
+    return []
+  }
+
+  // Transform data to match expected Invite type
+  const invites = data.map((invite) => ({
+    id: invite.id,
+    email: invite.email,
+    invitedAt: invite.invited_at,
+    inviteBy: invite.invite_by,
+  }))
+
+  return invites
+}

--- a/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/index.ts
+++ b/frontend/apps/app/features/organizations/pages/OrganizationMembersPage/index.ts
@@ -1,0 +1,1 @@
+export * from './OrganizationMembersPage'

--- a/frontend/packages/ui/src/components/Avatar/Avatar.tsx
+++ b/frontend/packages/ui/src/components/Avatar/Avatar.tsx
@@ -6,7 +6,7 @@ import styles from './Avatar.module.css'
 import { UserAvatarIcon } from './UserAvatarIcon'
 
 type AvatarSize = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
-type AvatarUser =
+export type AvatarUser =
   | 'you'
   | 'collaborator-1'
   | 'collaborator-2'
@@ -20,6 +20,24 @@ type AvatarUser =
   | 'collaborator-10'
   | 'collaborator-11'
   | 'jack'
+
+/**
+ * Maps a color number to the corresponding AvatarUser type
+ * @param colorNum - A number between 1 and 7
+ * @returns The corresponding AvatarUser value
+ */
+export const getAvatarUserFromColor = (colorNum: number): AvatarUser => {
+  const colorMap: Record<number, AvatarUser> = {
+    1: 'you',
+    2: 'collaborator-1',
+    3: 'collaborator-2',
+    4: 'collaborator-3',
+    5: 'collaborator-4',
+    6: 'collaborator-5',
+    7: 'collaborator-6',
+  }
+  return colorMap[colorNum] || 'you'
+}
 
 type AvatarProps = {
   initial: string


### PR DESCRIPTION
## Issue

- resolve: Add organization settings pages

## Why is this change needed?
Added organization settings pages with tabbed navigation to allow users to manage organization settings including general, members, billing, and projects.

## What would you like reviewers to focus on?
- Tab navigation implementation
- Organization members page functionality
- Component structure and reusability

## Testing Verification
Tested organization settings pages navigation and members listing functionality.

## What was done
pr_agent:summary

## Detailed Changes
pr_agent:walkthrough

## Additional Notes
Member invitation functionality is currently stubbed for future implementation.
