### PR TITLE
🐛(layout): Update parameter parsing in layout components to await params

### DIFF
--- a/frontend/apps/app/app/(app)/app/(with-project)/projects/[projectId]/layout.tsx
+++ b/frontend/apps/app/app/(app)/app/(with-project)/projects/[projectId]/layout.tsx
@@ -8,7 +8,7 @@ const paramsSchema = v.object({
 })
 
 export default async function Layout({ children, params }: LayoutProps) {
-  const parsedParams = v.safeParse(paramsSchema, params)
+  const parsedParams = v.safeParse(paramsSchema, await params)
   if (!parsedParams.success) {
     // TODO: Reconsider the display when parse fails
     return children

--- a/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/layout.tsx
+++ b/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/layout.tsx
@@ -11,7 +11,7 @@ const paramsSchema = v.object({
 })
 
 export default async function Layout({ params, children }: LayoutProps) {
-  const parsedParams = v.safeParse(paramsSchema, params)
+  const parsedParams = v.safeParse(paramsSchema, await params)
   if (!parsedParams.success) {
     // TODO: Reconsider the display when parse fails
     return children

--- a/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/page.tsx
+++ b/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/page.tsx
@@ -10,7 +10,7 @@ const paramsSchema = v.object({
 })
 
 export default async function Page({ params }: PageProps) {
-  const parsedParams = v.safeParse(paramsSchema, params)
+  const parsedParams = v.safeParse(paramsSchema, await params)
   if (!parsedParams.success) throw new Error('Invalid parameters')
 
   const { projectId, branchOrCommit } = parsedParams.output


### PR DESCRIPTION
## Issue

- Fixes NextJS warning about synchronous dynamic APIs

## Why is this change needed?
NextJS warns about using `params` without awaiting it first. This PR fixes the warning by properly awaiting the params object before accessing its properties.

The following warning was shown:
```
Error: Route "/app/projects/[projectId]/ref/[branchOrCommit]/schema-poc" used `params.projectId`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
```

## What would you like reviewers to focus on?
- Confirm this is the correct way to handle params in Next.js async layouts and pages

## Testing Verification
- Verified that the warning no longer appears
- Verified that the layout and routing functionality works as expected

## What was done
### 🤖 Generated by PR Agent at f52bbaf10865ca9ec255e015fd286f9e39a4ae9a

- Fix parameter parsing by awaiting `params` in layout and page components
- Resolve Next.js warning about synchronous dynamic API usage
- Ensure proper validation of route parameters in affected files


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Await params before parsing in project layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/(with-project)/projects/[projectId]/layout.tsx

<li>Await <code>params</code> before parsing in layout component<br> <li> Ensures parameter validation is performed on resolved params


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1572/files#diff-94c5aad1b83483092ceb4813246ea88011998978289f5982a39aa37d4db75efd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Await params before parsing in branch layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/layout.tsx

<li>Await <code>params</code> before parsing in layout component<br> <li> Fixes parameter validation for dynamic routes


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1572/files#diff-1920ffdbd4156ff5bf3eaacd170031339f5d310ea478891459696ba2a49e0d07">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Await params before parsing in branch page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/page.tsx

<li>Await <code>params</code> before parsing in page component<br> <li> Ensures error is thrown only after params are resolved and validated


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1572/files#diff-cae64e13e99f700e7548e6b9394ac5a3c690cccd7660b6dffb2aa358aa738905">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
None

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>