### PR TITLE
🐛 Fix frontend lint CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fmt:syncpack-format": "syncpack format",
     "fmt:turbo": "turbo fmt",
     "gen:turbo": "turbo gen",
-    "lint": "concurrently \"pnpm:lint:*\"",
+    "lint": "pnpm lint:turbo && pnpm lint:syncpack && pnpm lint:knip",
     "lint:knip": "knip",
     "lint:syncpack": "syncpack lint",
     "lint:turbo": "turbo lint",


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/actions/runs/14703913476/job/41259394426

## Why is this change needed?
Currently, in CI, there's a race condition between parallel lint scripts. The lint:knip job runs before lint:turbo completes type generation, resulting in 'unused export' errors.

## What would you like reviewers to focus on?
- Is the execution order of lint tasks appropriate?
- Are there any better ways to manage the build step dependencies?

## Testing Verification
Verified locally that running type generation and lint:knip sequentially resolves the errors.

## What was done

### 🤖 Generated by PR Agent at dd7ad9b64cb8fb2eb237e68aae92f453d22db543

- Fixes race condition in frontend lint CI by running lint scripts sequentially
- Ensures `lint:knip` runs after type generation from `lint:turbo`
- Improves reliability of linting process in CI environments


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Make lint scripts sequential to avoid CI race conditions</code>&nbsp; </dd></summary>
<hr>

package.json

<li>Changed <code>lint</code> script to run <code>lint:turbo</code>, <code>lint:syncpack</code>, and <code>lint:knip</code> <br>sequentially<br> <li> Replaced concurrent execution with chained commands to prevent race <br>conditions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1546/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
If additional CI job runs are needed, please let me know in the PR comments.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>