### PR TITLE
🐛 Hide OrganizationItem in GlobalNav when no organizations exist instead of triggering notFound

### DIFF
--- a/frontend/apps/app/components/CommonLayout/CommonLayout.tsx
+++ b/frontend/apps/app/components/CommonLayout/CommonLayout.tsx
@@ -17,36 +17,24 @@ export async function CommonLayout({ children }: CommonLayoutProps) {
   // In a Server Component, we can't directly access the URL path
   // We'll let the ClientAppBar handle path detection and project ID extraction
   const organizationId = await getOrganizationId()
-  const { data: organization, error } = await getOrganization(organizationId)
+  const { data: organization } = await getOrganization(organizationId)
 
+  const { data: authUser, error } = await getAuthUser()
   if (error) {
     return notFound()
   }
 
-  const { data: authUser, error: authUserError } = await getAuthUser()
-
-  if (authUserError) {
-    return notFound()
-  }
-
-  const { data: organizations, error: organizationsError } =
-    await getOrganizationsByUserId(authUser.user.id)
-
-  if (organizationsError) {
-    return notFound()
-  }
+  const { data: organizations } = await getOrganizationsByUserId(
+    authUser.user.id,
+  )
 
   return (
     <div className={styles.layout}>
-      {organization && (
-        <>
-          <OrgCookie orgId={organization.id} />
-          <GlobalNav
-            currentOrganization={organization}
-            organizations={organizations}
-          />
-        </>
-      )}
+      {organization && <OrgCookie orgId={organization.id} />}
+      <GlobalNav
+        currentOrganization={organization}
+        organizations={organizations}
+      />
       <div className={styles.mainContent}>
         <ClientAppBar avatarInitial="L" avatarColor="var(--color-teal-800)" />
         <main className={styles.content}>{children}</main>

--- a/frontend/apps/app/components/CommonLayout/GlobalNav/GlobalNav.tsx
+++ b/frontend/apps/app/components/CommonLayout/GlobalNav/GlobalNav.tsx
@@ -4,14 +4,9 @@ import { LiamLogoMark, LiamMigrationLogo } from '@/logos'
 import { urlgen } from '@/utils/routes'
 import { LayoutGrid } from '@liam-hq/ui/src/icons'
 import clsx from 'clsx'
-import {
-  type ComponentProps,
-  type FC,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { type FC, useCallback, useEffect, useRef, useState } from 'react'
+import type { Organization } from '../services/getOrganization'
+import type { OrganizationsByUserId } from '../services/getOrganizationsByUserId'
 import styles from './GlobalNav.module.css'
 import itemStyles from './Item.module.css'
 import { LinkItem, type LinkItemProps } from './LinkItem'
@@ -26,10 +21,8 @@ const items: LinkItemProps[] = [
 ]
 
 type Props = {
-  currentOrganization: ComponentProps<
-    typeof OrganizationItem
-  >['currentOrganization']
-  organizations: ComponentProps<typeof OrganizationItem>['organizations']
+  currentOrganization: Organization | null
+  organizations: OrganizationsByUserId | null
 }
 
 export const GlobalNav: FC<Props> = ({
@@ -121,13 +114,15 @@ export const GlobalNav: FC<Props> = ({
         </div>
 
         <div className={styles.navSection}>
-          <OrganizationItem
-            isExpanded={isExpanded}
-            currentOrganization={currentOrganization}
-            organizations={organizations}
-            open={organizationMenuOpen}
-            onOpenChange={handleOrganizationMenuOpenChange}
-          />
+          {currentOrganization && (
+            <OrganizationItem
+              isExpanded={isExpanded}
+              currentOrganization={currentOrganization}
+              organizations={organizations ?? []}
+              open={organizationMenuOpen}
+              onOpenChange={handleOrganizationMenuOpenChange}
+            />
+          )}
 
           {items.map((item) => (
             <LinkItem


### PR DESCRIPTION
## Issue

N/A

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


A 404 error was occurring when accessing the `/organizations/new` page with no existing organizations.  

Since the `/organizations/new` page should still be accessible even when there are no organizations, I removed the conditional logic that returns the 404 error and fixed the issue by hiding the `OrganizationItem` in the `GlobalNav`.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

| Before | After |
|--------|--------|
| <img width="1241" alt="スクリーンショット 2025-04-24 20 41 12" src="https://github.com/user-attachments/assets/72d42c57-1237-4cf2-9d33-4f4565807c72" /> | <img width="1239" alt="スクリーンショット 2025-04-24 20 40 41" src="https://github.com/user-attachments/assets/f77c3ca2-7446-4f6c-86f0-17b14d88a69e" /> | 

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 3b8f0ce701ea0ef5cddc93b53228619b2a25b87a

- Prevent 404 error when no organizations exist
- Hide `OrganizationItem` in `GlobalNav` if no organizations
- Refactor error handling to allow `/organizations/new` access


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommonLayout.tsx</strong><dd><code>Refactor layout to avoid 404 and hide OrganizationItem</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/CommonLayout/CommonLayout.tsx

<li>Removed 404 error when no organizations exist<br> <li> Always render <code>GlobalNav</code>, hiding <code>OrganizationItem</code> if needed<br> <li> Simplified organization and organizations fetching logic


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1495/files#diff-6f6acdaa340a061452d00683078d451ff961a52b63b9b1f3d3cbf0bb7c3e8dda">+9/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GlobalNav.tsx</strong><dd><code>Conditionally render OrganizationItem in GlobalNav</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/CommonLayout/GlobalNav/GlobalNav.tsx

<li>Only render <code>OrganizationItem</code> if <code>currentOrganization</code> exists<br> <li> Pass empty array to <code>OrganizationItem</code> if no organizations<br> <li> Cleaned up props and imports for clarity


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1495/files#diff-7dfc4c65a9103b327fdcf5dd1e6bd86f0785782c9261504fe7f736264d1ea67c">+14/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>