### PR TITLE
Chore: migrate "resolutions" to "pnpm.overrides" for version fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,11 @@
       "supabase"
     ],
     "overrides": {
+      "esbuild": "0.25.4",
       "node-gtts": "workspace:*",
-      "prismjs": "1.30.0"
+      "path-to-regexp": "8.2.0",
+      "prismjs": "1.30.0",
+      "undici": "7.9.0"
     }
-  },
-  "resolutions": {
-    "esbuild": "0.25.4",
-    "path-to-regexp": "8.2.0",
-    "undici": "7.9.0"
   }
 }


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

"resolutions" is functionally identical to "pnpm.overrides". This change integrates version overrides into "pnpm.overrides" to reduce confusion.
ref: https://pnpm.io/ja/9.x/package_json#resolutions

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- the migration is correct

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

- This change doesn't produce any change in pnpm-lock.yml file.

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 3c5a8b5accd8606bd428f04eda3bc72abd26f8d5

- Migrated all version overrides from `resolutions` to `pnpm.overrides`
- Consolidated dependency version management under `pnpm.overrides`
- Removed the obsolete `resolutions` field from `package.json`


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Migrated version overrides to pnpm.overrides and removed resolutions</code></dd></summary>
<hr>

package.json

<li>Moved all version overrides from <code>resolutions</code> to <code>pnpm.overrides</code><br> <li> Added <code>esbuild</code>, <code>path-to-regexp</code>, and <code>undici</code> to <code>pnpm.overrides</code><br> <li> Removed the <code>resolutions</code> field entirely<br> <li> Ensured all overrides are now managed by pnpm


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1835/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

There are descriptions about "overrides" and "resolution" in the document of 9.x but not in 10.x. https://pnpm.io/ja/9.x/package_json#resolutions
It looks they are valid in 10.x as well, but why not in the document... 🤔

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>