### PR TITLE
✨ Enhance the PostgreSQL parser to support Constraints

### DIFF
--- a/.changeset/olive-women-notice.md
+++ b/.changeset/olive-women-notice.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/db-structure": patch
+---
+
+✨ Enhance the postgresql parser to support Constraints

--- a/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
+++ b/frontend/packages/db-structure/src/parser/__snapshots__/index.test.ts.snap
@@ -40,7 +40,22 @@ exports[`parse > should parse postgresql to JSON correctly 1`] = `
         },
       },
       "comment": null,
-      "constraints": {},
+      "constraints": {
+        "PRIMARY_id": {
+          "columnName": "id",
+          "name": "PRIMARY_id",
+          "type": "PRIMARY KEY",
+        },
+        "users_id_to_posts_user_id": {
+          "columnName": "user_id",
+          "deleteConstraint": "NO_ACTION",
+          "name": "users_id_to_posts_user_id",
+          "targetColumnName": "id",
+          "targetTableName": "users",
+          "type": "FOREIGN KEY",
+          "updateConstraint": "NO_ACTION",
+        },
+      },
       "indexes": {},
       "name": "posts",
     },
@@ -88,7 +103,23 @@ exports[`parse > should parse postgresql to JSON correctly 1`] = `
         },
       },
       "comment": "store our users.",
-      "constraints": {},
+      "constraints": {
+        "PRIMARY_id": {
+          "columnName": "id",
+          "name": "PRIMARY_id",
+          "type": "PRIMARY KEY",
+        },
+        "UNIQUE_email": {
+          "columnName": "email",
+          "name": "UNIQUE_email",
+          "type": "UNIQUE",
+        },
+        "UNIQUE_username": {
+          "columnName": "username",
+          "name": "UNIQUE_username",
+          "type": "UNIQUE",
+        },
+      },
       "indexes": {
         "index_users_on_id_and_email": {
           "columns": [

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -203,6 +203,22 @@ describe(processor, () => {
           'users_id_to_posts_user_id',
         ),
       )
+      expect(value.tables['posts']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        users_id_to_posts_user_id: {
+          name: 'users_id_to_posts_user_id',
+          type: 'FOREIGN KEY',
+          columnName: 'user_id',
+          targetColumnName: 'id',
+          targetTableName: 'users',
+          updateConstraint: 'NO_ACTION',
+          deleteConstraint: 'NO_ACTION',
+        },
+      })
     })
 
     it('foreign key (one-to-one)', async () => {
@@ -217,6 +233,27 @@ describe(processor, () => {
       expect(value.relationships).toEqual(
         parserTestCases['foreign key (one-to-one)'](keyName),
       )
+      expect(value.tables['posts']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        UNIQUE_user_id: {
+          name: 'UNIQUE_user_id',
+          type: 'UNIQUE',
+          columnName: 'user_id',
+        },
+        users_id_to_posts_user_id: {
+          name: 'users_id_to_posts_user_id',
+          type: 'FOREIGN KEY',
+          columnName: 'user_id',
+          targetColumnName: 'id',
+          targetTableName: 'users',
+          updateConstraint: 'NO_ACTION',
+          deleteConstraint: 'NO_ACTION',
+        },
+      })
     })
   })
 
@@ -224,6 +261,11 @@ describe(processor, () => {
     it('foreign key (one-to-many)', async () => {
       const keyName = 'fk_posts_user_id'
       const { value } = await processor(/* sql */ `
+        CREATE TABLE posts (
+            id SERIAL PRIMARY KEY,
+            user_id INT NOT NULL
+        );
+
         ALTER TABLE posts
         ADD CONSTRAINT ${keyName} FOREIGN KEY (user_id) REFERENCES users(id);
       `)
@@ -231,6 +273,22 @@ describe(processor, () => {
       expect(value.relationships).toEqual(
         parserTestCases['foreign key (one-to-many)'](keyName),
       )
+      expect(value.tables['posts']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        fk_posts_user_id: {
+          name: 'fk_posts_user_id',
+          type: 'FOREIGN KEY',
+          columnName: 'user_id',
+          targetTableName: 'users',
+          targetColumnName: 'id',
+          updateConstraint: 'NO_ACTION',
+          deleteConstraint: 'NO_ACTION',
+        },
+      })
     })
 
     it('foreign key (one-to-one)', async () => {
@@ -248,6 +306,27 @@ describe(processor, () => {
       expect(value.relationships).toEqual(
         parserTestCases['foreign key (one-to-one)'](keyName),
       )
+      expect(value.tables['posts']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        UNIQUE_user_id: {
+          name: 'UNIQUE_user_id',
+          type: 'UNIQUE',
+          columnName: 'user_id',
+        },
+        users_id_to_posts_user_id: {
+          name: 'users_id_to_posts_user_id',
+          type: 'FOREIGN KEY',
+          columnName: 'user_id',
+          targetTableName: 'users',
+          targetColumnName: 'id',
+          updateConstraint: 'NO_ACTION',
+          deleteConstraint: 'NO_ACTION',
+        },
+      })
     })
 
     it('foreign key with action', async () => {
@@ -264,6 +343,22 @@ describe(processor, () => {
       expect(value.relationships).toEqual(
         parserTestCases['foreign key with action'],
       )
+      expect(value.tables['posts']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        fk_posts_user_id: {
+          name: 'fk_posts_user_id',
+          type: 'FOREIGN KEY',
+          columnName: 'user_id',
+          targetTableName: 'users',
+          targetColumnName: 'id',
+          updateConstraint: 'RESTRICT',
+          deleteConstraint: 'CASCADE',
+        },
+      })
     })
   })
 

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -255,6 +255,29 @@ describe(processor, () => {
         },
       })
     })
+
+    it('check constraint', async () => {
+      const { value } = await processor(/* sql */ `
+        CREATE TABLE products (
+            id SERIAL PRIMARY KEY,
+            name text,
+            price numeric CHECK (price > 0)
+        );
+      `)
+
+      expect(value.tables['products']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        CHECK_price: {
+          name: 'CHECK_price',
+          type: 'CHECK',
+          detail: 'CHECK (price > 0)',
+        },
+      })
+    })
   })
 
   describe('should parse ALTER TABLE statement correctly', () => {
@@ -357,6 +380,32 @@ describe(processor, () => {
           targetColumnName: 'id',
           updateConstraint: 'RESTRICT',
           deleteConstraint: 'CASCADE',
+        },
+      })
+    })
+
+    it('check constraint', async () => {
+      const { value } = await processor(/* sql */ `
+        CREATE TABLE products (
+            id SERIAL PRIMARY KEY,
+            name text,
+            price numeric
+        );
+
+        ALTER TABLE products
+        ADD CONSTRAINT price_check_is_positive CHECK (price > 0);
+      `)
+
+      expect(value.tables['products']?.constraints).toEqual({
+        PRIMARY_id: {
+          name: 'PRIMARY_id',
+          type: 'PRIMARY KEY',
+          columnName: 'id',
+        },
+        price_check_is_positive: {
+          name: 'price_check_is_positive',
+          type: 'CHECK',
+          detail: 'CHECK (price > 0)',
         },
       })
     })

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts
@@ -25,6 +25,14 @@ describe(processor, () => {
             ...override?.indexes,
           },
           comment: override?.comment ?? null,
+          constraints: {
+            ...override?.constraints,
+            PRIMARY_id: {
+              name: 'PRIMARY_id',
+              type: 'PRIMARY KEY',
+              columnName: 'id',
+            },
+          },
         }),
       },
     })
@@ -117,7 +125,24 @@ describe(processor, () => {
         );
       `)
 
-      expect(value).toEqual(parserTestCases.unique)
+      expect(value).toEqual(
+        userTable({
+          columns: {
+            mention: aColumn({
+              name: 'mention',
+              type: 'text',
+              unique: true,
+            }),
+          },
+          constraints: {
+            UNIQUE_mention: {
+              name: 'UNIQUE_mention',
+              type: 'UNIQUE',
+              columnName: 'mention',
+            },
+          },
+        }),
+      )
     })
 
     it('index (unique: false)', async () => {

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/index.ts
@@ -54,6 +54,7 @@ async function processChunk(
   chunk: string,
   schema: Schema,
   parseErrors: ProcessError[],
+  rawSql: string,
 ): Promise<[number | null, number | null, ProcessError[]]> {
   let readOffset: number | null = null
   let retryOffset: number | null = null
@@ -83,6 +84,7 @@ async function processChunk(
 
   const { value: convertedSchema, errors: conversionErrors } = convertToSchema(
     isLastStatementComplete ? parse_tree.stmts : parse_tree.stmts.slice(0, -1),
+    rawSql,
   )
 
   if (conversionErrors !== null) {
@@ -113,7 +115,7 @@ export const processor: Processor = async (sql: string) => {
   const parseErrors: ProcessError[] = []
 
   const errors = await processSQLInChunks(sql, CHUNK_SIZE, async (chunk) => {
-    return processChunk(chunk, schema, parseErrors)
+    return processChunk(chunk, schema, parseErrors, sql)
   })
 
   return { value: schema, errors: parseErrors.concat(errors) }


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

We introduced constraints of schema and update tbls and Prisma parser to support the feature.
This PR will update PostgreSQL parser to support constraints.


### ref
- introduce constraints and update tbls parser https://github.com/liam-hq/liam/pull/1168
- enhance Prisma parser https://github.com/liam-hq/liam/pull/1386
- enhance schema.rb parser https://github.com/liam-hq/liam/pull/1408

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- the constraints are parsed properly
  - The PostgreSQL parser will support "PRIMARY KEY", "FOREIGN KEY", "UNIQUE" and "CHECK" constraints.
- the tests are appropriate

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

- About the parser, I updated some test cases
- About the application, I checked the behaviour in the following steps
  1. copy the following schema and save on your local PC (that's a slight modified copy of [this file](https://github.com/liam-hq/liam/blob/4271e7b9af6f73e142678f73b3a7cd293f0a641b/frontend/packages/db-structure/src/parser/sql/input/postgresql_schema1.in.sql))
  2. run `pnpm run build --filter @liam-hq/cli` to build cli
  3. run `node frontend/packages/cli/dist-cli/bin/cli.js erd build --format postgres --input schema.in.sql` to generate scripts
  4. run `npx http-server dist` to run the application and go to http://localhost:8080/
  5. click "users" and "posts" tables and see the Constraints section of its table details

<details>
<summary>schema.in.sql</summary>

```
CREATE TABLE users (
  id SERIAL PRIMARY KEY,
  username VARCHAR(255) NOT NULL UNIQUE,
  email VARCHAR(255) NOT NULL UNIQUE CHECK (char_length(name) <= 255),
  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE posts (
  id SERIAL PRIMARY KEY,
  user_id INT REFERENCES users(id)
);

CREATE UNIQUE INDEX index_users_on_id_and_email ON public.users USING btree (id, email);
COMMENT ON TABLE users IS 'store our users.';
COMMENT ON COLUMN users.username IS 'user fullname.';
```

</details>

|users|posts|
|-|-|
|![Screenshot 0007-05-05 at 12 31 27](https://github.com/user-attachments/assets/b28bb233-9ebd-4115-9c16-8686cd5e9d33)|![Screenshot 0007-05-05 at 12 32 06](https://github.com/user-attachments/assets/b7110f8f-443f-4022-8232-8ddb36049176)|




## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 342d6e009505a29ce3b09e141ad5863338213297

- Add support for parsing PostgreSQL table constraints:
    - PRIMARY KEY, UNIQUE, FOREIGN KEY, and CHECK constraints now parsed.
    - Constraints are extracted from both column and table definitions.
- Update schema conversion logic to include constraints in table objects.
- Extend and enhance test coverage for constraint parsing.
- Update processor interface to pass raw SQL for CHECK constraint extraction.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter.ts</strong><dd><code>Add constraint extraction and storage to PostgreSQL schema converter</code></dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts

<li>Add logic to extract PRIMARY KEY, UNIQUE, FOREIGN KEY, and CHECK <br>constraints.<br> <li> Refactor relationship extraction to also return foreign key <br>constraints.<br> <li> Implement parsing of CHECK constraint expressions from raw SQL.<br> <li> Store constraints in the table schema output.<br> <li> Update index and ALTER TABLE handling to preserve constraints.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1587/files#diff-bae74cb1e5472bf6f333ebc48a79fe05fa5d0b74268d5cd067967896ef0f2cb8">+132/-44</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update processor to support raw SQL for constraint parsing</code></dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/index.ts

<li>Pass raw SQL to schema converter for CHECK constraint extraction.<br> <li> Update processor to accommodate new converter signature.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1587/files#diff-e947976bc36e479c39dfed57edcc5c82e7e189f08fe1bf6b4e7f4bffbc19aa04">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add and update tests for constraint parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/index.test.ts

<li>Add and update tests for PRIMARY KEY, UNIQUE, FOREIGN KEY, and CHECK <br>constraints.<br> <li> Assert that constraints are correctly parsed and included in output.<br> <li> Enhance test coverage for new constraint logic.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1587/files#diff-2ffdcf3d84e15e4ef7dd163c02f09c80bd750fb31b3effe125fc475c73bdf936">+81/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>olive-women-notice.md</strong><dd><code>Add changeset for PostgreSQL constraint support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/olive-women-notice.md

<li>Add changeset describing enhancement of PostgreSQL parser to support <br>constraints.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1587/files#diff-1951d54764740ab79f74d355c5714d1a6d3b10518bb5bc56e9ed7d6cf1ec44c4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>