### PR TITLE
✅ test: increase timeout for toolbar zoom button tests

### DIFF
--- a/frontend/packages/e2e/tests/e2e/toolbar.test.ts
+++ b/frontend/packages/e2e/tests/e2e/toolbar.test.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page, isMobile }) => {
     const openToolbarButton = page.getByRole('button', {
       name: 'Open toolbar',
     })
-    await openToolbarButton.click({ force: true, timeout: 15000 })
+    await openToolbarButton.click({ force: true })
   }
 })
 
@@ -45,6 +45,7 @@ test('should be visible', async ({ page }) => {
 })
 
 test('zoom in button should increase zoom level', async ({ page }) => {
+  test.setTimeout(15000)
   const toolbar = page.getByRole('toolbar', { name: 'Toolbar' })
   const zoomLevelText = toolbar.getByLabel('Zoom level')
 
@@ -61,6 +62,7 @@ test('zoom in button should increase zoom level', async ({ page }) => {
 })
 
 test('zoom out button should decrease zoom level', async ({ page }) => {
+  test.setTimeout(15000)
   const toolbar = page.getByRole('toolbar', { name: 'Toolbar' })
   const zoomLevelText = toolbar.getByLabel('Zoom level')
 


### PR DESCRIPTION
## Issue


## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

For flaky tests .


- Removed custom timeout from `click` in `beforeEach`, relying on the default instead
- Added `test.setTimeout(15000)` to zoom in/out tests to reduce flakiness on slow environments

This helps prevent CI failures like the following:

* [https://github.com/liam-hq/liam/actions/runs/15181480991](https://github.com/liam-hq/liam/actions/runs/15181480991)
* [https://github.com/liam-hq/liam/actions/runs/15201652861](https://github.com/liam-hq/liam/actions/runs/15201652861)
* [https://github.com/liam-hq/liam/actions/runs/15201651871](https://github.com/liam-hq/liam/actions/runs/15201651871)


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->


## Testing Verification

<!-- Please describe how you verified these changes in your local environment using text/images/video -->

* Created a temporary branch and ran the tests 10 times: [https://github.com/liam-hq/liam/compare/9fe95b1bdb7..7b4ff1b32ab971](https://github.com/liam-hq/liam/compare/9fe95b1bdb7..7b4ff1b32ab971) https://github.com/liam-hq/liam/pull/1755
* All 6 consecutive runs passed successfully
  * <img width="939" alt="Screenshot 2025-05-26 13:50:03" src="https://github.com/user-attachments/assets/17ddab39-a001-4798-958a-35f549553917" />


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 71dae964c95723504acd043d98ab218e54e8e3d2

- Increased test timeout for zoom in/out toolbar tests
- Removed custom timeout from toolbar open button click
- Improves reliability of toolbar-related E2E tests


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.test.ts</strong><dd><code>Adjust timeouts for toolbar zoom button E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/e2e/tests/e2e/toolbar.test.ts

<li>Removed custom timeout from <code>click</code> in <code>beforeEach</code>, using default instead<br> <li> Added <code>test.setTimeout(15000)</code> to zoom in and zoom out tests<br> <li> Enhances test stability on slow environments


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1768/files#diff-588d467fc6e4ec55a8106e9d04be9786dba77a283e2b2c8f05c52dc20efa4949">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>