### PR TITLE
Classification of ask and build agents

### DIFF
--- a/frontend/apps/app/app/api/chat/route.ts
+++ b/frontend/apps/app/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { mastra } from '@/lib/mastra'
+import { classifyQuestion } from '@/lib/mastra/agents'
 import {
   processAndStoreSchema,
   querySchemaVectorStore,
@@ -196,8 +197,13 @@ export async function POST(request: Request) {
 
   // Variables for agent selection and relevant schema
   let relevantSchemaText = ''
-  // Always use the same agent, regardless of RAG
-  const agentName = 'databaseSchemaAgent'
+
+  // Determine which agent to use based on the question type
+  const questionType = classifyQuestion(message)
+  const agentName =
+    questionType === 'build'
+      ? 'databaseSchemaBuildAgent'
+      : 'databaseSchemaAskAgent'
 
   // Process RAG if needed
   if (useRAG) {

--- a/frontend/apps/app/lib/mastra/agents/databaseSchemaAskAgent.ts
+++ b/frontend/apps/app/lib/mastra/agents/databaseSchemaAskAgent.ts
@@ -1,0 +1,34 @@
+import { openai } from '@ai-sdk/openai'
+import type { Metric } from '@mastra/core'
+import { Agent, type ToolsInput } from '@mastra/core/agent'
+
+export const databaseSchemaAskAgent: Agent<
+  'Database Schema Expert (Ask)',
+  ToolsInput,
+  Record<string, Metric>
+> = new Agent({
+  name: 'Database Schema Expert (Ask)',
+  instructions: `
+You are Ask Agent, a friendly and knowledgeable senior engineer specializing in database design.
+Your role is to answer user questions clearly and accurately while fostering understanding.
+You speak in a polite yet approachable tone ("desu/masu" style in Japanese), and often use analogies and examples to explain difficult concepts.
+
+Your personality is warm, encouraging, and collaborative — you often say things like “That’s a great question!” or “Let’s think through it together.”  
+Avoid technical jargon unless you explain it simply.
+
+Your communication should embody the qualities of clarity, friendliness, and insight, like a yellow sun gently illuminating knowledge.
+
+Do:
+  - Use simple, relatable analogies (e.g., “That’s like putting dishes and food in the same drawer.”)
+  - Use phrases like “It might be helpful to...”, “Shall we try...?”, or “You could consider...”
+  - Encourage curiosity: “Would you like to dive deeper into this topic?”
+
+Don’t:
+  - Be overly assertive (“You must do...”, “This is wrong”)
+  - Use unexplained technical terms or overwhelming detail
+
+When in doubt, prioritize kindness, clarity, and shared discovery.
+
+`,
+  model: openai('o4-mini-2025-04-16'),
+})

--- a/frontend/apps/app/lib/mastra/agents/databaseSchemaBuildAgent.ts
+++ b/frontend/apps/app/lib/mastra/agents/databaseSchemaBuildAgent.ts
@@ -1,0 +1,35 @@
+import { openai } from '@ai-sdk/openai'
+import type { Metric } from '@mastra/core'
+import { Agent, type ToolsInput } from '@mastra/core/agent'
+
+export const databaseSchemaBuildAgent: Agent<
+  'Database Schema Expert (Build)',
+  ToolsInput,
+  Record<string, Metric>
+> = new Agent({
+  name: 'Database Schema Expert (Build)',
+  instructions: `
+You are Build Agent, an energetic and innovative system designer who builds and edits ERDs with lightning speed.
+Your role is to execute user instructions immediately and offer smart suggestions for schema improvements.
+You speak in a lively, action-oriented tone (“desu/masu” style in Japanese), showing momentum and confidence.
+
+Your personality is bold, constructive, and enthusiastic — like a master architect in a hardhat, ready to build.
+You say things like “Done!”, “You can now...”, and “Shall we move to the next step?”.
+
+Your communication should feel fast, fresh, and forward-moving, like a green plant constantly growing.
+
+Do:
+  - Confirm execution quickly: “Added!”, “Created!”, “Linked!”
+  - Propose the next steps: “Would you like to add an index?”, “Let’s relate this to the User table too!”
+  - Emphasize benefits: “This makes tracking updates easier.”
+
+Don’t:
+  - Hesitate (“Maybe”, “We’ll have to check...”)
+  - Use long, uncertain explanations
+  - Get stuck in abstract talk — focus on action and outcomes
+
+When in doubt, prioritize momentum, simplicity, and clear results.
+
+`,
+  model: openai('o4-mini-2025-04-16'),
+})

--- a/frontend/apps/app/lib/mastra/agents/index.ts
+++ b/frontend/apps/app/lib/mastra/agents/index.ts
@@ -1,1 +1,4 @@
 export { databaseSchemaAgent } from './databaseSchemaAgent'
+export { databaseSchemaAskAgent } from './databaseSchemaAskAgent'
+export { databaseSchemaBuildAgent } from './databaseSchemaBuildAgent'
+export { classifyQuestion } from './utils/questionClassifier'

--- a/frontend/apps/app/lib/mastra/agents/utils/questionClassifier.ts
+++ b/frontend/apps/app/lib/mastra/agents/utils/questionClassifier.ts
@@ -1,0 +1,50 @@
+/**
+ * Classifies a user question as either an "Ask" or "Build" type question
+ * for database schema-related queries.
+ *
+ * - "Ask" questions are about explaining, understanding, or querying existing schemas
+ * - "Build" questions are about designing, creating, or optimizing schemas
+ *
+ * @param question The user's question text
+ * @returns 'ask' or 'build' based on the classification
+ */
+type QuestionType = 'ask' | 'build'
+
+export function classifyQuestion(question: string): QuestionType {
+  const normalizedQuestion = question.toLowerCase().trim()
+
+  // Keywords that indicate a "Build" question
+  const buildKeywords = [
+    'design',
+    'create',
+    'build',
+    'optimize',
+    'improve',
+    'suggest',
+    'recommend',
+    'implement',
+    'structure',
+    'architect',
+    'best practice',
+    'best way',
+    'how should i',
+    'how would you',
+    'what is the best',
+    'how to design',
+    'how to structure',
+    'how to implement',
+    'how to model',
+    'how to represent',
+    'how to organize',
+  ]
+
+  // Check if the question contains any build keywords
+  for (const keyword of buildKeywords) {
+    if (normalizedQuestion.includes(keyword)) {
+      return 'build'
+    }
+  }
+
+  // Default to "Ask" if no build keywords are found
+  return 'ask'
+}

--- a/frontend/apps/app/lib/mastra/index.ts
+++ b/frontend/apps/app/lib/mastra/index.ts
@@ -1,6 +1,10 @@
 import { Mastra } from '@mastra/core'
 import { LangfuseExporter } from 'langfuse-vercel'
-import { databaseSchemaAgent } from './agents'
+import {
+  databaseSchemaAgent,
+  databaseSchemaAskAgent,
+  databaseSchemaBuildAgent,
+} from './agents'
 /**
  * Mastra instance with Langfuse tracing integration
  *
@@ -11,6 +15,8 @@ import { databaseSchemaAgent } from './agents'
 export const mastra = new Mastra({
   agents: {
     databaseSchemaAgent,
+    databaseSchemaAskAgent,
+    databaseSchemaBuildAgent,
   },
   telemetry: {
     serviceName: 'ai', // Must match ATTR_SERVICE_NAME in instrumentation.ts


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This PR implements a dual-agent system for database schema interactions, splitting functionality between an "Ask" agent for answering questions and a "Build" agent for design recommendations. The system uses a classifyQuestion function that analyzes user queries for specific keywords to dynamically route questions to the appropriate specialized agent.

```mermaid
flowchart TD
    A[User Question] --> B{classifyQuestion}
    
    B -->|"Contains: design, create, build,<br>optimize, improve, suggest,<br>recommend, how should I..."| C[databaseSchemaBuildAgent]
    
    B -->|"No build keywords found<br>(defaults to Ask)"| D[databaseSchemaAskAgent]
    
    C --> E[Generate Build Response]
    D --> F[Generate Ask Response]
    
    E --> G[Return Response to User]
    F --> G
    
    style C fill:#a0d8a0,stroke:#178217,color:#000
    style D fill:#a0c8f0,stroke:#1762d8,color:#000
    style B fill:#f5f5a0,stroke:#d8d817,color:#000
```

⚠️ I have not implemented the part where the ask agent and build agent switch on the UI.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

✅ Personality check

### Ask Agent
I asked `What is the purpose of the Users table in our database?`

Agents are now more attentive to explain the process.

![ss 3308](https://github.com/user-attachments/assets/3e1f9444-6b6d-4300-b780-3ee3f13a5b42)

### Build Agent
I asked `What is the best schema design for a notification system?`

Build agents are focused on the build and are able to respond energetically to prompts.
![ss 3306](https://github.com/user-attachments/assets/77e4878f-b03f-4db7-8af6-4286f4ec9fb4)

![ss 3307](https://github.com/user-attachments/assets/c99c90f1-c233-4c11-8913-53d52b52a536)

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
