### PR TITLE
Organization_id-retrieval-in-review-feedback-mappings

### DIFF
--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -527,23 +527,11 @@ CREATE OR REPLACE FUNCTION "public"."set_review_feedback_knowledge_suggestion_ma
     LANGUAGE "plpgsql" SECURITY DEFINER
     AS $$
 BEGIN
-  IF NEW.knowledge_suggestion_id IS NOT NULL THEN
-    NEW.organization_id := (
-      SELECT "organization_id" 
-      FROM "public"."knowledge_suggestions" 
-      WHERE "id" = NEW.knowledge_suggestion_id
-    );
-  ELSIF NEW.review_feedback_id IS NOT NULL THEN
-    NEW.organization_id := (
-      SELECT p."organization_id"
-      FROM "public"."review_feedbacks" rf
-      JOIN "public"."overall_reviews" orv ON rf."overall_review_id" = orv."id"
-      JOIN "public"."projects" p ON orv."project_id" = p."id"
-      WHERE rf."id" = NEW.review_feedback_id
-    );
-  ELSE
-    RAISE EXCEPTION 'Either knowledge_suggestion_id or review_feedback_id must be provided';
-  END IF;
+  NEW.organization_id := (
+    SELECT "organization_id" 
+    FROM "public"."knowledge_suggestions" 
+    WHERE "id" = NEW.knowledge_suggestion_id
+  );
   
   RETURN NEW;
 END;
@@ -814,7 +802,7 @@ CREATE TABLE IF NOT EXISTS "public"."review_feedback_knowledge_suggestion_mappin
     "knowledge_suggestion_id" "uuid",
     "created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     "updated_at" timestamp(3) with time zone NOT NULL,
-    "organization_id" "uuid" NOT NULL
+    "organization_id" "uuid"
 );
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -724,7 +724,7 @@ export type Database = {
           created_at: string
           id: string
           knowledge_suggestion_id: string | null
-          organization_id: string
+          organization_id: string | null
           review_feedback_id: string | null
           updated_at: string
         }
@@ -732,7 +732,7 @@ export type Database = {
           created_at?: string
           id?: string
           knowledge_suggestion_id?: string | null
-          organization_id: string
+          organization_id?: string | null
           review_feedback_id?: string | null
           updated_at: string
         }
@@ -740,7 +740,7 @@ export type Database = {
           created_at?: string
           id?: string
           knowledge_suggestion_id?: string | null
-          organization_id?: string
+          organization_id?: string | null
           review_feedback_id?: string | null
           updated_at?: string
         }

--- a/frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql
+++ b/frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql
@@ -10,8 +10,8 @@ SET "organization_id" = (
   LIMIT 1
 );
 
-ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
-  ALTER COLUMN "organization_id" SET NOT NULL;
+-- ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
+--   ALTER COLUMN "organization_id" SET NOT NULL;
 
 ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
   ADD CONSTRAINT "review_feedback_knowledge_suggestion_mappings_organization_id_fkey" 

--- a/frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql
+++ b/frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql
@@ -4,21 +4,10 @@ ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" ADD COLUMN 
 
 UPDATE "public"."review_feedback_knowledge_suggestion_mappings" rfksm
 SET "organization_id" = (
-  CASE
-    WHEN rfksm."knowledge_suggestion_id" IS NOT NULL THEN
-      (SELECT ks."organization_id"
-       FROM "public"."knowledge_suggestions" ks
-       WHERE ks."id" = rfksm."knowledge_suggestion_id"
-       LIMIT 1)
-    WHEN rfksm."review_feedback_id" IS NOT NULL THEN
-      (SELECT p."organization_id"
-       FROM "public"."review_feedbacks" rf
-       JOIN "public"."overall_reviews" orv ON rf."overall_review_id" = orv."id"
-       JOIN "public"."projects" p ON orv."project_id" = p."id"
-       WHERE rf."id" = rfksm."review_feedback_id"
-       LIMIT 1)
-    ELSE NULL
-  END
+  SELECT ks."organization_id"
+  FROM "public"."knowledge_suggestions" ks
+  WHERE ks."id" = rfksm."knowledge_suggestion_id"
+  LIMIT 1
 );
 
 ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
@@ -33,23 +22,11 @@ CREATE OR REPLACE FUNCTION "public"."set_review_feedback_knowledge_suggestion_ma
     LANGUAGE "plpgsql" SECURITY DEFINER
     AS $$
 BEGIN
-  IF NEW.knowledge_suggestion_id IS NOT NULL THEN
-    NEW.organization_id := (
-      SELECT "organization_id" 
-      FROM "public"."knowledge_suggestions" 
-      WHERE "id" = NEW.knowledge_suggestion_id
-    );
-  ELSIF NEW.review_feedback_id IS NOT NULL THEN
-    NEW.organization_id := (
-      SELECT p."organization_id"
-      FROM "public"."review_feedbacks" rf
-      JOIN "public"."overall_reviews" orv ON rf."overall_review_id" = orv."id"
-      JOIN "public"."projects" p ON orv."project_id" = p."id"
-      WHERE rf."id" = NEW.review_feedback_id
-    );
-  ELSE
-    RAISE EXCEPTION 'Either knowledge_suggestion_id or review_feedback_id must be provided';
-  END IF;
+  NEW.organization_id := (
+    SELECT "organization_id" 
+    FROM "public"."knowledge_suggestions" 
+    WHERE "id" = NEW.knowledge_suggestion_id
+  );
   
   RETURN NEW;
 END;


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

<img width="1268" alt="スクリーンショット_2025-04-30_19_10_01" src="https://github.com/user-attachments/assets/5d34430f-45f4-43fa-ba26-b54efaba0a18" />


The previous implementation attempted to enforce a `NOT NULL` constraint on the `organization_id` column of the `review_feedback_knowledge_suggestion_mappings` table. However, this led to failures in production due to legacy records missing either `knowledge_suggestion_id` or `review_feedback_id`.  
To fix this, we are removing the `NOT NULL` constraint and simplifying the trigger/function logic to avoid assumptions about data availability.

## What would you like reviewers to focus on?

- Confirm that relaxing the `NOT NULL` constraint aligns with downstream usage expectations.
- Review the updated trigger logic: we now assign `organization_id` solely based on `knowledge_suggestion_id`.
- Ensure the removal of fallback logic (via `review_feedback_id`) doesn't affect functionality.

## Testing Verification

- Ran migrations locally on a seeded database containing both legacy and new data.
- Verified no errors during migration and correct `organization_id` assignment from `knowledge_suggestions`.
- Tested new inserts and updates to confirm trigger behavior and policy enforcement remain intact.


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 3a747b9fb579cfecd93153850bdb07912fce4ca0

- Remove NOT NULL constraint from organization_id column
- Simplify organization_id assignment logic in triggers and migrations
- Update TypeScript types to reflect nullable organization_id
- Clean up legacy fallback logic for organization_id population


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.types.ts</strong><dd><code>Make organization_id nullable in TypeScript database types</code></dd></summary>
<hr>

frontend/packages/db/supabase/database.types.ts

<li>Changed organization_id to nullable in Row, Insert, and Update types<br> <li> Updated types to match new database schema allowing null <br>organization_id


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1558/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Simplify trigger and relax NOT NULL on organization_id</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Updated trigger function to assign organization_id only from <br>knowledge_suggestion_id<br> <li> Removed fallback and error logic for review_feedback_id<br> <li> Made organization_id column nullable in table definition


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1558/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+6/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql</strong><dd><code>Refactor migration and trigger for organization_id assignment</code></dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql

<li>Updated migration to assign organization_id only from <br>knowledge_suggestion_id<br> <li> Removed fallback logic using review_feedback_id<br> <li> Commented out NOT NULL constraint for organization_id<br> <li> Simplified trigger function for organization_id assignment


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1558/files#diff-fdedeaa2c3ccf86267166f104de6eabab6356a4c64dd567180af4241cc2cc0af">+11/-34</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>