### PR TITLE
🔒(security): Refactor GitHub repository fetching to use server route

### DIFF
--- a/frontend/apps/app/app/api/github/repositories/route.ts
+++ b/frontend/apps/app/app/api/github/repositories/route.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@/libs/db/server'
+import { getRepositoriesByInstallationId } from '@liam-hq/github'
+import { type NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const installationId = Number(searchParams.get('installationId'))
+
+  if (!installationId) {
+    return NextResponse.json(
+      { error: 'Installation ID is required' },
+      { status: 400 },
+    )
+  }
+
+  const supabase = await createClient()
+  const { data } = await supabase.auth.getSession()
+  const session = data.session
+
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const res = await getRepositoriesByInstallationId(session, installationId)
+    return NextResponse.json(res.repositories)
+  } catch (error) {
+    console.error('Error fetching repositories:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch repositories' },
+      { status: 500 },
+    )
+  }
+}

--- a/frontend/apps/app/features/projects/pages/ProjectNewPage/InstallationSelector/RepositoriesPanel.tsx
+++ b/frontend/apps/app/features/projects/pages/ProjectNewPage/InstallationSelector/RepositoriesPanel.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { addProject } from '@/features/projects/actions'
+import type { Repository } from '@liam-hq/github'
+import { useEffect, useState } from 'react'
+import { RepositoryItem } from '../RepositoryItem'
+import styles from './InstallationSelector.module.css'
+
+type Props = {
+  installationId: number
+  organizationId: string
+}
+
+export function RepositoriesPanel({ installationId, organizationId }: Props) {
+  const [repositories, setRepositories] = useState<Repository[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchRepositories = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const response = await fetch(
+          `/api/github/repositories?installationId=${installationId}`,
+          { cache: 'no-store' },
+        )
+
+        if (!response.ok) {
+          const errorData = await response.json()
+          throw new Error(errorData.error || 'Failed to fetch repositories')
+        }
+
+        const data = await response.json()
+        setRepositories(data)
+      } catch (error) {
+        console.error('Error fetching repositories:', error)
+        setError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to load repositories',
+        )
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchRepositories()
+  }, [installationId])
+
+  // Show loading state
+  if (isLoading) {
+    return <div>Loading repositories...</div>
+  }
+
+  // Show error state
+  if (error) {
+    return <div>Error: {error}</div>
+  }
+
+  // Show empty state
+  if (repositories.length === 0) {
+    return <div>No repositories found</div>
+  }
+
+  // Render repositories with form actions
+  return (
+    <div className={styles.repositoriesList}>
+      <h3>Repositories</h3>
+      {repositories.map((repo) => (
+        <form key={repo.id} action={addProject}>
+          <input type="hidden" name="projectName" value={repo.name} />
+          <input type="hidden" name="repositoryName" value={repo.name} />
+          <input
+            type="hidden"
+            name="repositoryOwner"
+            value={repo.owner.login}
+          />
+          <input type="hidden" name="repositoryId" value={repo.id.toString()} />
+          <input
+            type="hidden"
+            name="installationId"
+            value={installationId.toString()}
+          />
+          <input type="hidden" name="organizationId" value={organizationId} />
+          <RepositoryItem name={repo.name} isLoading={false} />
+        </form>
+      ))}
+    </div>
+  )
+}

--- a/frontend/apps/app/features/projects/pages/ProjectNewPage/ProjectNewPage.tsx
+++ b/frontend/apps/app/features/projects/pages/ProjectNewPage/ProjectNewPage.tsx
@@ -5,7 +5,7 @@ import styles from './ProjectNewPage.module.css'
 
 type Props = {
   installations: Installation[]
-  organizationId?: string
+  organizationId: string
 }
 
 export const ProjectNewPage: FC<Props> = ({

--- a/frontend/apps/app/features/projects/pages/ProjectNewPage/RepositoryItem/RepositoryItem.tsx
+++ b/frontend/apps/app/features/projects/pages/ProjectNewPage/RepositoryItem/RepositoryItem.tsx
@@ -4,23 +4,18 @@ import styles from './RepositoryItem.module.css'
 
 type Props = {
   name: string
-  onClick: () => void
   isLoading?: boolean
 }
 
-export const RepositoryItem: FC<Props> = ({
-  name,
-  onClick,
-  isLoading = false,
-}) => {
+export const RepositoryItem: FC<Props> = ({ name, isLoading = false }) => {
   return (
     <div className={styles.wrapper}>
       <span>{name}</span>
       <Button
         size="sm"
         variant="solid-primary"
-        onClick={onClick}
         disabled={isLoading}
+        type="submit"
       >
         {isLoading ? 'Importing...' : 'Import'}
       </Button>


### PR DESCRIPTION
## Issue

- resolve: Enhance security for GitHub repository access

## Why is this change needed?
This refactoring improves security by moving GitHub repository API calls from client-side to server-side. Previously, Supabase client credentials were exposed to the browser, making it easier for attackers to access sensitive data. With this change, all repository data is now fetched through a dedicated API route with proper authentication checks.

## What would you like reviewers to focus on?
- Verify API route security implementation (authentication, error handling)
- Check if the UX remains consistent with the previous implementation
- Review the form-based approach for importing repositories

## Testing Verification
- Tested repository fetching with valid and invalid installation IDs
- Verified authentication is properly enforced
- Confirmed error states are handled and displayed correctly
- Tested project import flow with various repositories

## What was done
pr_agent:summary

## Detailed Changes
pr_agent:walkthrough

## Additional Notes
This change is part of ongoing security improvements to reduce client-side credential exposure.