### PR TITLE
Add database seed script for local and preview environments

### DIFF
--- a/frontend/packages/db/supabase/seed.sql
+++ b/frontend/packages/db/supabase/seed.sql
@@ -1,0 +1,152 @@
+/*
+ * SEED.SQL - Database Initialization Script
+ * =========================================
+ *
+ * Purpose:
+ * This script populates the database with initial test data for local and preview environments.
+ * It is NOT intended for production use and should only be applied to development or testing databases.
+ *
+ * Environment Detection:
+ * - Automatically detects environment by checking server IP address (inet_server_addr())
+ * - Local environment: IP starts with '172.*' (typical for Docker Compose networks)
+ * - Preview environment: Any other IP address
+ *
+ * Key Features:
+ * - Creates immediately usable data for UI verification and testing
+ * - Provides a pre-configured test user with fixed credentials for easy login:
+ *   Email: test@example.com
+ *   Password: liampassword1234
+ *
+ * Installation ID Handling:
+ * - GitHub installation IDs differ between local and preview environments:
+ *   - Local environment: 63410913
+ *   - Preview environment: 63410962
+ * - The script automatically applies the appropriate ID based on detected environment
+ *
+ * Actions for Both Local and Preview Environments:
+ * 1. Creates a test user (test@example.com / liampassword1234)
+ * 2. Creates an organization (liam-hq)
+ * 3. Links the user to the organization
+ * 4. Creates a GitHub repository entry for liam-hq/liam with environment-specific installation ID
+ * 5. Creates a project named "liam"
+ * 6. Links the project to the repository
+ * 7. Sets up a schema file path pointing to the schema.sql file
+ */
+do $$
+declare
+  server_addr text := inet_server_addr()::text;
+  is_local boolean;
+
+  -- variables to store ids
+  v_installation_id integer;
+  v_org_id uuid;
+  v_user_id uuid;
+  v_repo_id uuid;
+  v_project_id uuid;
+begin
+  -- check if local environment (ipv4 address starting with 172.*)
+  -- this is typically the case for docker compose networks
+  is_local := server_addr like '172.%';
+  -- Set installation_id based on environment
+  v_installation_id := case when is_local then 63410913 else 63410962 end;
+
+  raise notice 'server address: %, environment: %',
+    server_addr,
+    case when is_local then 'local' else 'preview' end;
+
+  -- 1. create a single user
+  v_user_id := gen_random_uuid();
+  insert into auth.users
+    (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, recovery_sent_at, last_sign_in_at, raw_app_meta_data, raw_user_meta_data, created_at, updated_at, confirmation_token, email_change, email_change_token_new, recovery_token)
+  values
+    ('00000000-0000-0000-0000-000000000000', v_user_id, 'authenticated', 'authenticated', 'test@example.com', crypt('liampassword1234', gen_salt('bf')), now(), now(), now(), '{"provider":"email","providers":["email"]}', '{}', now(), now(), '', '', '', '');
+  insert into auth.identities (id, user_id, provider_id, identity_data, provider, last_sign_in_at, created_at, updated_at)
+  values
+    (gen_random_uuid(), v_user_id, v_user_id, format('{"sub":"%s","email":"%s"}', v_user_id::text, 'test@example.com')::jsonb, 'email', now(), now(), now());
+
+  -- 2. create a single organization
+  insert into public.organizations (id, name)
+  values
+    (gen_random_uuid(), 'liam-hq')
+  on conflict (id) do nothing
+  returning id into v_org_id;
+
+  -- 3. link user to organization (organization_members table)
+  insert into public.organization_members (user_id, organization_id)
+  values
+    (v_user_id, v_org_id)
+  on conflict (user_id, organization_id) do nothing;
+
+  -- 4. create a single github repository with environment-specific installation_id
+  insert into public.github_repositories (
+    name,
+    owner,
+    github_installation_identifier,
+    github_repository_identifier,
+    organization_id,
+    created_at,
+    updated_at
+  )
+  values (
+    'liam',
+    'liam-hq',
+    v_installation_id, -- Use the environment-specific installation_id
+    839216423, -- fixed repository_identifier for liam-hq/liam. `$ curl -s https://api.github.com/repos/liam-hq/liam | jq '.id'`
+    v_org_id,
+    current_timestamp,
+    current_timestamp
+  )
+  on conflict (github_repository_identifier, organization_id) do nothing
+  returning id into v_repo_id;
+
+  -- 5. create a single project
+  insert into public.projects (
+    name,
+    organization_id,
+    created_at,
+    updated_at
+  )
+  values (
+    'liam',
+    v_org_id,
+    current_timestamp,
+    current_timestamp
+  )
+  returning id into v_project_id;
+
+  -- 6. link project to repository
+  insert into public.project_repository_mappings (
+    project_id,
+    repository_id,
+    created_at,
+    updated_at
+  )
+  values (
+    v_project_id,
+    v_repo_id,
+    current_timestamp,
+    current_timestamp
+  )
+  on conflict (project_id, repository_id) do nothing;
+
+  -- 7. create a schema_file_path
+  insert into public.schema_file_paths (
+    project_id,
+    path,
+    format,
+    created_at,
+    updated_at
+  )
+  values (
+    v_project_id,
+    'frontend/packages/db/schema/schema.sql', -- liam's schema file path
+    'postgres', -- liam's schema file format
+    current_timestamp,
+    current_timestamp
+  );
+
+  raise notice 'environment: %, seeded database with test data.',
+    case when is_local then 'local' else 'preview' end;
+  raise notice 'test user created: test@example.com with password: liampassword1234';
+  raise notice 'using installation_id: %', v_installation_id;
+end $$;


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

- Populates the database with test data for both local and preview environments
- Automatically detects the environment and applies the appropriate GitHub installation ID
- Creates a test user with fixed credentials (test@example.com/liampassword1234)
- Sets up an organization, repository, project, and necessary mappings
- Enables immediate UI verification after seeding

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

( liam-hq member only now) 

click here https://github.com/liam-hq/liam/pull/1552#issuecomment-2840712589

<img width="773" alt="preview" src="https://github.com/user-attachments/assets/dc90f15d-46dd-4d47-b1f3-f07f131a7edd" />

make the flag enable 

<img width="548" alt="スクリーンショット 2025-04-30 12 38 28" src="https://github.com/user-attachments/assets/76f262f5-b2d8-4c4b-88e6-ad9a55c888bd" />

enter user with fixed credentials ( test@example.com / liampassword1234 )

<img width="478" alt="スクリーンショット 2025-04-30 12 45 02" src="https://github.com/user-attachments/assets/1bbfcca0-f5b8-429a-9a99-3b8e8a560af4" />


then you can see the ERD and play Chat 

<img width="1330" alt="スクリーンショット 2025-04-30 12 39 00" src="https://github.com/user-attachments/assets/a2e5de87-7e60-440f-a308-68a2efeb3e54" />


<img width="1329" alt="スクリーンショット 2025-04-30 12 39 07" src="https://github.com/user-attachments/assets/b1666ee9-2160-488d-bff0-930858694d65" />

<img width="1326" alt="スクリーンショット 2025-04-30 12 40 02" src="https://github.com/user-attachments/assets/1eaf4713-29d5-4bb2-9a8e-222ccc550887" />


<img width="1317" alt="スクリーンショット 2025-04-30 12 41 22" src="https://github.com/user-attachments/assets/0097e04d-f7ba-4bab-beb8-1338cd835eb2" />





## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 7d6cbebf9f552f4741c93e477fe55b6890eeafa9

- Adds a SQL seed script for local and preview environments
- Automatically detects environment and sets GitHub installation ID
- Creates test user, organization, repository, and project for testing
- Enables immediate UI verification with pre-configured data


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seed.sql</strong><dd><code>Add SQL seed script for local and preview environments</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/seed.sql

<li>Introduces a comprehensive SQL seed script for test data population<br> <li> Detects environment (local or preview) and sets installation ID <br>accordingly<br> <li> Creates test user, organization, repository, project, and related <br>mappings<br> <li> Provides notices for environment, test credentials, and installation <br>ID


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1552/files#diff-9482d70356b945f0202be6c0898d1a8f042b740a3accacdbf77a5ba2dbd5d4cc">+152/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>