### PR TITLE
✨(organization): Add constraint to prevent deletion of last organization member

### DIFF
--- a/.ai-agents/memory-bank/activeContext.md
+++ b/.ai-agents/memory-bank/activeContext.md
@@ -129,6 +129,16 @@ The current focus is on enhancing the Reviewer User experience with AI-driven an
     - Updated all code references to use the new table name
     - This change provides a more consistent naming approach across the application
 
+15. **Implemented Organization Last Member Protection**: Added database-level constraint to prevent organizations from having zero members:
+
+    - Created a migration to add a BEFORE DELETE trigger on the "organization_members" table
+    - The trigger checks if the member being deleted is the last one in an organization
+    - If it is the last member, the trigger raises an exception to prevent deletion
+    - Enhanced the removeMember server action to handle the specific error and provide a user-friendly message
+    - Improved error handling throughout the application to properly display database error messages
+    - Added comprehensive test cases to verify the constraint works correctly in all scenarios
+    - This enhancement ensures data integrity by preventing organizations from becoming orphaned
+
 ## Next Steps
 
 1. **Enhance Supabase Implementation**:

--- a/.ai-agents/memory-bank/progress.md
+++ b/.ai-agents/memory-bank/progress.md
@@ -48,6 +48,11 @@
 - Improved type safety with proper type definitions and return types for functions.
 - Implemented relationship between overall_reviews and knowledge_suggestions tables using an intermediate mapping table (overall_review_knowledge_suggestion_mappings), allowing users to track and navigate to knowledge_suggestions from the MigrationDetailPage.
 - Enhanced MigrationDetailPage to fetch and display related knowledge_suggestions with proper navigation using the urlgen utility for type-safe route generation.
+- Implemented organization last member protection with a database-level constraint:
+  - Created a PostgreSQL trigger that prevents deleting the last member of an organization
+  - Enhanced error handling in the removeMember server action to provide clear error messages
+  - Added comprehensive test suite for the constraint to verify it works in all scenarios
+  - This ensures data integrity by preventing organizations from having zero members
 
 ## What's Left to Build
 

--- a/frontend/apps/app/features/organizations/actions/removeMember.ts
+++ b/frontend/apps/app/features/organizations/actions/removeMember.ts
@@ -38,7 +38,7 @@ export async function removeMember(formData: FormData) {
     console.error('Error removing organization member:', error)
     return {
       success: false,
-      error: 'Failed to remove member',
+      error: error?.message || 'Failed to remove member',
     }
   }
 

--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -336,6 +336,24 @@ $$;
 ALTER FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."prevent_delete_last_organization_member"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    AS $$
+BEGIN
+  -- Check if this is the last member in the organization
+  IF (SELECT COUNT(*) FROM organization_members WHERE organization_id = OLD.organization_id) <= 1 THEN
+    RAISE EXCEPTION 'Cannot remove the last member of an organization';
+  END IF;
+
+  -- If not the last member, allow the deletion
+  RETURN OLD;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."prevent_delete_last_organization_member"() OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "public"."set_knowledge_suggestions_organization_id"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
     AS $$
@@ -890,6 +908,14 @@ CREATE UNIQUE INDEX "schema_file_path_path_project_id_key" ON "public"."schema_f
 
 
 CREATE UNIQUE INDEX "schema_file_path_project_id_key" ON "public"."schema_file_paths" USING "btree" ("project_id");
+
+
+
+CREATE OR REPLACE TRIGGER "check_last_organization_member" BEFORE DELETE ON "public"."organization_members" FOR EACH ROW EXECUTE FUNCTION "public"."prevent_delete_last_organization_member"();
+
+
+
+COMMENT ON TRIGGER "check_last_organization_member" ON "public"."organization_members" IS 'Prevents deletion of the last member of an organization to ensure organizations always have at least one member';
 
 
 
@@ -1478,6 +1504,12 @@ GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "service_role";
 
 GRANT ALL ON FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."invite_organization_member"("p_email" "text", "p_organization_id" "uuid") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."prevent_delete_last_organization_member"() TO "anon";
+GRANT ALL ON FUNCTION "public"."prevent_delete_last_organization_member"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."prevent_delete_last_organization_member"() TO "service_role";
 
 
 

--- a/frontend/packages/db/supabase/migrations/20250428034646_prevent_delete_last_organization_member.sql
+++ b/frontend/packages/db/supabase/migrations/20250428034646_prevent_delete_last_organization_member.sql
@@ -1,0 +1,23 @@
+-- Create a function that will be called by the trigger
+CREATE OR REPLACE FUNCTION prevent_delete_last_organization_member()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Check if this is the last member in the organization
+  IF (SELECT COUNT(*) FROM organization_members WHERE organization_id = OLD.organization_id) <= 1 THEN
+    RAISE EXCEPTION 'Cannot remove the last member of an organization';
+  END IF;
+
+  -- If not the last member, allow the deletion
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger that calls the function before deletion
+CREATE TRIGGER check_last_organization_member
+BEFORE DELETE ON organization_members
+FOR EACH ROW
+EXECUTE FUNCTION prevent_delete_last_organization_member();
+
+-- Add a comment to explain the purpose of the trigger
+COMMENT ON TRIGGER check_last_organization_member ON organization_members
+IS 'Prevents deletion of the last member of an organization to ensure organizations always have at least one member';

--- a/frontend/packages/db/supabase/tests/database/02-prevent_delete_last_organization_member.test.sql
+++ b/frontend/packages/db/supabase/tests/database/02-prevent_delete_last_organization_member.test.sql
@@ -1,0 +1,74 @@
+-- Test file for prevent_delete_last_organization_member trigger
+BEGIN;
+
+-- Load the pgtap extension
+SELECT plan(3);
+
+-- Create test users and organization
+SELECT tests.create_supabase_user('owner@example.com', 'owner_user');
+SELECT tests.create_supabase_user('member1@example.com', 'member1_user');
+SELECT tests.create_supabase_user('member2@example.com', 'member2_user');
+
+-- Create test organization
+INSERT INTO organizations (id, name)
+VALUES ('22222222-2222-2222-2222-222222222222', 'Test Organization For Deletion')
+ON CONFLICT DO NOTHING;
+
+-- Store user IDs in temporary variables and add users to the organization
+DO $$
+DECLARE
+    v_owner_id uuid;
+    v_member1_id uuid;
+    v_member2_id uuid;
+    v_member1_org_id uuid;
+BEGIN
+    -- Get user IDs
+    SELECT tests.get_supabase_uid('owner@example.com') INTO v_owner_id;
+    SELECT tests.get_supabase_uid('member1@example.com') INTO v_member1_id;
+    SELECT tests.get_supabase_uid('member2@example.com') INTO v_member2_id;
+
+    -- Add members to the organization
+    INSERT INTO organization_members (id, user_id, organization_id)
+    VALUES
+      ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', v_owner_id, '22222222-2222-2222-2222-222222222222'),
+      ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', v_member1_id, '22222222-2222-2222-2222-222222222222'),
+      ('cccccccc-cccc-cccc-cccc-cccccccccccc', v_member2_id, '22222222-2222-2222-2222-222222222222')
+    ON CONFLICT DO NOTHING;
+
+    -- Save member1's organization member ID
+    SELECT id INTO v_member1_org_id FROM organization_members
+    WHERE user_id = v_member1_id AND organization_id = '22222222-2222-2222-2222-222222222222';
+END $$;
+
+-- Test 1: Successfully delete a member when not the last one
+SELECT lives_ok(
+    $$DELETE FROM organization_members WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'$$,
+    'Should successfully delete a member when they are not the last one'
+);
+
+-- Test 2: Verify there are still members after deleting one
+SELECT is(
+    (SELECT COUNT(*) FROM organization_members WHERE organization_id = '22222222-2222-2222-2222-222222222222'),
+    2::bigint,
+    'Should have two members remaining after deletion'
+);
+
+-- Test 3: Try to delete the last member (should fail)
+SELECT throws_ok(
+    $$
+    -- Delete the second to last member
+    DELETE FROM organization_members
+    WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' AND organization_id = '22222222-2222-2222-2222-222222222222';
+
+    -- This should fail when trying to delete the last member
+    DELETE FROM organization_members
+    WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc' AND organization_id = '22222222-2222-2222-2222-222222222222';
+    $$,
+    'Cannot remove the last member of an organization',
+    'Should prevent deletion of the last member of an organization'
+);
+
+-- Finish the tests and print a diagnostic count
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
Organizations should always have at least one member. In the current system, deleting the last member would leave an organization without any members. This change prevents the deletion of the last member of an organization, maintaining data integrity.

## What would you like reviewers to focus on?
- Is the database trigger implementation appropriate?
- Is the error message handling user-friendly?
- Is the test coverage sufficient?

## Testing Verification
- Implemented database tests to verify deletion when multiple members exist and behavior when attempting to delete the last member.
- Manually verified that error messages are properly displayed in the frontend.


https://github.com/user-attachments/assets/f9324646-a55a-404a-87c0-7b946b03fd2a



## What was done
### 🤖 Generated by PR Agent at 0b74e2859e3c468c99284847f67c31d264335883

- Added a database trigger to prevent deleting the last organization member
  - Ensures organizations always have at least one member
  - Raises a clear exception if deletion is attempted
- Enhanced server and frontend error handling for member removal
  - Surfaces database error messages to users
- Introduced comprehensive database-level tests for the new constraint
  - Verifies correct behavior for single and multiple member deletions
- Updated project documentation and progress logs to reflect the new protection


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20250428034646_prevent_delete_last_organization_member.sql</strong><dd><code>Add DB trigger to prevent deleting last organization member</code></dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250428034646_prevent_delete_last_organization_member.sql

<li>Added a PostgreSQL function and trigger to block deletion of the last <br>organization member<br> <li> Included a comment explaining the trigger's purpose


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1532/files#diff-d6859e2d74ee9be7c48fa8a82af3702226b5cdb7e0e985a12b5ae94d45838372">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>removeMember.ts</strong><dd><code>Enhance error handling in removeMember action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/organizations/actions/removeMember.ts

<li>Improved error handling to return specific database error messages<br> <li> Ensures user receives detailed feedback on failure


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1532/files#diff-877e78cc5bfb289b27a39b1fe4dfc337bff64ee1706629e51021fc64687232aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DeleteMemberModal.tsx</strong><dd><code>Show detailed error in DeleteMemberModal toast</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/organizations/pages/OrganizationMembersPage/DeleteMemberModal.tsx

<li>Updated toast error message to display specific error from backend<br> <li> Improves user feedback on deletion failure


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1532/files#diff-5b777e62b4767161444f542c10fc94d831abc8124a7f0a86a6b9b2508bade1a4">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>02-prevent_delete_last_organization_member.test.sql</strong><dd><code>Add database tests for last member deletion constraint</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/tests/database/02-prevent_delete_last_organization_member.test.sql

<li>Added pgtap tests for the last member deletion constraint<br> <li> Tests successful and failed deletions, including error message checks


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1532/files#diff-c07226282970bb8e5f359e20d46abb1900707121ab5b5aa58bc9c1a9e973d3e7">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>activeContext.md</strong><dd><code>Document organization last member protection in context</code>&nbsp; &nbsp; </dd></summary>
<hr>

.ai-agents/memory-bank/activeContext.md

<li>Documented the addition of the last member deletion protection<br> <li> Listed technical details and rationale for the change


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1532/files#diff-2de460a46443ae41e75eddf0c70ffb15eefad6ef7dd45dcd09b0e9174ca139de">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>progress.md</strong><dd><code>Update progress log for last member deletion constraint</code>&nbsp; &nbsp; </dd></summary>
<hr>

.ai-agents/memory-bank/progress.md

<li>Added progress notes on implementing last member protection<br> <li> Summarized technical approach and testing


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1532/files#diff-505de9ce6ac6ba1aa89e95499ccc7e5411922ff42aa1e465bd276cefc6fb3f26">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This PR is part of a series of improvements to enhance the robustness of the organization management functionality.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>