### PR TITLE
🔒️ Enable RLS on users table and add policy to allow access to users in the same organization

### DIFF
--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -796,6 +796,16 @@ COMMENT ON POLICY "service_role_can_update_all_projects" ON "public"."projects" 
 
 
 
+ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "users_same_organization_select_policy" ON "public"."users" FOR SELECT TO "authenticated" USING (((EXISTS ( SELECT 1
+   FROM ("public"."organization_members" "om1"
+     JOIN "public"."organization_members" "om2" ON (("om1"."organization_id" = "om2"."organization_id")))
+  WHERE (("om1"."user_id" = "users"."id") AND ("om2"."user_id" = "auth"."uid"())))) OR ("id" = "auth"."uid"())));
+
+
+
 
 
 ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";

--- a/frontend/packages/db/supabase/migrations/20250423040522_users_table_policy.sql
+++ b/frontend/packages/db/supabase/migrations/20250423040522_users_table_policy.sql
@@ -1,0 +1,20 @@
+-- enable row level security on the users table
+alter table public.users enable row level security;
+
+-- create a policy that allows users to select their own record
+-- and records of users who are in the same organization
+create policy "users_same_organization_select_policy" on public.users
+    for select to authenticated
+    using (
+        exists (
+            -- user can select records of users who are in the same organization
+            -- using exists to avoid infinite recursion
+            select 1
+            from public.organization_members om1
+            join public.organization_members om2 on om1.organization_id = om2.organization_id
+            where om1.user_id = public.users.id  -- the user being accessed
+              and om2.user_id = auth.uid()  -- the authenticated user
+        )
+        or
+        public.users.id = auth.uid() -- user can select their own record
+    );


### PR DESCRIPTION
- Enabled Row Level Security (RLS) on the public.users table
- Added a policy allowing authenticated users to select:
  - their own user record
  - user records belonging to the same organization (based on organization_members)

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

user-organization base RLS is needed.

## What would you like reviewers to focus on?
check the SQL!

## Testing & Verification

<!-- Please describe how you verified these changes in your local environment using text/images/video -->

### Preconditions

- Two users exist in the system.  

<img width="1147" alt="スクリーンショット 2025-04-23 17 09 33" src="https://github.com/user-attachments/assets/cd692f7c-20aa-4e60-a666-c07c32f6c325" />


---

### Test Case 1: Users in the Same Organization

1. Ensure both users are assigned to the **same** organization.  
2. Visit:  
   ```
   http://localhost:3001/app/organizations/{organizationId}/settings/members
   ```
3. **Expected Results:**
   - Both users are displayed.
   - No errors are shown.

<img width="1327" alt="スクリーンショット 2025-04-23 17 09 42" src="https://github.com/user-attachments/assets/7eb39220-fd6b-46ea-99bc-234068e65abe" />

<img width="1270" alt="スクリーンショット 2025-04-23 16 53 54" src="https://github.com/user-attachments/assets/c119422f-4ce1-4d52-8678-46622946a623" />


---

### Test Case 2: Users in Different Organizations

1. Assign the two users to **different** organizations.  
2. Visit:  
   ```
   http://localhost:3001/app/organizations/{organizationId}/settings/members
   ```
3. **Expected Results:**
   - Only the user belonging to the specified organization is displayed.
   - No errors are shown.

<img width="1394" alt="スクリーンショット 2025-04-23 17 10 17" src="https://github.com/user-attachments/assets/9fc814cf-12d8-4a8c-9df5-f37b2a04320d" />

<img width="1393" alt="スクリーンショット 2025-04-23 17 10 26" src="https://github.com/user-attachments/assets/6d4d2e80-d30c-477b-8325-5b69079764ac" />




## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 02f683839e101a28ed318d75b27c27e11436fd0b

- Enable Row Level Security (RLS) on `public.users` table
- Add policy to allow authenticated users to select:
  - Their own user record
  - User records in the same organization
- Update schema and add migration for new RLS policy


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Enable RLS and add select policy for users table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Enabled Row Level Security on <code>public.users</code> table<br> <li> Added select policy for authenticated users to access users in same <br>organization or themselves


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1451/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250423040522_users_table_policy.sql</strong><dd><code>Migration for RLS and select policy on users table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250423040522_users_table_policy.sql

<li>Migration to enable RLS on <code>public.users</code><br> <li> Migration to create select policy for authenticated users (same org or <br>self)


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1451/files#diff-0f510b6554173b1816461c5efbd61104950880fa89d04e76921d48b563fc9347">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>