### PR TITLE
✅️  feat(ci): post E2E test status manually using GitHub CLI

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -4,13 +4,16 @@ on:
   deployment_status:
 
 jobs:
-  e2e-tests:
+  _e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
         browser: [chromium, "Mobile Safari"]
       fail-fast: false
+    permissions:
+      contents: read
+      statuses: write
     defaults:
       run:
         working-directory: "frontend/packages/e2e"
@@ -40,7 +43,7 @@ jobs:
               if (environment_val.include?("Production") && target_url.include?("liam-app-git-main"))
                 "should_run=true"
               # Preview deployment
-              elsif environment_val.include?("Preview") && !target_url.include?("liam-erd-sample") && !target_url.include?("liam-docs")
+              elsif environment_val.include?("Preview") && !target_url.include?("liam-erd-sample") && !target_url.include?("liam-docs") && !target_url.include?("liam-storybook")
                 "should_run=true"
               else
                 "should_run=false"
@@ -94,6 +97,20 @@ jobs:
           name: test-results-${{ matrix.browser }}
           path: frontend/packages/e2e/test-results/
           retention-days: 30
+
+      - name: Post E2E status manually (with gh)
+        if: steps.check.outputs.should_run == 'true' && always()
+        run: |
+          STATE="${{ job.status }}"
+          CONTEXT="E2E Tests / e2e-tests (${{ matrix.browser }})"
+          gh api repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            --method POST \
+            --field state="${STATE}" \
+            --field context="${CONTEXT}" \
+            --field description="E2E test result for ${{ matrix.browser }}: (${STATE})" \
+            --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Slack Notification on Failure
         if: ${{ steps.check.outputs.should_run == 'true' && env.ENVIRONMENT == 'Production – liam-app' && failure() }}


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

 E2E Test Status: Improving the Reliability of PR Check Results

## 🔴 The Problem

We were triggering E2E tests using the `deployment_status` event from Supabase or Vercel, but the following issue occurred:

### What Was Happening

- Multiple `deployment_status` events were triggered for a single PR (e.g., for `liam-app`, `liam-docs`)
- Every event triggered the `e2e-tests.yml` workflow
- Deployments that shouldn't run tests were skipped via `should_run=false`
- However, GitHub would still automatically mark these skipped jobs with a `success` status
- As a result, even if an earlier test failed, a later skipped job could overwrite it with `success`, making the PR appear to have passed

<p>Example:</p>
<ol>
<li>
<p>Deployment for liam-app → E2E tests run → ❌ fail</p>
</li>
<li>
<p>Deployment for liam-docs → should_run=false → ✅ success (automatically marked)</p>
</li>
</ol>
<p>Result: GitHub treats the PR check as passed.</p>

## ✅ The Solution

### Policy

- Ignore GitHub’s automatic job status
- Manually post status updates using GitHub CLI (`gh`), but **only when `should_run=true`**
- Use different `context` values for each browser in `matrix.browser` to clearly separate test results

### Example: Manual Status Update

Add the following step to `e2e-tests.yml`:


```yaml
- name: Post E2E status manually (with gh)
  if: steps.check.outputs.should_run == 'true' &amp;&amp; always()
  run: |
    STATE="${GITHUB_JOB_STATUS:-success}"
    CONTEXT="e2e-tests (${MATRIX_BROWSER})"

    gh api repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA} \
      --method POST \
      --field state="$STATE" \
      --field context="$CONTEXT" \
      --field description="E2E result for ${MATRIX_BROWSER}: $STATE" \
      --field target_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```


<p><em>Note: <code inline="">${{ ... }}</code> has been replaced with <code inline="">${...}</code> to avoid being interpreted by Markdown renderers.</em></p>
<hr>
<h2>💡 Benefits</h2>

Item | Before | After
-- | -- | --
When statuses are sent | Automatically for all jobs | Only when should_run=true
Risk of status overwrite | Last job overwrites the rest | Only one intentional status is sent
Browser-specific results | Combined in a single check | Separated (e.g., e2e-tests (chromium))
False positive PR statuses | Possible | Avoided by not sending for skipped jobs


<hr>
<h2>✅ Conclusion</h2>
<p>With this improvement, we achieve:</p>
<ul>
<li>
<p>Only deployments that actually need testing send status updates</p>
</li>
<li>
<p>Results for each browser are visible separately</p>
</li>
<li>
<p>False positives due to skipped jobs marking <code inline="">success</code> are eliminated</p>
</li>
</ul>


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at dfc5873d4f376d8bc2b3b26a67ddd7abe9737ac9

- Renamed E2E test job to prevent automatic PR check status.
- Added manual E2E test status posting using GitHub CLI.
- Set permissions for status API and increased job timeout.
- Included browser context in status for clearer reporting.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_tests.yml</strong><dd><code>Manual E2E test status posting and workflow improvements</code>&nbsp; </dd></summary>
<hr>

.github/workflows/e2e_tests.yml

<li>Renamed job from <code>e2e-tests</code> to <code>_e2e-tests</code> to avoid automatic PR check <br>status.<br> <li> Increased job timeout from 10 to 15 minutes.<br> <li> Added <code>permissions: statuses: write</code> for manual status posting.<br> <li> Introduced a new step to post E2E test status manually via <code>gh api</code>, <br>including browser context.<br> <li> Ensured status is only posted when <code>should_run</code> is true, and always <br>posts regardless of test outcome.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1600/files#diff-37aed4ad4a8c3a4220c5e3c2eee33093073b8d64f480cc742b63764c859b6c72">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>