### PR TITLE
feat(chat): persist messages to database using Supabase

### DIFF
--- a/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/sessions/[id]/page.tsx
+++ b/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/sessions/[id]/page.tsx
@@ -26,6 +26,7 @@ export default async function Page({ params }: PageProps) {
     <SessionDetailPage
       projectId={parsedParams.output.projectId}
       schema={schema}
+      designSessionId={parsedParams.output.id}
     />
   )
 }

--- a/frontend/apps/app/components/Chat/services/index.ts
+++ b/frontend/apps/app/components/Chat/services/index.ts
@@ -1,0 +1,1 @@
+export * from './messageServiceClient'

--- a/frontend/apps/app/components/Chat/services/messageServiceClient.ts
+++ b/frontend/apps/app/components/Chat/services/messageServiceClient.ts
@@ -1,0 +1,126 @@
+'use client'
+
+import { createClient } from '@/libs/db/client'
+import type { Tables, TablesInsert } from '@liam-hq/db/supabase/database.types'
+import * as v from 'valibot'
+
+type Message = Tables<'messages'>
+type MessageInsert = TablesInsert<'messages'>
+
+const saveMessageSchema = v.object({
+  designSessionId: v.pipe(v.string(), v.uuid()),
+  content: v.pipe(v.string(), v.minLength(1)),
+  role: v.picklist(['user', 'assistant']),
+  userId: v.optional(v.nullable(v.pipe(v.string(), v.uuid()))),
+})
+
+const loadMessagesSchema = v.object({
+  designSessionId: v.pipe(v.string(), v.uuid()),
+})
+
+/**
+ * Save a message to the database (client-side)
+ */
+export const saveMessage = async (data: {
+  designSessionId: string
+  content: string
+  role: 'user' | 'assistant'
+  userId?: string | null
+}): Promise<{ success: boolean; message?: Message; error?: string }> => {
+  const parsedData = v.parse(saveMessageSchema, data)
+  const { designSessionId, content, role, userId } = parsedData
+
+  const supabase = createClient()
+  const now = new Date().toISOString()
+
+  // Get organization_id from design_session
+  const { data: designSession, error: sessionError } = await supabase
+    .from('design_sessions')
+    .select('organization_id')
+    .eq('id', designSessionId)
+    .single()
+
+  if (sessionError || !designSession) {
+    console.error('Failed to get design session:', sessionError)
+    return { success: false, error: 'Design session not found' }
+  }
+
+  const messageData: MessageInsert = {
+    design_session_id: designSessionId,
+    content,
+    role,
+    user_id: userId || null,
+    updated_at: now,
+    organization_id: designSession.organization_id,
+  }
+
+  const { data: message, error } = await supabase
+    .from('messages')
+    .insert(messageData)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('Failed to save message:', JSON.stringify(error, null, 2))
+    return { success: false, error: error.message }
+  }
+
+  return { success: true, message }
+}
+
+/**
+ * Load messages for a design session (client-side)
+ */
+export const loadMessages = async (data: {
+  designSessionId: string
+}): Promise<{ success: boolean; messages?: Message[]; error?: string }> => {
+  const parsedData = v.parse(loadMessagesSchema, data)
+  const { designSessionId } = parsedData
+
+  const supabase = createClient()
+
+  const { data: messages, error } = await supabase
+    .from('messages')
+    .select('*')
+    .eq('design_session_id', designSessionId)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('Failed to load messages:', error)
+    return { success: false, error: error.message }
+  }
+
+  return { success: true, messages: messages || [] }
+}
+
+/**
+ * Get current user ID from Supabase auth
+ */
+export const getCurrentUserId = async (): Promise<string | null> => {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error) {
+    console.error('Failed to get current user:', error)
+    return null
+  }
+
+  return user?.id || null
+}
+
+/**
+ * Convert database message to ChatEntry format
+ */
+export const convertMessageToChatEntry = (message: Message) => {
+  return {
+    id: message.id,
+    content: message.content,
+    isUser: message.role === 'user',
+    timestamp: new Date(message.created_at),
+    isGenerating: false,
+    agentType: message.role === 'assistant' ? ('ask' as const) : undefined,
+  }
+}

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx
@@ -15,9 +15,14 @@ import styles from './SessionDetailPage.module.css'
 type Props = {
   projectId: string
   schema: Schema
+  designSessionId: string
 }
 
-export const SessionDetailPage: FC<Props> = ({ projectId, schema }) => {
+export const SessionDetailPage: FC<Props> = ({
+  projectId,
+  schema,
+  designSessionId,
+}) => {
   // Update the schema store with the fetched schema
   useEffect(() => {
     if (schema) {
@@ -42,7 +47,11 @@ export const SessionDetailPage: FC<Props> = ({ projectId, schema }) => {
     <div className={styles.container}>
       <div className={styles.columns}>
         <div className={styles.chatSection}>
-          <Chat schemaData={schema} projectId={projectId} />
+          <Chat
+            schemaData={schema}
+            projectId={projectId}
+            designSessionId={designSessionId}
+          />
         </div>
         <TabsRoot defaultValue="erd" className={styles.tabsRoot}>
           <TabsContent value="erd" className={styles.tabsContent}>


### PR DESCRIPTION
- [x] please check https://github.com/liam-hq/liam/pull/1809 first. 🙏 


## Screenshots

Now each messages are persisted in `messages` table.


messages:
<img width="1284" alt="1" src="https://github.com/user-attachments/assets/e1379ff1-6ace-4089-96ae-b2e4be929a33" />

db:
<img width="1295" alt="2" src="https://github.com/user-attachments/assets/047dc454-65dd-4f1f-baf4-298990a3e788" />



## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

want to save the chat messages.

- Messages are now saved to and loaded from the `messages` table, ensuring session history is preserved
- Introduced `designSessionId` prop to `Chat` and `SessionDetailPage` components
- Added `saveMessage`, `loadMessages`, and `updateMessage` service methods (client-side)
- Implemented loading indicator while fetching past messages
- Synced user and assistant messages with Supabase during chat flow
- Improved error handling for persistence-related failures

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 9e8dd2160c9e5e32965a213e10d960e6e04e72c3

- Persist chat messages to Supabase `messages` table
  - Added client-side message save and load logic
  - Messages are loaded on chat mount and saved on send/receive
- Introduced `designSessionId` prop to `Chat` and `SessionDetailPage`
  - Enables session-specific message history
- Improved chat UI to show loading indicator while fetching messages
- Enhanced error handling for persistence operations


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messageServiceClient.ts</strong><dd><code>Add Supabase message persistence client and utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/Chat/services/messageServiceClient.ts

<li>Added client-side service for message persistence via Supabase<br> <li> Implemented <code>saveMessage</code>, <code>loadMessages</code>, and <code>getCurrentUserId</code> functions<br> <li> Provided message-to-chat-entry conversion utility<br> <li> Included schema validation for message operations


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1831/files#diff-4d58d11f9bd7bb8a632fe78eba9b83915ed3310aa79ffc6843c42b4b70801426">+126/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export message service client functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/Chat/services/index.ts

- Exported all message service client functions for use in Chat


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1831/files#diff-8f5963341e76532782e710b00b65c35a99d57e8d53c2ffad2be1a138b7407059">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Chat.tsx</strong><dd><code>Integrate Supabase message persistence into Chat component</code></dd></summary>
<hr>

frontend/apps/app/components/Chat/Chat.tsx

<li>Integrated message loading and saving with Supabase<br> <li> Added <code>designSessionId</code> prop for session-specific chat history<br> <li> Loaded messages on mount and saved user/assistant messages<br> <li> Displayed loading indicator while fetching messages<br> <li> Updated chat state to sync with database IDs


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1831/files#diff-1baef2cffdebe35482fef40f1083d823e062fd797dcb4c27358601541db43aeb">+107/-24</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SessionDetailPage.tsx</strong><dd><code>Pass designSessionId to Chat for session context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx

<li>Added <code>designSessionId</code> prop and passed it to Chat<br> <li> Updated component signature and usage accordingly


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1831/files#diff-878b7cacaadb0ed1008eb8e7edfd399f78dc00e8252022664a2a3f7490f3e7d5">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Provide designSessionId to session detail page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/sessions/[id]/page.tsx

- Passed session ID as `designSessionId` prop to SessionDetailPage


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1831/files#diff-24d6b0461b65ebd2adeb4fd7744621b765d587da114335c8c0d8a25db5f3321a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>