### PR TITLE
feat: add RPC function for transactional schema updates with versioning

### DIFF
--- a/frontend/packages/db/schema/schema.sql
+++ b/frontend/packages/db/schema/schema.sql
@@ -769,6 +769,75 @@ $$;
 
 ALTER FUNCTION "public"."sync_existing_users"() OWNER TO "postgres";
 
+
+CREATE OR REPLACE FUNCTION "public"."update_building_schema"("p_schema_id" "uuid", "p_schema_schema" "jsonb", "p_schema_version_patch" "jsonb", "p_schema_version_reverse_patch" "jsonb", "p_latest_schema_version_number" integer) RETURNS "jsonb"
+    LANGUAGE "plpgsql"
+    AS $$
+declare
+  v_result jsonb;
+  v_organization_id uuid;
+  v_next_version_number integer;
+begin
+  -- Start transaction
+  begin
+    -- 1. Select organization_id from building_schemas
+    select organization_id into v_organization_id
+    from building_schemas
+    where id = p_schema_id;
+    
+    if not found then
+      v_result := jsonb_build_object(
+        'success', false,
+        'error', 'Building schema not found'
+      );
+      return v_result;
+    end if;
+
+    -- Calculate the next version number
+    v_next_version_number := p_latest_schema_version_number + 1;
+    
+    -- 2. Insert into building_schema_versions
+    insert into building_schema_versions (
+      organization_id,
+      building_schema_id,
+      number,
+      patch,
+      reverse_patch,
+      created_at
+    ) values (
+      v_organization_id,
+      p_schema_id,
+      v_next_version_number,
+      p_schema_version_patch,
+      p_schema_version_reverse_patch,
+      now()
+    );
+    
+    -- 3. Update building_schemas with the new schema
+    update building_schemas
+    set schema = p_schema_schema
+    where id = p_schema_id;
+    
+    -- Commit transaction
+    v_result := jsonb_build_object(
+      'success', true,
+      'versionNumber', v_next_version_number
+    );
+    return v_result;
+  exception when others then
+    -- Handle any errors
+    v_result := jsonb_build_object(
+      'success', false,
+      'error', sqlerrm
+    );
+    return v_result;
+  end;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."update_building_schema"("p_schema_id" "uuid", "p_schema_schema" "jsonb", "p_schema_version_patch" "jsonb", "p_schema_version_reverse_patch" "jsonb", "p_latest_schema_version_number" integer) OWNER TO "postgres";
+
 SET default_tablespace = '';
 
 SET default_table_access_method = "heap";
@@ -3590,6 +3659,11 @@ GRANT ALL ON FUNCTION "public"."subvector"("public"."vector", integer, integer) 
 GRANT ALL ON FUNCTION "public"."sync_existing_users"() TO "anon";
 GRANT ALL ON FUNCTION "public"."sync_existing_users"() TO "authenticated";
 GRANT ALL ON FUNCTION "public"."sync_existing_users"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."update_building_schema"("p_schema_id" "uuid", "p_schema_schema" "jsonb", "p_schema_version_patch" "jsonb", "p_schema_version_reverse_patch" "jsonb", "p_latest_schema_version_number" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."update_building_schema"("p_schema_id" "uuid", "p_schema_schema" "jsonb", "p_schema_version_patch" "jsonb", "p_schema_version_reverse_patch" "jsonb", "p_latest_schema_version_number" integer) TO "service_role";
 
 
 

--- a/frontend/packages/db/supabase/database.types.ts
+++ b/frontend/packages/db/supabase/database.types.ts
@@ -1305,6 +1305,16 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: undefined
       }
+      update_building_schema: {
+        Args: {
+          p_schema_id: string
+          p_schema_schema: Json
+          p_schema_version_patch: Json
+          p_schema_version_reverse_patch: Json
+          p_latest_schema_version_number: number
+        }
+        Returns: Json
+      }
       vector_avg: {
         Args: { '': number[] }
         Returns: string

--- a/frontend/packages/db/supabase/migrations/20250521190230_add_update_building_schema.sql
+++ b/frontend/packages/db/supabase/migrations/20250521190230_add_update_building_schema.sql
@@ -1,0 +1,70 @@
+create or replace function update_building_schema(
+  p_schema_id uuid,
+  p_schema_schema jsonb,
+  p_schema_version_patch jsonb,
+  p_schema_version_reverse_patch jsonb,
+  p_latest_schema_version_number integer
+) returns jsonb as $$
+declare
+  v_result jsonb;
+  v_organization_id uuid;
+  v_next_version_number integer;
+begin
+  -- Start transaction
+  begin
+    -- 1. Select organization_id from building_schemas
+    select organization_id into v_organization_id
+    from building_schemas
+    where id = p_schema_id;
+  
+    if not found then
+      v_result := jsonb_build_object(
+        'success', false,
+        'error', 'Building schema not found'
+      );
+      return v_result;
+    end if;
+
+    -- Calculate the next version number
+    v_next_version_number := p_latest_schema_version_number + 1;
+
+    -- 2. Insert into building_schema_versions
+    insert into building_schema_versions (
+      organization_id,
+      building_schema_id,
+      number,
+      patch,
+      reverse_patch,
+      created_at
+    ) values (
+      v_organization_id,
+      p_schema_id,
+      v_next_version_number,
+      p_schema_version_patch,
+      p_schema_version_reverse_patch,
+      now()
+    );
+
+    -- 3. Update building_schemas with the new schema
+    update building_schemas
+    set schema = p_schema_schema
+    where id = p_schema_id;
+
+    -- Commit transaction
+    v_result := jsonb_build_object(
+      'success', true,
+      'versionNumber', v_next_version_number
+    );
+    return v_result;
+  exception when others then
+    -- Handle any errors
+    v_result := jsonb_build_object(
+      'success', false,
+      'error', sqlerrm
+    );
+    return v_result;
+  end;
+end;
+$$ language plpgsql;
+
+revoke all on function update_building_schema(uuid, jsonb, jsonb, jsonb, integer) from anon;

--- a/frontend/packages/db/supabase/tests/database/04-update_building_schema.test.sql
+++ b/frontend/packages/db/supabase/tests/database/04-update_building_schema.test.sql
@@ -1,0 +1,180 @@
+-- Test file for update_building_schema function
+BEGIN;
+
+-- Load the pgtap extension
+SELECT plan(8);
+
+-- Set role to postgres for preparation
+SET ROLE postgres;
+
+-- Create test users
+SELECT tests.create_supabase_user('schema_owner@example.com', 'schema_owner');
+SELECT tests.create_supabase_user('non_member@example.com', 'non_member');
+
+-- Get user IDs and setup test data
+DO $$
+DECLARE
+    v_owner_id uuid;
+    v_org_id uuid := '44444444-4444-4444-4444-444444444444';
+    v_design_session_id uuid := '77777777-7777-7777-7777-777777777777';
+    v_schema_id uuid := '55555555-5555-5555-5555-555555555555';
+    v_non_existent_schema_id uuid := '66666666-6666-6666-6666-666666666666';
+BEGIN
+    -- Get user IDs
+    SELECT tests.get_supabase_uid('schema_owner@example.com') INTO v_owner_id;
+
+    -- Create test organization
+    INSERT INTO organizations (id, name)
+    VALUES (v_org_id, 'Test Org for Building Schema')
+    ON CONFLICT DO NOTHING;
+
+    -- Add schema_owner to organization
+    INSERT INTO organization_members (user_id, organization_id)
+    VALUES (v_owner_id, v_org_id)
+    ON CONFLICT DO NOTHING;
+
+    -- Create a test project
+    INSERT INTO projects (id, name, organization_id, created_at, updated_at)
+    VALUES (
+        gen_random_uuid(),
+        'Test Project for Building Schema',
+        v_org_id,
+        now(),
+        now()
+    )
+    ON CONFLICT DO NOTHING;
+
+    -- Create a test design session
+    INSERT INTO design_sessions (
+        id,
+        project_id,
+        organization_id,
+        created_by_user_id,
+        name,
+        created_at
+    ) VALUES (
+        v_design_session_id,
+        (SELECT id FROM projects WHERE organization_id = v_org_id LIMIT 1),
+        v_org_id,
+        v_owner_id,
+        'Test Design Session',
+        now() - interval '2 days'
+    )
+    ON CONFLICT DO NOTHING;
+
+    -- Create a test building schema
+    INSERT INTO building_schemas (id, design_session_id, organization_id, schema)
+    VALUES (
+        v_schema_id,
+        v_design_session_id,
+        v_org_id,
+        '{"version": 1, "fields": {"name": {"type": "string"}}}'::jsonb
+    )
+    ON CONFLICT DO NOTHING;
+
+    -- Create an initial version
+    INSERT INTO building_schema_versions (
+        organization_id,
+        building_schema_id,
+        number,
+        patch,
+        reverse_patch,
+        created_at
+    ) VALUES (
+        v_org_id,
+        v_schema_id,
+        1,
+        '{"op": "add", "path": "/fields/name", "value": {"type": "string"}}'::jsonb,
+        '{"op": "remove", "path": "/fields/name"}'::jsonb,
+        now() - interval '1 day'
+    )
+    ON CONFLICT DO NOTHING;
+END $$;
+
+-- Test 1: Successfully update a building schema - success is true
+SELECT ok(
+    (SELECT (result->>'success')::boolean FROM (
+        SELECT update_building_schema(
+            '55555555-5555-5555-5555-555555555555',
+            '{"version": 2, "fields": {"name": {"type": "string"}, "address": {"type": "string"}}}'::jsonb,
+            '{"op": "add", "path": "/fields/address", "value": {"type": "string"}}'::jsonb,
+            '{"op": "remove", "path": "/fields/address"}'::jsonb,
+            1
+        ) AS result
+    ) AS t),
+    'Should return success = true when updating a valid building schema'
+);
+
+-- Test 2: Successfully update a building schema - version number is returned
+SELECT is(
+    (SELECT (result->>'versionNumber')::integer FROM (
+        SELECT update_building_schema(
+            '55555555-5555-5555-5555-555555555555',
+            '{"version": 2, "fields": {"name": {"type": "string"}, "address": {"type": "string"}}}'::jsonb,
+            '{"op": "add", "path": "/fields/address", "value": {"type": "string"}}'::jsonb,
+            '{"op": "remove", "path": "/fields/address"}'::jsonb,
+            1
+        ) AS result
+    ) AS t),
+    2,
+    'Should return version number 2'
+);
+
+-- Test 3: Verify the building schema was updated
+SELECT is(
+    (SELECT schema FROM building_schemas WHERE id = '55555555-5555-5555-5555-555555555555'),
+    '{"version": 2, "fields": {"name": {"type": "string"}, "address": {"type": "string"}}}'::jsonb,
+    'Building schema should be updated with new schema'
+);
+
+-- Test 4: Verify new version records were created
+SELECT is(
+    (SELECT COUNT(*) FROM building_schema_versions WHERE building_schema_id = '55555555-5555-5555-5555-555555555555'),
+    3::bigint,
+    'Should create new version records'
+);
+
+-- Test 5: Verify the new version record has the correct number
+SELECT is(
+    (SELECT number FROM building_schema_versions 
+     WHERE building_schema_id = '55555555-5555-5555-5555-555555555555'
+     ORDER BY created_at DESC LIMIT 1),
+    2,
+    'New version record should have number 2'
+);
+
+-- Test 6: Verify the new version record has the correct patch
+SELECT is(
+    (SELECT patch FROM building_schema_versions 
+     WHERE building_schema_id = '55555555-5555-5555-5555-555555555555'
+     ORDER BY created_at DESC LIMIT 1),
+    '{"op": "add", "path": "/fields/address", "value": {"type": "string"}}'::jsonb,
+    'New version record should have the correct patch'
+);
+
+-- Test 7: Verify the new version record has the correct reverse patch
+SELECT is(
+    (SELECT reverse_patch FROM building_schema_versions 
+     WHERE building_schema_id = '55555555-5555-5555-5555-555555555555'
+     ORDER BY created_at DESC LIMIT 1),
+    '{"op": "remove", "path": "/fields/address"}'::jsonb,
+    'New version record should have the correct reverse patch'
+);
+
+-- Test 8: Attempt to update a non-existent building schema
+SELECT is(
+    (SELECT update_building_schema(
+        '66666666-6666-6666-6666-666666666666',
+        '{"version": 1, "fields": {}}'::jsonb,
+        '{}'::jsonb,
+        '{}'::jsonb,
+        0
+    )),
+    '{"success": false, "error": "Building schema not found"}'::jsonb,
+    'Should fail when building schema does not exist'
+);
+
+-- Finish the tests and print a diagnostic count
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Issue


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I want to add RPC function for transactional schema updates with versioning

- Introduce `update_building_schema` RPC to atomically insert version and update schema
- Replace direct insert/update logic in `createNewVersion` with RPC call
- Add Valibot schema validation for RPC response
- Grant execution permissions on RPC to `authenticated` and `service_role`
- Add pgtap tests to verify RPC behavior, including error handling and patch correctness


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->



- a `design_sessions` record inserted
- a `building_schemas` record inserted
- login
    - get access token

### test 

test curl command:







```
$ curl -i -X POST 'http://localhost:3001/api/buildingSchemas/versions' --cookie 'sb-localhost-auth-token=base64-eyJ....;' \
 -d '{"latestVersionNumber":0,"buildingSchemaId":"9bc93231-6718-4a3e-981f-20cc0cbd7221","patch":[{"op": "add", "path": "/foo", "value": "bar"},{"op":"add","path":"/foo2","value":{}}]}'

HTTP/1.1 201 Created
x-url-path: /api/buildingSchemas/versions
content-type: application/json
Date: Thu, 22 May 2025 00:25:57 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{"success":true}%
```


then,

- ✔️   `building_schemas` table record updated. 
    - ✔️  `schema` is filled 


<img width="1410" alt="filled" src="https://github.com/user-attachments/assets/d26beedc-98c1-4606-b4f9-77b3d9837460" />

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 85f605ce3359e91ca129c827ebad0c3e910cb37e

- Introduce transactional RPC for building schema updates with versioning
  - Adds `update_building_schema` function for atomic schema/version changes
  - Grants execution permissions to relevant roles
- Refactor frontend logic to use new RPC and validate responses
  - Replaces direct table manipulation with RPC call in `createNewVersion`
  - Adds Valibot schema validation for RPC responses
- Add comprehensive pgtap tests for new RPC
  - Covers success, error, and edge cases for schema updates


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.sql</strong><dd><code>Add and authorize transactional update_building_schema function</code></dd></summary>
<hr>

frontend/packages/db/schema/schema.sql

<li>Added <code>update_building_schema</code> PL/pgSQL function for atomic <br>schema/version updates<br> <li> Granted execution permissions to <code>authenticated</code> and <code>service_role</code> roles<br> <li> Registered function ownership and permissions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1733/files#diff-8b2c9777e5e6614148282316dd37f3a4e9d4f6f4f2ad15b5247aea65a7bd010d">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database.types.ts</strong><dd><code>Add update_building_schema RPC to Supabase types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/database.types.ts

<li>Declared new <code>update_building_schema</code> RPC in Supabase type definitions<br> <li> Defined input arguments and return type for the new function


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1733/files#diff-9790acb5594a7a7ed6d0d917ca1ae8f549dd984aa7f3e96b549b6939f84a7f01">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>createNewVersion.ts</strong><dd><code>Refactor to use update_building_schema RPC with validation</code></dd></summary>
<hr>

frontend/apps/app/libs/schema/createNewVersion.ts

<li>Replaced direct insert/update logic with <code>update_building_schema</code> RPC <br>call<br> <li> Added Valibot schema validation for RPC responses<br> <li> Improved error handling for RPC and parsing failures


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1733/files#diff-e88418a273be461c2db87117e973a41c771b992433922ef8b1c3c35b224a79a8">+43/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20250521190230_add_update_building_schema.sql</strong><dd><code>Migration for update_building_schema transactional function</code></dd></summary>
<hr>

frontend/packages/db/supabase/migrations/20250521190230_add_update_building_schema.sql

<li>Added migration to create <code>update_building_schema</code> function<br> <li> Set up error handling and revoked anon access


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1733/files#diff-b1eaaa710f3497039fc3106017b11ca19d8388906755e2c7322469e26d0b7977">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>04-update_building_schema.test.sql</strong><dd><code>Add pgtap tests for update_building_schema RPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db/supabase/tests/database/04-update_building_schema.test.sql

<li>Added pgtap tests for <code>update_building_schema</code> function<br> <li> Covered success, versioning, patch, and error scenarios<br> <li> Verified permissions and data integrity


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1733/files#diff-ac27339fc0758edb4b45f42188f5d651afd358682d51f7e7d9d6ce8a46808084">+180/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>