### PR TITLE
✨Set organization ID cookie upon successful organization creation

### DIFF
--- a/frontend/apps/app/features/organizations/pages/OrganizationNewPage/OrganizationNewPage.tsx
+++ b/frontend/apps/app/features/organizations/pages/OrganizationNewPage/OrganizationNewPage.tsx
@@ -5,6 +5,7 @@ import { Button, Input } from '@liam-hq/ui'
 import { useRouter } from 'next/navigation'
 import { type FC, type FormEvent, useState } from 'react'
 import { createOrganization } from '../../actions/createOrganizations'
+import { setOrganizationIdCookie } from '../../services/setOrganizationIdCookie'
 import styles from './OrganizationNewPage.module.css'
 
 export const OrganizationNewPage: FC = () => {
@@ -29,6 +30,8 @@ export const OrganizationNewPage: FC = () => {
     const result = await createOrganization(name)
 
     if (result.success) {
+      // Set the organization ID cookie before redirecting
+      await setOrganizationIdCookie(result.organizationId)
       router.push(urlgen('projects/new'))
     } else {
       setError(

--- a/frontend/apps/app/features/organizations/pages/OrganizationNewPage/OrganizationNewPage.tsx
+++ b/frontend/apps/app/features/organizations/pages/OrganizationNewPage/OrganizationNewPage.tsx
@@ -30,7 +30,7 @@ export const OrganizationNewPage: FC = () => {
     const result = await createOrganization(name)
 
     if (result.success) {
-      // Set the organization ID cookie before redirecting
+      // Set the organization ID cookie
       await setOrganizationIdCookie(result.organizationId)
       router.push(urlgen('projects/new'))
     } else {

--- a/frontend/apps/app/features/projects/pages/ProjectNewPage/InstallationSelector/InstallationSelector.tsx
+++ b/frontend/apps/app/features/projects/pages/ProjectNewPage/InstallationSelector/InstallationSelector.tsx
@@ -18,7 +18,7 @@ import styles from './InstallationSelector.module.css'
 
 type Props = {
   installations: Installation[]
-  organizationId?: string
+  organizationId: string
 }
 
 export const InstallationSelector: FC<Props> = ({
@@ -80,10 +80,7 @@ export const InstallationSelector: FC<Props> = ({
           'installationId',
           selectedInstallation?.id.toString() || '',
         )
-
-        if (organizationId) {
-          formData.set('organizationId', organizationId.toString())
-        }
+        formData.set('organizationId', organizationId.toString())
 
         await addProject(formData)
         // This point is not reached because a redirect occurs on success

--- a/frontend/apps/app/features/projects/pages/ProjectNewPage/ProjectNewPage.tsx
+++ b/frontend/apps/app/features/projects/pages/ProjectNewPage/ProjectNewPage.tsx
@@ -5,7 +5,7 @@ import styles from './ProjectNewPage.module.css'
 
 type Props = {
   installations: Installation[]
-  organizationId?: string
+  organizationId: string
 }
 
 export const ProjectNewPage: FC<Props> = ({


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

When creating a new organization in the OrganizationNewPage component, we need to set the organization ID in a cookie. Currently, the organization ID is set in the cookie when selecting an organization from the dropdown, but not when creating a new one. This change ensures consistency in user experience and smoother navigation after creating a new organization.

- console
  - <img width="291" alt="スクリーンショット 2025-04-28 13 17 43" src="https://github.com/user-attachments/assets/52c4e1d2-16b4-47dd-9518-f70c0fc8551d" />

- database
  - <img width="964" alt="スクリーンショット 2025-04-28 13 17 52" src="https://github.com/user-attachments/assets/13c95a6d-152d-4e4b-8dfe-6e90890d69db" />


## What would you like reviewers to focus on?
- Is the usage of the setOrganizationIdCookie function appropriate?



## Testing Verification
I verified this change in my local environment with the following steps:

1. Logged into the application
2. Clicked on "Create New Organization" button
3. Entered an organization name and created it
4. Confirmed the organization was created successfully and redirected to the project creation page
5. Checked browser cookies to confirm that organizationId was set with the ID of the newly created organization
6. Navigated to different pages and confirmed that the selected organization remained as the newly created one

This is a small but important improvement to maintain consistency in the user experience.

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 5e2c1c460c439153364b6a4a442e38af3fa89d89

- Set organization ID cookie after successful organization creation
- Ensure organization ID is always passed to project creation components
- Simplify organization ID handling in project creation workflow


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrganizationNewPage.tsx</strong><dd><code>Set organization ID cookie after creating organization</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/features/organizations/pages/OrganizationNewPage/OrganizationNewPage.tsx

<li>Import and use <code>setOrganizationIdCookie</code> after organization creation<br> <li> Set organization ID cookie before redirecting to project creation


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1533/files#diff-95100cba7b6e4bde3595837152d629ec3a6be4ddeca64f51b34170b6cebd2ced">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InstallationSelector.tsx</strong><dd><code>Require and always use organization ID in project creation</code></dd></summary>
<hr>

frontend/apps/app/features/projects/pages/ProjectNewPage/InstallationSelector/InstallationSelector.tsx

<li>Make <code>organizationId</code> prop required (remove optionality)<br> <li> Always set <code>organizationId</code> in form data for project creation<br> <li> Remove conditional check for <code>organizationId</code>


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1533/files#diff-e578beff1ae9dc4a406e9c379442f084b123a2ad7c68488dfdea89a61c7afebb">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProjectNewPage.tsx</strong><dd><code>Make organization ID a required prop for project creation</code></dd></summary>
<hr>

frontend/apps/app/features/projects/pages/ProjectNewPage/ProjectNewPage.tsx

- Make `organizationId` prop required instead of optional


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1533/files#diff-fa53cf45c85ffafde90c0474c59b9869e5f85aa320bb3e556de8d62ad0807488">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>