### PR TITLE
🔧 fetch and display user's avatar initial in ClientAppBar

### DIFF
--- a/frontend/apps/app/components/CommonLayout/CommonLayout.tsx
+++ b/frontend/apps/app/components/CommonLayout/CommonLayout.tsx
@@ -1,3 +1,4 @@
+import { createClient } from '@/libs/db/server'
 import type { ReactNode } from 'react'
 import { ClientAppBar } from './ClientAppBar'
 import styles from './CommonLayout.module.css'
@@ -11,11 +12,33 @@ export async function CommonLayout({ children }: CommonLayoutProps) {
   // In a Server Component, we can't directly access the URL path
   // We'll let the ClientAppBar handle path detection and project ID extraction
 
+  // Get the current user
+  const supabase = await createClient()
+  const { data: userData } = await supabase.auth.getUser()
+
+  // Get the user's name from the users table
+  let avatarInitial = 'L' // Default initial
+  if (userData?.user?.id) {
+    const { data: userDetails } = await supabase
+      .from('users')
+      .select('name')
+      .eq('id', userData.user.id)
+      .single()
+
+    // Extract the first initial from the user's name
+    if (userDetails?.name) {
+      avatarInitial = userDetails.name.charAt(0).toUpperCase()
+    }
+  }
+
   return (
     <div className={styles.layout}>
       <GlobalNav />
       <div className={styles.mainContent}>
-        <ClientAppBar avatarInitial="L" avatarColor="var(--color-teal-800)" />
+        <ClientAppBar
+          avatarInitial={avatarInitial}
+          avatarColor="var(--color-teal-800)"
+        />
         <main className={styles.content}>{children}</main>
       </div>
     </div>

--- a/frontend/apps/app/components/CommonLayout/CommonLayout.tsx
+++ b/frontend/apps/app/components/CommonLayout/CommonLayout.tsx
@@ -17,7 +17,7 @@ export async function CommonLayout({ children }: CommonLayoutProps) {
   const { data: userData } = await supabase.auth.getUser()
 
   // Get the user's name from the users table
-  let avatarInitial = 'L' // Default initial
+  let avatarInitial = ''
   if (userData?.user?.id) {
     const { data: userDetails } = await supabase
       .from('users')


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

In Avatar, initials that were temporarily displayed are now obtained from the current user.

![ss 3190](https://github.com/user-attachments/assets/189b7646-8d6c-440e-aeb9-be8e5b85c918)


## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
