### PR TITLE
refactor: Use `supabase.rpc()` to make `inviteMember` an atomic database operation

### DIFF
--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -127,6 +127,81 @@ $$;
 ALTER FUNCTION "public"."handle_new_user"() OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid", "p_invite_by_user_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
+declare
+  v_is_member boolean;
+  v_existing_invite_id uuid;
+  v_result jsonb;
+begin
+  -- Start transaction
+  begin
+    -- Check if user is already a member
+    select exists(
+      select 1
+      from organization_members om
+      join users u on om.user_id = u.id
+      where om.organization_id = p_organization_id
+      and lower(u.email) = lower(p_email)
+    ) into v_is_member;
+    
+    if v_is_member then
+      v_result := jsonb_build_object(
+        'success', false,
+        'error', 'this user is already a member of the organization'
+      );
+      return v_result;
+    end if;
+    
+    -- Check if invitation already exists
+    select id into v_existing_invite_id
+    from invitations
+    where organization_id = p_organization_id
+    and lower(email) = lower(p_email)
+    limit 1;
+    
+    -- If invitation exists, update it
+    if v_existing_invite_id is not null then
+      update invitations
+      set invited_at = current_timestamp
+      where id = v_existing_invite_id;
+      
+      v_result := jsonb_build_object('success', true, 'error', null);
+    else
+      -- Create new invitation
+      insert into invitations (
+        organization_id,
+        email,
+        invite_by_user_id,
+        invited_at
+      ) values (
+        p_organization_id,
+        lower(p_email),
+        p_invite_by_user_id,
+        current_timestamp
+      );
+      
+      v_result := jsonb_build_object('success', true, 'error', null);
+    end if;
+    
+    -- Commit transaction
+    return v_result;
+  exception when others then
+    -- Handle any errors
+    v_result := jsonb_build_object(
+      'success', false,
+      'error', sqlerrm
+    );
+    return v_result;
+  end;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid", "p_invite_by_user_id" "uuid") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "public"."sync_existing_users"() RETURNS "void"
     LANGUAGE "plpgsql" SECURITY DEFINER
     AS $$
@@ -1025,6 +1100,12 @@ GRANT USAGE ON SCHEMA "public" TO "service_role";
 GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "anon";
 GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "authenticated";
 GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid", "p_invite_by_user_id" "uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid", "p_invite_by_user_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid", "p_invite_by_user_id" "uuid") TO "service_role";
 
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -812,6 +812,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      invite_organization_member: {
+        Args: {
+          p_email: string
+          p_organization_id: string
+          p_invite_by_user_id: string
+        }
+        Returns: Json
+      }
       sync_existing_users: {
         Args: Record<PropertyKey, never>
         Returns: undefined

--- a/frontend/packages/db/supabase/migrations/20250423123348_invite_organization_member.sql
+++ b/frontend/packages/db/supabase/migrations/20250423123348_invite_organization_member.sql
@@ -1,0 +1,73 @@
+-- Function to handle organization member invitations atomically
+create or replace function invite_organization_member(
+  p_email text,
+  p_organization_id uuid,
+  p_invite_by_user_id uuid
+) returns jsonb as $$
+declare
+  v_is_member boolean;
+  v_existing_invite_id uuid;
+  v_result jsonb;
+begin
+  -- Start transaction
+  begin
+    -- Check if user is already a member
+    select exists(
+      select 1
+      from organization_members om
+      join users u on om.user_id = u.id
+      where om.organization_id = p_organization_id
+      and lower(u.email) = lower(p_email)
+    ) into v_is_member;
+    
+    if v_is_member then
+      v_result := jsonb_build_object(
+        'success', false,
+        'error', 'this user is already a member of the organization'
+      );
+      return v_result;
+    end if;
+    
+    -- Check if invitation already exists
+    select id into v_existing_invite_id
+    from invitations
+    where organization_id = p_organization_id
+    and lower(email) = lower(p_email)
+    limit 1;
+    
+    -- If invitation exists, update it
+    if v_existing_invite_id is not null then
+      update invitations
+      set invited_at = current_timestamp
+      where id = v_existing_invite_id;
+      
+      v_result := jsonb_build_object('success', true, 'error', null);
+    else
+      -- Create new invitation
+      insert into invitations (
+        organization_id,
+        email,
+        invite_by_user_id,
+        invited_at
+      ) values (
+        p_organization_id,
+        lower(p_email),
+        p_invite_by_user_id,
+        current_timestamp
+      );
+      
+      v_result := jsonb_build_object('success', true, 'error', null);
+    end if;
+    
+    -- Commit transaction
+    return v_result;
+  exception when others then
+    -- Handle any errors
+    v_result := jsonb_build_object(
+      'success', false,
+      'error', sqlerrm
+    );
+    return v_result;
+  end;
+end;
+$$ language plpgsql security definer;


### PR DESCRIPTION
## Issue

- resolve:


## Why is this change needed?

The invitation process for organization members previously involved multiple client-side Supabase queries (checking membership, checking existing invites, updating or inserting). This approach was prone to race conditions and inconsistencies.

This change introduces an atomic Postgres RPC function `invite_organization_member` that encapsulates all related logic within a single transaction. It ensures consistency, simplifies client code, and provides a clearer success/failure response structure.

## What would you like reviewers to focus on?

- The correctness and safety of the `invite_organization_member` function logic, especially around transactional behavior and edge cases.
- The response shape returned from the RPC function and whether it aligns with expected client-side schema (`success`, `error`).
- Supabase permissions (`GRANT`) applied to the new function — are they appropriate for the intended usage?
- Any opportunities to further simplify the invite flow or improve error handling.


## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

tested with https://github.com/liam-hq/liam/pull/1480 , and 

> ### Setup
> 1. Sign in using **my GitHub account** (= my GitHub account's email address).
> 2. Create an organization.
>    
>    * The organization ID was `82a814fa-ac59-4798-a991-5232da90c66c`.
> 3. Visit:
>    `http://localhost:3001/app/organizations/82a814fa-ac59-4798-a991-5232da90c66c/settings/members`
> 4. Invite `someone1@example.com`.

was worked ✔️ 

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 51240f60413bfa5cdcfff7f5999fe912b7fac567

- Introduced atomic invitation logic via Postgres RPC function
  - All membership/invitation checks and updates now handled in one transaction
  - Reduces race conditions and ensures data consistency
- Refactored `inviteMember` server action to use new RPC
  - Removed multiple client-side queries and logic
  - Unified error handling and response structure
- Updated database types and schema for new RPC
  - Added Supabase type definitions and SQL grants for the function


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inviteMember.ts</strong><dd><code>Refactor inviteMember to use atomic RPC function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/organizations/actions/inviteMember.ts

<li>Removed all client-side invitation logic and checks<br> <li> Integrated new <code>invite_organization_member</code> RPC for atomic operation<br> <li> Simplified error handling and response validation<br> <li> Updated validation schema for RPC response


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1463/files#diff-ddf577cb26f510be8e68c60406c3c13c4fe6c01dd8afbf978158170ddf966089">+28/-116</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database.types.ts</strong><dd><code>Add Supabase type for invite_organization_member RPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/database.types.ts

<li>Added type definition for <code>invite_organization_member</code> RPC function<br> <li> Defined input arguments and JSON return type


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1463/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Add and grant invite_organization_member RPC in schema</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Added SQL definition for <code>invite_organization_member</code> function<br> <li> Implemented logic for atomic invitation handling in PL/pgSQL<br> <li> Granted permissions to relevant roles for the new function


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1463/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250423123348_invite_organization_member.sql</strong><dd><code>Migration for atomic invite_organization_member RPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250423123348_invite_organization_member.sql

<li>Introduced migration for <code>invite_organization_member</code> function<br> <li> Implements atomic invitation logic in a single transaction<br> <li> Handles membership checks, invite updates/creation, and error <br>reporting


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1463/files#diff-1797d6e0a74c67eca9d97ef6b43391a730328cb51e70ce00a2c6cb877b1a23f7">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>