### PR TITLE
Make organization_id field non-nullable in review_feedback_knowledge_suggestion_mappings

### DIFF
--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -802,7 +802,7 @@ CREATE TABLE IF NOT EXISTS "public"."review_feedback_knowledge_suggestion_mappin
     "knowledge_suggestion_id" "uuid",
     "created_at" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     "updated_at" timestamp(3) with time zone NOT NULL,
-    "organization_id" "uuid"
+    "organization_id" "uuid" NOT NULL
 );
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -724,7 +724,7 @@ export type Database = {
           created_at: string
           id: string
           knowledge_suggestion_id: string | null
-          organization_id: string | null
+          organization_id: string
           review_feedback_id: string | null
           updated_at: string
         }
@@ -732,7 +732,7 @@ export type Database = {
           created_at?: string
           id?: string
           knowledge_suggestion_id?: string | null
-          organization_id?: string | null
+          organization_id: string
           review_feedback_id?: string | null
           updated_at: string
         }
@@ -740,7 +740,7 @@ export type Database = {
           created_at?: string
           id?: string
           knowledge_suggestion_id?: string | null
-          organization_id?: string | null
+          organization_id?: string
           review_feedback_id?: string | null
           updated_at?: string
         }

--- a/frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql
+++ b/frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql
@@ -10,8 +10,8 @@ SET "organization_id" = (
   LIMIT 1
 );
 
--- ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
---   ALTER COLUMN "organization_id" SET NOT NULL;
+ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
+  ALTER COLUMN "organization_id" SET NOT NULL;
 
 ALTER TABLE "public"."review_feedback_knowledge_suggestion_mappings" 
   ADD CONSTRAINT "review_feedback_knowledge_suggestion_mappings_organization_id_fkey" 


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

Since the data migration for the `organization_id` column was successfully completed in https://github.com/liam-hq/liam/pull/1558, this PR re-enables the originally intended `NOT NULL` constraint on the column. This helps ensure data integrity and prevents unintended `null` values from being inserted.

## What would you like reviewers to focus on?

- Confirming that the `NOT NULL` constraint is correctly re-applied to the `organization_id` column  
- Verifying the updates to the Supabase type definitions (`database.types.ts`)  
- Ensuring the migration script correctly reflects the intended schema change (i.e., the constraint line is uncommented)

## Testing Verification

- Ran `supabase db reset` and `supabase db push` locally to confirm the migration applies successfully  
- Verified that insertions with `null` for `organization_id` now fail, and valid entries succeed as expected

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at f8ef0eaf2a4c6de81b53fcfc8c9bd5449e43c355

- Make `organization_id` non-nullable in `review_feedback_knowledge_suggestion_mappings`
- Update Supabase type definitions to reflect non-nullable field
- Apply NOT NULL constraint in schema and migration SQL


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.types.ts</strong><dd><code>Make organization_id non-nullable in Supabase type definitions</code></dd></summary>
<hr>

frontend/packages/db/supabase/database.types.ts

<li>Changed <code>organization_id</code> type from nullable to non-nullable in Row, <br>Insert, and Update types<br> <li> Ensured type definitions align with new schema constraints


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1559/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Enforce NOT NULL on organization_id in schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Added NOT NULL constraint to <code>organization_id</code> in table definition<br> <li> Updated schema to enforce data integrity at the database level


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1559/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql</strong><dd><code>Apply NOT NULL constraint in migration SQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250424000000_add_organization_id_to_review_feedback_knowledge_suggestion_mappings.sql

<li>Uncommented and enabled ALTER TABLE statement to set NOT NULL on <br><code>organization_id</code><br> <li> Ensured migration script applies the constraint as intended


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1559/files#diff-fdedeaa2c3ccf86267166f104de6eabab6356a4c64dd567180af4241cc2cc0af">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>