### PR TITLE
Add stale issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 13 * * *" # Runs at 22:00 JST
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'This Pull Request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          days-before-issue-stale: 60
+          days-before-issue-close: 5


### PR DESCRIPTION
### Summary
- add workflow to mark issues and pull requests as stale

### Testing
- `pnpm run fmt` *(fails: command finished with error)*


------
https://chatgpt.com/codex/tasks/task_e_683d17d647dc832392f5ec65a49a1457