### PR TITLE
🔧 Fix import path for langfuseWeb in Storybook configuration

### DIFF
--- a/frontend/internal-packages/storybook/.storybook/main.ts
+++ b/frontend/internal-packages/storybook/.storybook/main.ts
@@ -23,9 +23,12 @@ const config: StorybookConfig = {
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
-        '@': path.resolve(__dirname, '../'),
+        '@': path.resolve(__dirname, '../../../apps/app'),
         // Redirect imports of langfuseWeb to our mock implementation
-        '../../../apps/app/lib/langfuseWeb': path.resolve(__dirname, './langfuseWeb.mock.ts'),
+        '@/libs/langfuse/langfuseWeb': path.resolve(
+          __dirname,
+          './langfuseWeb.mock.ts',
+        ),
       }
     }
     return config


### PR DESCRIPTION

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

Fixed the import path for `lib/langfuse` to the correct one, as the Storybook build started failing due to its location being changed in #1626.


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
