### PR TITLE
🔧 chore: modify complexity threshold of db-structure package

### DIFF
--- a/frontend/packages/db-structure/biome.jsonc
+++ b/frontend/packages/db-structure/biome.jsonc
@@ -20,6 +20,13 @@
             }
           }
         }
+      },
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "options": {
+            "maxAllowedComplexity": 20
+          }
+        }
       }
     }
   }

--- a/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
+++ b/frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts
@@ -311,7 +311,6 @@ export const convertToSchema = (
     comment: string | null
   }
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: <explanation>
   function processRelationshipsAndConstraints(
     tableName: string,
     columnName: string,


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/pull/1587#discussion_r2083677394

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

As we discussed in the thread, the parser logic can be more complex than the codes of the other packages. This PR will relaxing threshold, 15 to 20, to allow a bit more complex code.

I don't have a strong opinion about the magic number 20, just a bit greater than the previous value of 15.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- check if the new threshold is suitable

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at eef8bc64b9f176a3d94a162046a9b6465ff924ad

- Increase cognitive complexity threshold for `db-structure` package to 20
- Update Biome linter configuration to reflect new threshold
- Remove local ignore comment for complexity rule in parser file


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>biome.jsonc</strong><dd><code>Increase cognitive complexity threshold in Biome config</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/biome.jsonc

<li>Added <code>complexity.noExcessiveCognitiveComplexity</code> rule with <br><code>maxAllowedComplexity</code> set to 20<br> <li> Set rule level to <code>warn</code> for excessive cognitive complexity


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1723/files#diff-0c801d1916d8058600fe618eee61bd34a93d542f3668a969b37f0bd7bded8bae">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter.ts</strong><dd><code>Remove local complexity ignore comment from parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/sql/postgresql/converter.ts

<li>Removed local ignore comment for <code>noExcessiveCognitiveComplexity</code> rule


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1723/files#diff-bae74cb1e5472bf6f333ebc48a79fe05fa5d0b74268d5cd067967896ef0f2cb8">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

It looks Biome VSCode extension doesn't support monorepo. It shows a warning with the code while CLI doesn't produce it. It looks the extension refers to the root config file (./biome.jsonc) rather than the config files of the packages (like ./frontend/packages/db-structure/biome.jsonc). At the moment, [it looks monorepo is not supported yet](https://github.com/biomejs/biome-vscode/discussions/38)

<img width="927" alt="Screenshot 0007-05-20 at 21 53 03" src="https://github.com/user-attachments/assets/c528464d-6dbf-4732-8888-fbc00dc8d5b0" />



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>