### PR TITLE
chore: add unique constraint on design_session_id in building_schemas

### DIFF
--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -1138,6 +1138,11 @@ ALTER TABLE ONLY "public"."building_schema_versions"
 
 
 ALTER TABLE ONLY "public"."building_schemas"
+    ADD CONSTRAINT "building_schemas_design_session_id_key" UNIQUE ("design_session_id");
+
+
+
+ALTER TABLE ONLY "public"."building_schemas"
     ADD CONSTRAINT "building_schemas_pkey" PRIMARY KEY ("id");
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -105,7 +105,7 @@ export type Database = {
           {
             foreignKeyName: 'building_schemas_design_session_id_fkey'
             columns: ['design_session_id']
-            isOneToOne: false
+            isOneToOne: true
             referencedRelation: 'design_sessions'
             referencedColumns: ['id']
           },

--- a/frontend/packages/db/supabase/migrations/20250521190001_add_unique_constraint_to_building_schemas.sql
+++ b/frontend/packages/db/supabase/migrations/20250521190001_add_unique_constraint_to_building_schemas.sql
@@ -1,0 +1,5 @@
+begin;
+
+alter table public.building_schemas add constraint building_schemas_design_session_id_key unique (design_session_id);
+
+commit;


### PR DESCRIPTION
## Issue


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I want to add unique constraint on design_session_id in building_schemas. this should be `has_one` relationship

- Enforce one-to-one relationship between building_schemas and design_sessions
- Update Supabase types to reflect isOneToOne: true
- Add migration to apply unique constraint

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 78709155a1b5cdefe283ec302d2b4764553c9a4e

- Enforce one-to-one relationship between `building_schemas` and `design_sessions`
  - Add unique constraint on `design_session_id` in `building_schemas`
  - Update Supabase types to reflect one-to-one relationship
  - Add migration for unique constraint enforcement


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.types.ts</strong><dd><code>Update Supabase types for one-to-one relationship</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/database.types.ts

<li>Set <code>isOneToOne: true</code> for <code>design_session_id</code> foreign key in <br><code>building_schemas</code><br> <li> Reflects new one-to-one relationship in Supabase types


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1732/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Add unique constraint to building_schemas schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Add unique constraint on <code>design_session_id</code> in <code>building_schemas</code><br> <li> Ensures one-to-one mapping at the schema level


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1732/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250521190001_add_unique_constraint_to_building_schemas.sql</strong><dd><code>Migration for unique constraint on design_session_id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250521190001_add_unique_constraint_to_building_schemas.sql

<li>New migration to add unique constraint on <code>design_session_id</code><br> <li> Ensures database enforces one-to-one relationship


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1732/files#diff-a9c940c455f7a4b8779cc45e131aeb501a2169e40a24ba601a2d44038672789c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>