### PR TITLE
♻️(database): Refactor GitHub PR comments into separate table

### DIFF
--- a/.liam/schema-override.yml
+++ b/.liam/schema-override.yml
@@ -22,9 +22,9 @@ overrides:
       comment: "GitHub repositories table with github_ prefix pattern"
     github_pull_requests:
       comment: "GitHub pull requests table with github_ prefix pattern. Should be updated to have migration_id instead of migrations having pull_request_id."
+    github_pull_request_comments:
+      comment: "Stores GitHub comment information for pull requests, maintaining a 1:1 relationship with github_pull_requests"
     migrations:
       comment: "Should have project_id instead of pull_request_id to remove GitHub dependency"
     overall_reviews:
       comment: "Should have migration_id instead of pull_request_id to remove GitHub dependency"
-    github_pull_request_comments:
-      comment: "Stores GitHub comment information for pull requests, maintaining a 1:1 relationship with github_pull_requests"

--- a/.liam/schema-override.yml
+++ b/.liam/schema-override.yml
@@ -7,6 +7,7 @@ overrides:
         - github_pull_requests
         - github_schema_file_paths
         - github_doc_file_paths
+        - github_pull_request_comments
       comment: "Tables related to GitHub. All tables in this group should have a GitHub prefix. External tables must not depend on these tables (e.g., no pullRequestId foreign keys in tables outside this group)."
     Organization:
       name: Organization
@@ -25,3 +26,5 @@ overrides:
       comment: "Should have project_id instead of pull_request_id to remove GitHub dependency"
     overall_reviews:
       comment: "Should have migration_id instead of pull_request_id to remove GitHub dependency"
+    github_pull_request_comments:
+      comment: "Stores GitHub comment information for pull requests, maintaining a 1:1 relationship with github_pull_requests"

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -180,8 +180,7 @@ CREATE TABLE IF NOT EXISTS "public"."github_pull_requests" (
     "pull_number" bigint NOT NULL,
     "created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     "updated_at" timestamp(3) with time zone NOT NULL,
-    "repository_id" "uuid" NOT NULL,
-    "github_pull_request_identifier" bigint NOT NULL
+    "repository_id" "uuid" NOT NULL
 );
 
 
@@ -426,11 +425,6 @@ ALTER TABLE ONLY "public"."github_pull_request_comments"
 
 ALTER TABLE ONLY "public"."github_pull_request_comments"
     ADD CONSTRAINT "github_pull_request_comments_pkey" PRIMARY KEY ("id");
-
-
-
-ALTER TABLE ONLY "public"."github_pull_requests"
-    ADD CONSTRAINT "github_pull_request_repository_id_github_pull_request_identifie" UNIQUE ("repository_id", "github_pull_request_identifier");
 
 
 

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -175,10 +175,6 @@ CREATE TABLE IF NOT EXISTS "public"."github_pull_request_comments" (
 ALTER TABLE "public"."github_pull_request_comments" OWNER TO "postgres";
 
 
-COMMENT ON TABLE "public"."github_pull_request_comments" IS 'Stores GitHub comment information for pull requests, maintaining a 1:1 relationship with github_pull_requests';
-
-
-
 CREATE TABLE IF NOT EXISTS "public"."github_pull_requests" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "pull_number" bigint NOT NULL,

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -166,7 +166,7 @@ ALTER TABLE "public"."github_doc_file_paths" OWNER TO "postgres";
 CREATE TABLE IF NOT EXISTS "public"."github_pull_request_comments" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "github_pull_request_id" "uuid" NOT NULL,
-    "github_comment_identifier" bigint NOT NULL,
+    "github_comment_identifier" integer NOT NULL,
     "created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     "updated_at" timestamp(3) with time zone NOT NULL
 );

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -767,9 +767,6 @@ COMMENT ON POLICY "authenticated_users_can_update_org_projects" ON "public"."pro
 
 
 
-ALTER TABLE "public"."github_pull_request_comments" ENABLE ROW LEVEL SECURITY;
-
-
 ALTER TABLE "public"."projects" ENABLE ROW LEVEL SECURITY;
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -69,26 +69,58 @@ export type Database = {
           },
         ]
       }
+      github_pull_request_comments: {
+        Row: {
+          created_at: string
+          github_comment_identifier: number
+          github_pull_request_id: string
+          id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          github_comment_identifier: number
+          github_pull_request_id: string
+          id?: string
+          updated_at: string
+        }
+        Update: {
+          created_at?: string
+          github_comment_identifier?: number
+          github_pull_request_id?: string
+          id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'github_pull_request_comments_github_pull_request_id_fkey'
+            columns: ['github_pull_request_id']
+            isOneToOne: true
+            referencedRelation: 'github_pull_requests'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       github_pull_requests: {
         Row: {
-          comment_id: number | null
           created_at: string
+          github_pull_request_identifier: number
           id: string
           pull_number: number
           repository_id: string
           updated_at: string
         }
         Insert: {
-          comment_id?: number | null
           created_at?: string
+          github_pull_request_identifier: number
           id?: string
           pull_number: number
           repository_id: string
           updated_at: string
         }
         Update: {
-          comment_id?: number | null
           created_at?: string
+          github_pull_request_identifier?: number
           id?: string
           pull_number?: number
           repository_id?: string

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -104,7 +104,6 @@ export type Database = {
       github_pull_requests: {
         Row: {
           created_at: string
-          github_pull_request_identifier: number
           id: string
           pull_number: number
           repository_id: string
@@ -112,7 +111,6 @@ export type Database = {
         }
         Insert: {
           created_at?: string
-          github_pull_request_identifier: number
           id?: string
           pull_number: number
           repository_id: string
@@ -120,7 +118,6 @@ export type Database = {
         }
         Update: {
           created_at?: string
-          github_pull_request_identifier?: number
           id?: string
           pull_number?: number
           repository_id?: string

--- a/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
+++ b/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
@@ -38,9 +38,6 @@ CREATE TABLE "public"."github_pull_request_comments" (
     ON DELETE CASCADE
 );
 
--- Add comments to the table
-COMMENT ON TABLE "public"."github_pull_request_comments" IS 'Stores GitHub comment information for pull requests, maintaining a 1:1 relationship with github_pull_requests';
-
 -- Grant permissions on the new table
 ALTER TABLE "public"."github_pull_request_comments" ENABLE ROW LEVEL SECURITY;
 GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "anon";

--- a/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
+++ b/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
@@ -39,7 +39,6 @@ CREATE TABLE "public"."github_pull_request_comments" (
 );
 
 -- Grant permissions on the new table
-ALTER TABLE "public"."github_pull_request_comments" ENABLE ROW LEVEL SECURITY;
 GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "anon";
 GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "authenticated";
 GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "service_role";

--- a/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
+++ b/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
@@ -16,7 +16,7 @@ BEGIN;
 CREATE TABLE "public"."github_pull_request_comments" (
   "id" uuid DEFAULT gen_random_uuid() NOT NULL,
   "github_pull_request_id" uuid NOT NULL,
-  "github_comment_identifier" bigint NOT NULL,
+  "github_comment_identifier" integer NOT NULL,
   "created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
   "updated_at" timestamp(3) with time zone NOT NULL,
 

--- a/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
+++ b/frontend/packages/db/supabase/migrations/20250422051514_refactor_github_pull_requests.sql
@@ -1,0 +1,87 @@
+/*
+  Migration: Refactor github_pull_requests table and create github_pull_request_comments table
+
+  Purpose:
+  - Remove comment_id from github_pull_requests to avoid record updates, moving it to a separate table
+  - Add github_pull_request_identifier to github_pull_requests for direct reference to GitHub's pull request ID
+  - Create new github_pull_request_comments table with a 1:1 relationship to github_pull_requests
+
+  Affected tables:
+  - github_pull_requests
+  - github_pull_request_comments (new)
+*/
+
+BEGIN;
+
+-- Step 1: Create the new github_pull_request_comments table
+CREATE TABLE "public"."github_pull_request_comments" (
+  "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+  "github_pull_request_id" uuid NOT NULL,
+  "github_comment_identifier" bigint NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  "updated_at" timestamp(3) with time zone NOT NULL,
+
+  -- Define primary key
+  CONSTRAINT "github_pull_request_comments_pkey" PRIMARY KEY ("id"),
+
+  -- Define unique constraint on github_pull_request_id for 1:1 relationship
+  CONSTRAINT "github_pull_request_comments_github_pull_request_id_key" UNIQUE ("github_pull_request_id"),
+
+  -- Define unique constraint on github_comment_identifier
+  CONSTRAINT "github_pull_request_comments_github_comment_identifier_key" UNIQUE ("github_comment_identifier"),
+
+  -- Define foreign key relationship to github_pull_requests
+  CONSTRAINT "github_pull_request_comments_github_pull_request_id_fkey"
+    FOREIGN KEY ("github_pull_request_id")
+    REFERENCES "public"."github_pull_requests"("id")
+    ON UPDATE CASCADE
+    ON DELETE CASCADE
+);
+
+-- Add comments to the table
+COMMENT ON TABLE "public"."github_pull_request_comments" IS 'Stores GitHub comment information for pull requests, maintaining a 1:1 relationship with github_pull_requests';
+
+-- Grant permissions on the new table
+ALTER TABLE "public"."github_pull_request_comments" ENABLE ROW LEVEL SECURITY;
+GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "anon";
+GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "authenticated";
+GRANT ALL ON TABLE "public"."github_pull_request_comments" TO "service_role";
+
+-- Step 2: Add github_pull_request_identifier to github_pull_requests
+-- First, add the column as nullable
+ALTER TABLE "public"."github_pull_requests"
+ADD COLUMN "github_pull_request_identifier" bigint;
+
+-- Step 3: If there's data in the table, we need to populate the new column
+-- We'll use the pull_number as a fallback since it's likely the same identifier
+UPDATE "public"."github_pull_requests"
+SET "github_pull_request_identifier" = "pull_number";
+
+-- Step 4: Now make the column NOT NULL
+ALTER TABLE "public"."github_pull_requests"
+ALTER COLUMN "github_pull_request_identifier" SET NOT NULL;
+
+-- Step 5: Create composite unique constraint with repository_id
+-- This ensures that within a repository, each GitHub pull request identifier is unique
+ALTER TABLE "public"."github_pull_requests"
+ADD CONSTRAINT "github_pull_request_repository_id_github_pull_request_identifier_key"
+UNIQUE ("repository_id", "github_pull_request_identifier");
+
+-- Step 6: Optionally migrate existing comment_id data to the new table
+-- This will preserve any existing comment relationships
+INSERT INTO "public"."github_pull_request_comments"
+("github_pull_request_id", "github_comment_identifier", "updated_at")
+SELECT
+  "id",
+  "comment_id",
+  CURRENT_TIMESTAMP
+FROM "public"."github_pull_requests"
+WHERE "comment_id" IS NOT NULL;
+
+-- Step 7: Finally, drop the comment_id column from github_pull_requests
+-- This comment explains the potentially destructive operation
+-- Note: This is a destructive operation, but we've migrated the data in step 6
+ALTER TABLE "public"."github_pull_requests"
+DROP COLUMN "comment_id";
+
+COMMIT;

--- a/frontend/packages/jobs/src/tasks/review/__tests__/postComment.test.ts
+++ b/frontend/packages/jobs/src/tasks/review/__tests__/postComment.test.ts
@@ -44,7 +44,7 @@ describe.skip('postComment', () => {
     id: '9999',
     pull_number: 1,
     repository_id: '9999',
-    comment_id: null,
+    github_pull_request_identifier: 1,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   }
@@ -110,21 +110,23 @@ Migration URL: ${process.env['NEXT_PUBLIC_BASE_URL']}/app/migrations/${testMigra
     )
     expect(createPullRequestComment).toHaveBeenCalledTimes(1)
 
-    const { data: updatedPR } = await supabase
-      .from('github_pull_requests')
-      .select('*')
-      .eq('id', testPullRequest.id)
-      .single()
+    const { data: prComment } = await supabase
+      .from('github_pull_request_comments')
+      .select('github_comment_identifier')
+      .eq('github_pull_request_id', testPullRequest.id)
+      .maybeSingle()
 
-    expect(updatedPR?.comment_id).toBe(mockCommentId)
+    expect(prComment?.github_comment_identifier).toBe(mockCommentId)
   })
 
   it('should update existing comment when comment exists', async () => {
     const existingCommentId = 456
-    await supabase
-      .from('github_pull_requests')
-      .update({ comment_id: existingCommentId })
-      .eq('id', testPullRequest.id)
+    const now = new Date().toISOString()
+    await supabase.from('github_pull_request_comments').insert({
+      github_pull_request_id: testPullRequest.id,
+      github_comment_identifier: existingCommentId,
+      updated_at: now,
+    })
 
     const testPayload = {
       reviewComment: 'Updated review comment',
@@ -183,7 +185,7 @@ Migration URL: ${process.env['NEXT_PUBLIC_BASE_URL']}/app/migrations/${testMigra
       id: '8888',
       pull_number: 2,
       repository_id: testRepository.id,
-      comment_id: null,
+      github_pull_request_identifier: 2,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     }

--- a/frontend/packages/jobs/src/tasks/review/__tests__/postComment.test.ts
+++ b/frontend/packages/jobs/src/tasks/review/__tests__/postComment.test.ts
@@ -44,7 +44,6 @@ describe.skip('postComment', () => {
     id: '9999',
     pull_number: 1,
     repository_id: '9999',
-    github_pull_request_identifier: 1,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   }
@@ -185,7 +184,6 @@ Migration URL: ${process.env['NEXT_PUBLIC_BASE_URL']}/app/migrations/${testMigra
       id: '8888',
       pull_number: 2,
       repository_id: testRepository.id,
-      github_pull_request_identifier: 2,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     }

--- a/frontend/packages/jobs/src/tasks/review/__tests__/processSaveReview.test.ts
+++ b/frontend/packages/jobs/src/tasks/review/__tests__/processSaveReview.test.ts
@@ -28,7 +28,6 @@ describe.skip('processSaveReview', () => {
     id: '9999',
     pull_number: 9999,
     repository_id: '9999',
-    github_pull_request_identifier: 9999,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   }

--- a/frontend/packages/jobs/src/tasks/review/__tests__/processSaveReview.test.ts
+++ b/frontend/packages/jobs/src/tasks/review/__tests__/processSaveReview.test.ts
@@ -28,7 +28,7 @@ describe.skip('processSaveReview', () => {
     id: '9999',
     pull_number: 9999,
     repository_id: '9999',
-    comment_id: null,
+    github_pull_request_identifier: 9999,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   }

--- a/frontend/packages/jobs/src/tasks/review/postComment.ts
+++ b/frontend/packages/jobs/src/tasks/review/postComment.ts
@@ -118,6 +118,13 @@ export async function postComment(
       )
     }
 
+    // Fetch comment ID from github_pull_request_comments if exists
+    const { data: commentRecord } = await supabase
+      .from('github_pull_request_comments')
+      .select('github_comment_identifier')
+      .eq('github_pull_request_id', pullRequestId)
+      .maybeSingle()
+
     const migration = prRecord.migrations[0]
     const migrationUrl = `${process.env['NEXT_PUBLIC_BASE_URL']}/app/projects/${projectId}/ref/${encodeURIComponent(branchName)}/migrations/${migration.id}`
 
@@ -139,12 +146,12 @@ export async function postComment(
 
     const fullComment = `${reviewComment}\n\nMigration URL: ${migrationUrl}${erdLinkText}`
 
-    if (prRecord.comment_id) {
+    if (commentRecord?.github_comment_identifier) {
       await updatePullRequestComment(
         Number(installationId),
         owner,
         repo,
-        Number(prRecord.comment_id),
+        Number(commentRecord.github_comment_identifier),
         fullComment,
       )
     } else {
@@ -156,14 +163,18 @@ export async function postComment(
         fullComment,
       )
 
-      const { error: updateError } = await supabase
-        .from('github_pull_requests')
-        .update({ comment_id: commentResponse.id })
-        .eq('id', pullRequestId)
+      const now = new Date().toISOString()
+      const { error: createCommentError } = await supabase
+        .from('github_pull_request_comments')
+        .insert({
+          github_pull_request_id: pullRequestId,
+          github_comment_identifier: commentResponse.id,
+          updated_at: now,
+        })
 
-      if (updateError) {
+      if (createCommentError) {
         throw new Error(
-          `Failed to update pull request with comment ID: ${updateError.message}`,
+          `Failed to create github_pull_request_comments record: ${createCommentError.message}`,
         )
       }
     }

--- a/frontend/packages/jobs/src/tasks/review/savePullRequest.ts
+++ b/frontend/packages/jobs/src/tasks/review/savePullRequest.ts
@@ -151,7 +151,6 @@ async function getOrCreatePullRequestRecord(
   supabase: SupabaseClient,
   repositoryId: string,
   pullNumber: number,
-  githubPullRequestIdentifier: number,
 ): Promise<{ id: string }> {
   const { data: existingPR } = await supabase
     .from('github_pull_requests')
@@ -170,7 +169,6 @@ async function getOrCreatePullRequestRecord(
     .insert({
       repository_id: repositoryId,
       pull_number: pullNumber,
-      github_pull_request_identifier: githubPullRequestIdentifier,
       updated_at: now,
     })
     .select()
@@ -267,7 +265,6 @@ export async function processSavePullRequest(
     supabase,
     repository.id,
     payload.prNumber,
-    prDetails.id,
   )
 
   await createOrUpdateMigrationRecord(supabase, prRecord.id, prDetails.title)

--- a/frontend/packages/jobs/src/tasks/review/savePullRequest.ts
+++ b/frontend/packages/jobs/src/tasks/review/savePullRequest.ts
@@ -151,6 +151,7 @@ async function getOrCreatePullRequestRecord(
   supabase: SupabaseClient,
   repositoryId: string,
   pullNumber: number,
+  githubPullRequestIdentifier: number,
 ): Promise<{ id: string }> {
   const { data: existingPR } = await supabase
     .from('github_pull_requests')
@@ -169,7 +170,7 @@ async function getOrCreatePullRequestRecord(
     .insert({
       repository_id: repositoryId,
       pull_number: pullNumber,
-      github_pull_request_identifier: pullNumber, // Add the new required field
+      github_pull_request_identifier: githubPullRequestIdentifier,
       updated_at: now,
     })
     .select()
@@ -266,6 +267,7 @@ export async function processSavePullRequest(
     supabase,
     repository.id,
     payload.prNumber,
+    prDetails.id,
   )
 
   await createOrUpdateMigrationRecord(supabase, prRecord.id, prDetails.title)

--- a/frontend/packages/jobs/src/tasks/review/savePullRequest.ts
+++ b/frontend/packages/jobs/src/tasks/review/savePullRequest.ts
@@ -169,6 +169,7 @@ async function getOrCreatePullRequestRecord(
     .insert({
       repository_id: repositoryId,
       pull_number: pullNumber,
+      github_pull_request_identifier: pullNumber, // Add the new required field
       updated_at: now,
     })
     .select()


### PR DESCRIPTION
## Issue

- resolve: Improve database schema design for pull request comments

## Why is this change needed?
This change improves the structure of GitHub pull request data by:
1. Moving comment_id out of the github_pull_requests table into a dedicated github_pull_request_comments table
2. Creating a proper one-to-one relationship between PRs and comments
3. Adding github_pull_request_identifier to github_pull_requests to directly reference GitHub's PR IDs
4. Adding a composite unique constraint on repository_id and github_pull_request_identifier

These changes follow better database normalization practices, making the schema more maintainable and aligning with the established schema patterns.

## What would you like reviewers to focus on?
- Verify the migration script handles existing data correctly
- Check that the transaction wrapping ensures atomicity
- Review the changes to the postComment function to ensure it works with the new schema

## Testing Verification
- Verified migration runs correctly in local environment
- Tested pull request comment creation and updates with the new schema
- Ensured existing records are properly migrated to the new table structure

## What was done
### 🤖 Generated by PR Agent at d47a53d50f700140c55e89775993d3fe651744bf

- Refactored GitHub PR comments into a dedicated table
  - Created `github_pull_request_comments` with 1:1 PR relationship
  - Migrated existing comment data and updated schema constraints
- Added `github_pull_request_identifier` to PRs for direct GitHub mapping
  - Enforced composite uniqueness on repository and PR identifier
- Updated Supabase types, schema, and migration scripts
  - Ensured atomic migrations and backward compatibility
- Refactored backend logic and tests for new schema
  - Updated comment posting and retrieval logic
  - Adjusted tests to use new comment table


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>database.types.ts</strong><dd><code>Add PR comment table and update PR types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>postComment.ts</strong><dd><code>Refactor comment posting to use new table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-b6558755d1f7da7a01b322e4fbce4330d7318274e6a4539ab9c06d1ced4df574">+19/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>savePullRequest.ts</strong><dd><code>Add PR identifier to record creation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-de1f9b668b10e73efb8b0e18f8fa736b4b8c09e997e5972883f9f3429e4f88fe">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.sql</strong><dd><code>Add PR comment table and update constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+45/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>20250422051514_refactor_github_pull_requests.sql</strong><dd><code>Migration for PR comment table and schema refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-418498c78909a84550d4f8aa2fbfd1a3cd2f1a279105579bb5780f5a4ede5f25">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>postComment.test.ts</strong><dd><code>Update tests for new PR comment table schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-ec7543ead724f83277047b8b439089f639573716d9c82724ab8faebf720994d6">+14/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>processSaveReview.test.ts</strong><dd><code>Update test PR objects for new identifier field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-4ca61786ed603e44fd8529385f5bf68d8a8e486b623a33271abdfc07b55e3adc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>schema-override.yml</strong><dd><code>Update schema overrides for new table and comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-55ef933ea85c404dafbbfd720020db6174bd1f4862cc5282cc6206327c8c1479">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>migrationOpsContext.md</strong><dd><code>Document NOT NULL migrations and post-migration steps</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/1435/files#diff-8255db592ec0e6978247b5da69d01352aea6aae97ffb6772b0a164bfe0328470">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

## Additional Notes
This migration follows the documented schema patterns and includes transaction handling to ensure data integrity during the migration process.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>