### PR TITLE
Re-export createKnowledgeSuggestionTask

### DIFF
--- a/frontend/packages/jobs/src/trigger/jobs.ts
+++ b/frontend/packages/jobs/src/trigger/jobs.ts
@@ -89,7 +89,7 @@ export const generateSchemaOverrideSuggestionTask = task({
   },
 })
 
-const createKnowledgeSuggestionTask = task({
+export const createKnowledgeSuggestionTask = task({
   id: 'create-knowledge-suggestion',
   run: async (payload: {
     projectId: string

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -14,6 +14,8 @@
     "frontend/packages/db/supabase/database.types.ts",
     // - Script for workaround
     "frontend/apps/app/scripts/install-prisma-internals.mjs",
+    // - Script file which is read from trigger.config.ts
+    "frontend/packages/jobs/src/trigger/jobs.ts",
 
     // TODO: Temporarily ignore issues in the following files. Will be addressed later
     "frontend/packages/db-structure/src/parser.ts",


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

- After #1505,  `create-knowledge-suggestion` tasks become`pending version` . It seems that the function has not uploaded.
    -  <img width="677" alt="スクリーンショット 2025-04-25 21 12 18" src="https://github.com/user-attachments/assets/ffb7e250-d361-405d-bc5c-87c886b90a32" />
- I think re-exporting createKnowledgeSuggestionTask solves that.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->



- On the `main` branch:  
  - After running `$ pnpm --filter @liam-hq/jobs trigger:dev` locally and calling `create-knowledge-suggestion`, the job does **not** run.  
  - <img width="760" alt="1" src="https://github.com/user-attachments/assets/5de67a4b-1ba0-4c94-9d80-405c0caf9f40" />
- On this branch:  
  - `create-knowledge-suggestion` **runs**.


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 594b0b941b89532e62ce6cc0ab885f1d11078e91

- Re-exported `createKnowledgeSuggestionTask` for external usage
- Updated Knip config to ignore `jobs.ts` in analysis


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jobs.ts</strong><dd><code>Export createKnowledgeSuggestionTask for external access</code>&nbsp; </dd></summary>
<hr>

frontend/packages/jobs/src/trigger/jobs.ts

<li>Changed <code>createKnowledgeSuggestionTask</code> from internal to exported.<br> <li> Enables external modules to import and use this task.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1515/files#diff-2058cacc0f2a83e932ddde6ece0f30766b197a7f2d42b3506be73b24adf87c4c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>knip.jsonc</strong><dd><code>Update Knip config to ignore jobs.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

knip.jsonc

<li>Added <code>jobs.ts</code> to the ignore list for Knip analysis.<br> <li> Prevents false positives or unnecessary warnings for this file.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1515/files#diff-48d5ba4681726b42e98dae10c08bd94f7f9836644c8f183c6475d10dcf67ebf1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>