### PR TITLE
🔧 fix: Correct table name in projects query

### DIFF
--- a/frontend/apps/app/features/projects/pages/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/apps/app/features/projects/pages/ProjectsPage/ProjectsPage.tsx
@@ -1,4 +1,5 @@
 import { urlgen } from '@/utils/routes'
+import { notFound } from 'next/navigation'
 import { EmptyProjectsState } from '../../components/EmptyProjectsState'
 import styles from './ProjectsPage.module.css'
 import { ServerProjectsDataProvider } from './ServerProjectsDataProvider'
@@ -11,13 +12,17 @@ import { getProjects } from './getProjects'
 export async function ProjectsPage({
   organizationId,
 }: {
-  organizationId?: string
+  organizationId: string
 }) {
-  const currentOrganization = organizationId
-    ? await getCurrentOrganization(organizationId)
-    : await getCurrentOrganization()
+  const currentOrganization = await getCurrentOrganization(organizationId)
+
+  if (!currentOrganization) {
+    console.error('Organization not found')
+    return notFound()
+  }
+
   await getUserOrganizations() // Fetch for future use
-  const projects = await getProjects(currentOrganization?.id)
+  const projects = await getProjects(currentOrganization.id)
 
   return (
     <div className={styles.container}>

--- a/frontend/apps/app/features/projects/pages/ProjectsPage/getProjects.ts
+++ b/frontend/apps/app/features/projects/pages/ProjectsPage/getProjects.ts
@@ -12,7 +12,7 @@ export const getProjects = async (organizationId?: string) => {
       updated_at,
       organization_id,
       project_repository_mappings:project_repository_mappings(
-        repository:repositories(
+        repository:github_repositories(
           id,
           name,
           owner,


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
Fixed the database query in `getProjects.ts` by correcting the table name reference from `repositories` to `github_repositories` in the Supabase query. This resolves the PostgrestError that was preventing project list fetching.

<img width="1134" alt="スクリーンショット 2025-04-22 16 50 58" src="https://github.com/user-attachments/assets/6746d138-2f78-4399-af15-bbb176db5e46" />


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 6ff2895179bf27146d1a2b8278b0d0d8ab0b36fe

- Corrected database table reference in `getProjects` query.
  - Changed from `repositories` to `github_repositories` to resolve fetch errors.
- Enforced required `organizationId` parameter in `ProjectsPage`.
  - Improved error handling for missing organizations with `notFound()`.
- Updated project fetching logic to use validated organization ID.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getProjects.ts</strong><dd><code>Fix Supabase query to use correct repositories table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/pages/ProjectsPage/getProjects.ts

<li>Changed table reference from <code>repositories</code> to <code>github_repositories</code> in <br>the project repository mapping query.<br> <li> Ensures correct data is fetched and resolves previous PostgrestError.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1437/files#diff-178a8fe6b7a836858444bac3198cd8bcf0f7f090bcb27110114bfefa1bf07fe3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProjectsPage.tsx</strong><dd><code>Enforce organization ID and handle not found cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/projects/pages/ProjectsPage/ProjectsPage.tsx

<li>Made <code>organizationId</code> a required parameter for <code>ProjectsPage</code>.<br> <li> Added error handling: calls <code>notFound()</code> if organization is missing.<br> <li> Updated project fetching to use validated organization ID.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1437/files#diff-64133849c9acb8e4f2d887f5bfc472ec762c9f9e40dc4dcb829e87e2c6e0ae4d">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>