### PR TITLE
Now `notify_supabase_failure.yml` reports only main branch

### DIFF
--- a/.github/workflows/notify_supabase_failure.yml
+++ b/.github/workflows/notify_supabase_failure.yml
@@ -7,8 +7,7 @@ on:
 jobs:
   notify_slack:
     runs-on: ubuntu-latest
-    if: github.event.check_suite.app.name == 'Supabase' && github.event.check_suite.conclusion == 'failure'
-    # TODO: Add github.event.check_suite.head_branch == 'main'
+    if: github.event.check_suite.app.name == 'Supabase' && github.event.check_suite.conclusion == 'failure' && github.event.check_suite.head_branch == 'main'
     steps:
       - name: Slack Notification for Supabase Failure
         uses: tokorom/action-slack-incoming-webhook@d57bf1eb618f3dae9509afefa70d5774ad3d42bf # v1.3.0


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 2169bbb25282b4b7e69abc8b7b28eca7f894723a

- Restricts Supabase failure Slack notifications to `main` branch only
- Updates workflow condition for more targeted alerts


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notify_supabase_failure.yml</strong><dd><code>Restrict Supabase failure notifications to main branch</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/notify_supabase_failure.yml

<li>Adds <code>head_branch == 'main'</code> to workflow condition<br> <li> Ensures Slack notifications trigger only for main branch failures<br> <li> Removes outdated TODO comment


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1638/files#diff-00b20d327dbe992dd91e14e588fa830092e005f67fa5adf0da3636155a6d5d82">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>