### PR TITLE
🔧 chore: modify VSCode settings for Biome

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["bierner.comment-tagged-templates"]
+  "recommendations": ["bierner.comment-tagged-templates", "biomejs.biome"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,9 @@
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "[mdx]": {
     "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

With the current VSCode settings (.vscode/settings.json), JSONC files are formatted by [the Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), which insert trailing commas by default ([see this issue for the details](https://github.com/prettier/prettier/issues/15956)). However, JSONC files are checked by Biome when `lint:biome` script is executed.

<img width="964" alt="Screenshot 0007-05-20 at 21 24 42" src="https://github.com/user-attachments/assets/3d935dc4-684a-4f9d-96ca-a407643ae15c" />

*With the current settings, it inserts unexpected trailing commas in JSONC files (frontend/packages/db-structure/biome.jsonc in this example)*


This PR will update the default JSONC formatter in VSCode to Biome to resolve this conflict. Also, it will add the Biome VSCode extension as a recommended extension to make the setup easier.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- the formatter of JSONC files is appropriate

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 52f64bca2ae4c58a22fed0fca1abdb91acecff95

- Set Biome as the default formatter for JSONC files in VSCode.
- Add Biome VSCode extension to recommended extensions.
- Aligns formatting tools with project linting requirements.


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Set Biome as default formatter for JSONC files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/settings.json

<li>Added Biome as the default formatter for JSONC files.<br> <li> Ensures JSONC formatting is consistent with Biome linting.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1722/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extensions.json</strong><dd><code>Recommend Biome VSCode extension for setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/extensions.json

<li>Added Biome VSCode extension to recommendations.<br> <li> Helps users set up Biome formatting easily.


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1722/files#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>