### PR TITLE
🔧 Rely on ubuntu-latest default Ruby instead of explicitly setting version

### DIFF
--- a/.github/workflows/license-report-update.yml
+++ b/.github/workflows/license-report-update.yml
@@ -33,11 +33,8 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/pnpm-setup
-      - uses: ruby/setup-ruby@84684c07c1965536eb4802c8daf1a77968df0cb1 # v1.239.0
-        with:
-          ruby-version: '3.4'
       - name: Install License Finder
-        run: gem install -N license_finder
+        run: sudo gem install -N license_finder
       - name: Generate license report
         run: |
           mkdir -p "$(dirname "$LICENSE_REPORT")"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -40,13 +40,9 @@ jobs:
           fi
       - uses: ./.github/actions/pnpm-setup
         if: steps.determine.outputs.files_changed == 'true'
-      - uses: ruby/setup-ruby@84684c07c1965536eb4802c8daf1a77968df0cb1 # v1.239.0
-        if: steps.determine.outputs.files_changed == 'true'
-        with:
-          ruby-version: '3.4'
       - name: Install License Finder
         if: steps.determine.outputs.files_changed == 'true'
-        run: gem install -N license_finder
+        run: sudo gem install -N license_finder
       - name: Run License Finder
         if: steps.determine.outputs.files_changed == 'true'
         run: license_finder


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

- Simplifies workflow maintenance and reduces setup time
    - This will reduce renovate-bot setup-ruby updating https://github.com/liam-hq/liam/pulls?q=is%3Apr+is%3Aclosed+%22ruby%2Fsetup-ruby%22


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

https://github.com/liam-hq/liam/actions/runs/15341959003/job/43169779827

It maybe work
<img width="1282" alt="スクリーンショット 2025-05-30 21 45 16" src="https://github.com/user-attachments/assets/f5b5d872-87f5-414f-a059-198ffd219cf5" />


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 5d9a6e07664f6ee405f6b1d5c0b9887db9e9441d

- Remove explicit Ruby version setup from GitHub workflows
- Rely on `ubuntu-latest` default Ruby for license jobs
- Use `sudo` for `gem install` to ensure system-wide installation


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>license-report-update.yml</strong><dd><code>Remove explicit Ruby setup and use sudo for gem install</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/license-report-update.yml

<li>Removed explicit <code>ruby/setup-ruby</code> action and version specification<br> <li> Changed <code>gem install</code> to use <code>sudo</code> for system-wide installation


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1829/files#diff-27fd71a6aeaabc8f293b834e461226de4dd2ddc7d46bba203ea41eefad831ac9">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>license.yml</strong><dd><code>Eliminate Ruby setup and update gem install command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/license.yml

<li>Removed conditional <code>ruby/setup-ruby</code> action and version specification<br> <li> Updated <code>gem install</code> to use <code>sudo</code> for system-wide installation


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1829/files#diff-c24fd68dc9cdef9206805d2b129cc11ed4625d9cc30e582d905cc3a6d483d556">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>