### PR TITLE
PoC: refactor(LeftPane): replace width calculation logic to CSS for responsive visibility

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/ERDRenderer.tsx
@@ -91,19 +91,6 @@ export const ERDRenderer: FC<Props> = ({
 
   const setWidth = useCallback(
     (sizes: number[]) => {
-      if (open && sizes[0]) {
-        const panelGroupElement = document.querySelector(
-          `.${styles.mainWrapper}`,
-        )
-        if (panelGroupElement) {
-          const totalWidth = panelGroupElement.getBoundingClientRect().width
-          const leftPanelWidth = (sizes[0] / 100) * totalWidth
-
-          if (leftPanelWidth <= 260) {
-            leftPanelRef.current?.collapse()
-          }
-        }
-      }
       document.cookie = `${PANEL_LAYOUT_COOKIE_NAME}=${JSON.stringify(sizes)}; path=/; max-age=${COOKIE_MAX_AGE}`
     },
     [leftPanelRef, open],

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -3,6 +3,7 @@
   grid-auto-flow: column;
   align-items: center;
   justify-content: space-between;
+  container-type: inline-size;
 }
 
 .tableCount {
@@ -131,8 +132,8 @@
   margin-left: var(--spacing-1);
 }
 
-@media (max-width: 600px) {
-  .visibleCount {
-    display: none !important;
+@container (max-width: 250px) {
+  .groupLabel .visibleCount {
+    display: none;
   }
 }


### PR DESCRIPTION
- Removed the width calculation logic in the setWidth function that was dependent on the open state and sizes array.
- Updated LeftPane.module.css to use container queries for responsive design, hiding the visibleCount element when the container width is less than 250px.


https://github.com/user-attachments/assets/cc0d942f-37e7-401a-a69f-c7743837c27e

