### PR TITLE
✨(settings): Improve settings tab functionality with proper routing

### DIFF
--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.tsx
@@ -1,25 +1,32 @@
-'use client'
-
+import { urlgen } from '@/utils/routes/urlgen'
 import { TabsList, TabsTrigger } from '@liam-hq/ui'
+import Link from 'next/link'
 import type { FC } from 'react'
 import { SETTINGS_TABS } from '../../constants'
 import styles from './SettingsHeader.module.css'
 
-export const SettingsHeader: FC = () => {
+interface SettingsHeaderProps {
+  organizationId: string
+}
+
+export const SettingsHeader: FC<SettingsHeaderProps> = ({ organizationId }) => {
   return (
     <div className={styles.wrapper}>
       <TabsList className={styles.tabsList}>
         {SETTINGS_TABS.map((tab) => {
           const Icon = tab.icon
+          const href = urlgen(
+            `organizations/[organizationId]/settings/${tab.value}`,
+            { organizationId },
+          )
+
           return (
-            <TabsTrigger
-              key={tab.value}
-              value={tab.value}
-              className={styles.tabsTrigger}
-            >
-              <Icon size={16} />
-              {tab.label}
-            </TabsTrigger>
+            <Link href={href} key={tab.value}>
+              <TabsTrigger value={tab.value} className={styles.tabsTrigger}>
+                <Icon size={16} />
+                {tab.label}
+              </TabsTrigger>
+            </Link>
           )
         })}
       </TabsList>

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/constants.ts
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/constants.ts
@@ -1,4 +1,5 @@
 import { BookMarked, GitPullRequestArrow, LayoutGrid, Users } from '@liam-hq/ui'
+import { type InferOutput, literal, union } from 'valibot'
 
 export const SETTINGS_TAB = {
   GENERAL: 'general',
@@ -7,7 +8,14 @@ export const SETTINGS_TAB = {
   PROJECTS: 'projects',
 } as const
 
-export type SettingsTabValue = (typeof SETTINGS_TAB)[keyof typeof SETTINGS_TAB]
+export const SettingsTabSchema = union([
+  literal(SETTINGS_TAB.GENERAL),
+  literal(SETTINGS_TAB.MEMBERS),
+  literal(SETTINGS_TAB.BILLING),
+  literal(SETTINGS_TAB.PROJECTS),
+])
+
+export type SettingsTabValue = InferOutput<typeof SettingsTabSchema>
 
 export interface SettingsTab {
   value: SettingsTabValue

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx
@@ -1,7 +1,9 @@
+import type { LayoutProps } from '@/app/types'
 import { TabsContent, TabsRoot } from '@liam-hq/ui'
 import { headers } from 'next/headers'
-import type { ReactNode } from 'react'
+import { notFound } from 'next/navigation'
 import { safeParse } from 'valibot'
+import * as v from 'valibot'
 import { SettingsHeader } from './components/SettingsHeader'
 import {
   SETTINGS_TAB,
@@ -10,9 +12,9 @@ import {
 } from './constants'
 import styles from './layout.module.css'
 
-interface LayoutProps {
-  children: ReactNode
-}
+const paramsSchema = v.object({
+  organizationId: v.string(),
+})
 
 const getDefaultTabFromPath = async (): Promise<
   SettingsTabValue | undefined
@@ -29,8 +31,11 @@ const getDefaultTabFromPath = async (): Promise<
 
 export default async function OrganizationSettingsLayout({
   children,
+  params,
 }: LayoutProps) {
   const defaultTabFromPath = await getDefaultTabFromPath()
+  const parsedParams = v.safeParse(paramsSchema, await params)
+  if (!parsedParams.success) return notFound()
 
   return (
     <div className={styles.container}>
@@ -38,7 +43,7 @@ export default async function OrganizationSettingsLayout({
         <h1 className={styles.heading}>Settings</h1>
 
         <TabsRoot defaultValue={defaultTabFromPath}>
-          <SettingsHeader />
+          <SettingsHeader organizationId={parsedParams.output.organizationId} />
           <TabsContent
             value={SETTINGS_TAB.GENERAL}
             className={styles.tabContent}

--- a/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx
+++ b/frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx
@@ -1,25 +1,43 @@
 import { TabsContent, TabsRoot } from '@liam-hq/ui'
+import { headers } from 'next/headers'
 import type { ReactNode } from 'react'
+import { safeParse } from 'valibot'
 import { SettingsHeader } from './components/SettingsHeader'
-import { SETTINGS_TAB } from './constants'
+import {
+  SETTINGS_TAB,
+  SettingsTabSchema,
+  type SettingsTabValue,
+} from './constants'
 import styles from './layout.module.css'
 
 interface LayoutProps {
   children: ReactNode
 }
 
+const getDefaultTabFromPath = async (): Promise<
+  SettingsTabValue | undefined
+> => {
+  const headersList = await headers()
+  const urlPath = headersList.get('x-url-path') || ''
+  const pathSegments = urlPath.split('/')
+  const lastSegment = pathSegments[pathSegments.length - 1]
+
+  const result = safeParse(SettingsTabSchema, lastSegment)
+
+  return result.success ? result.output : undefined
+}
+
 export default async function OrganizationSettingsLayout({
   children,
 }: LayoutProps) {
+  const defaultTabFromPath = await getDefaultTabFromPath()
+
   return (
     <div className={styles.container}>
       <div className={styles.contentContainer}>
         <h1 className={styles.heading}>Settings</h1>
 
-        <TabsRoot
-          // TODO: Make it possible to retrieve it from the current path
-          defaultValue={SETTINGS_TAB.GENERAL}
-        >
+        <TabsRoot defaultValue={defaultTabFromPath}>
           <SettingsHeader />
           <TabsContent
             value={SETTINGS_TAB.GENERAL}

--- a/frontend/apps/app/app/types.ts
+++ b/frontend/apps/app/app/types.ts
@@ -1,5 +1,13 @@
+import type { ReactNode } from 'react'
+
 // https://nextjs.org/docs/app/api-reference/file-conventions/page
 export type PageProps = {
   params: Promise<{ [key: string]: string | string[] | undefined }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+//https://nextjs.org/docs/app/api-reference/file-conventions/layout
+export type LayoutProps = {
+  children?: ReactNode
+  params: Promise<{ [key: string]: string | string[] | undefined }>
 }

--- a/frontend/apps/app/middleware.ts
+++ b/frontend/apps/app/middleware.ts
@@ -83,7 +83,12 @@ export async function updateSession(request: NextRequest) {
 }
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request)
+  const response = await updateSession(request)
+  // NOTE: Set the x-url-path header to allow extracting the current path in layout.tsx and other components
+  // @see: https://github.com/vercel/next.js/issues/43704#issuecomment-1411186664
+  response.headers.set('x-url-path', request.nextUrl.pathname)
+
+  return response
 }
 
 export const config = {

--- a/frontend/apps/app/utils/routes/routeDefinitions.ts
+++ b/frontend/apps/app/utils/routes/routeDefinitions.ts
@@ -16,6 +16,18 @@ export type RouteDefinitions = {
   'organizations/[organizationId]/projects/new': (params: {
     organizationId: string
   }) => string
+  'organizations/[organizationId]/settings/general': (params: {
+    organizationId: string
+  }) => string
+  'organizations/[organizationId]/settings/members': (params: {
+    organizationId: string
+  }) => string
+  'organizations/[organizationId]/settings/billing': (params: {
+    organizationId: string
+  }) => string
+  'organizations/[organizationId]/settings/projects': (params: {
+    organizationId: string
+  }) => string
   'projects/[projectId]/ref/[branchOrCommit]': (params: {
     projectId: string
     branchOrCommit: string
@@ -64,6 +76,18 @@ export const routeDefinitions: RouteDefinitions = {
   },
   'organizations/[organizationId]/projects/new': ({ organizationId }) => {
     return `/app/organizations/${organizationId}/projects/new`
+  },
+  'organizations/[organizationId]/settings/general': ({ organizationId }) => {
+    return `/app/organizations/${organizationId}/settings/general`
+  },
+  'organizations/[organizationId]/settings/members': ({ organizationId }) => {
+    return `/app/organizations/${organizationId}/settings/members`
+  },
+  'organizations/[organizationId]/settings/billing': ({ organizationId }) => {
+    return `/app/organizations/${organizationId}/settings/billing`
+  },
+  'organizations/[organizationId]/settings/projects': ({ organizationId }) => {
+    return `/app/organizations/${organizationId}/settings/projects`
   },
   'projects/[projectId]': ({ projectId }) => {
     return `/app/projects/${projectId}`


### PR DESCRIPTION
## Issue

- N/A

## Why is this change needed?

The organization settings page needed improvements to properly handle tab navigation and maintain the selected tab state based on the URL. This change enhances the user experience by allowing direct navigation to specific settings tabs and preserving the current tab in the URL.

## What would you like reviewers to focus on?
- The middleware changes that now pass the URL path to components
- The tab selection logic in the layout component
- The new Link-based navigation in the SettingsHeader component

## Testing Verification
Manual testing performed:
- Navigating directly to each settings tab URL
- Clicking between tabs and verifying URL updates correctly
- Refreshing the page and confirming the correct tab remains selected


https://github.com/user-attachments/assets/52bee9d5-391f-4ad3-986c-1efb95c8334d



## What was done
### 🤖 Generated by PR Agent at 078d0a40a7f6b57ecbabe57e2a20c7ce5e44dcc0

- Added runtime type validation for settings tab values using valibot
- Enhanced settings layout to select tab based on URL path
- Refactored SettingsHeader to use dynamic links for tab navigation
- Updated middleware to set `x-url-path` header for server components


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Add runtime type validation for settings tab values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/constants.ts

<li>Added valibot-based runtime schema for settings tab values<br> <li> Introduced <code>SettingsTabSchema</code> and updated <code>SettingsTabValue</code> typing


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1418/files#diff-00eb7321780a5f10a8ee8b19e1dddf7132bf9e691522e9e39aac4d8addd86c66">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add and export LayoutProps type for layouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/types.ts

<li>Added <code>LayoutProps</code> type for improved layout typing<br> <li> Included <code>children</code> and <code>params</code> in layout props


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1418/files#diff-6c1cfb882b04af76c6da1a4d6424f0c654550fa6c4e0b68d457f7a51d7d9a9f3">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>middleware.ts</strong><dd><code>Add x-url-path header to middleware response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/middleware.ts

<li>Set <code>x-url-path</code> header on response for path extraction in components<br> <li> Updated middleware to include current URL path in headers


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1418/files#diff-d1cf14026f2ca0918ea1b428f3649551ed12bdfdeb061fd4f0ab7d4fe93de50e">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>routeDefinitions.ts</strong><dd><code>Add route definitions for settings tab URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/utils/routes/routeDefinitions.ts

<li>Added route definitions for each settings tab (general, members, <br>billing, projects)<br> <li> Updated route generation logic for new settings paths


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1418/files#diff-f477ac9ab5621f47f8ed19632791c39bf81ec791318804144428e1aa9c8f5e21">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsHeader.tsx</strong><dd><code>Refactor SettingsHeader for dynamic tab links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/components/SettingsHeader/SettingsHeader.tsx

<li>Refactored SettingsHeader to accept organizationId as prop<br> <li> Replaced static tab triggers with dynamic Link-based navigation<br> <li> Generated tab URLs using route definitions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1418/files#diff-755746d6aef5b56a46d429c4c7def7da3164153b5756cafdc050d5ffb904143d">+18/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Dynamically select settings tab and validate params in layout</code></dd></summary>
<hr>

frontend/apps/app/app/(app)/app/organizations/[organizationId]/settings/layout.tsx

<li>Used headers to extract current URL path for tab selection<br> <li> Validated params with valibot and handled not found cases<br> <li> Passed organizationId to SettingsHeader for dynamic links<br> <li> Set default tab dynamically based on URL path


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1418/files#diff-6f9b893e432ba1e881e1422b8bfe0d8332fa7342f51af577a752c5125c89613b">+32/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This implementation follows the recommended Next.js practice for sharing URL information with server components using headers.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>