### PR TITLE
Implement GitHub deployment for schema pages

### DIFF
--- a/frontend/apps/app/app/api/webhook/github/route.ts
+++ b/frontend/apps/app/app/api/webhook/github/route.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto'
 import { createClient } from '@/libs/db/server'
 import { supportedEvents } from '@liam-hq/github'
+import { savePullRequestTask, createSchemaDeploymentTask } from '@liam-hq/jobs'
 import type { GitHubWebhookPayload } from '@liam-hq/github'
-import { savePullRequestTask } from '@liam-hq/jobs'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSchemaChanges } from './utils/checkSchemaChanges'
 
@@ -135,6 +135,14 @@ const handlePullRequest = async (
       await savePullRequestTask.trigger({
         prNumber,
         projectId,
+      })
+
+      await createSchemaDeploymentTask.trigger({
+        installationId: data.installation.id,
+        owner: data.repository.owner.login,
+        repo: data.repository.name,
+        projectId,
+        branchRef: pullRequest.head.ref,
       })
 
       return NextResponse.json(

--- a/frontend/apps/app/app/api/webhook/github/route.ts
+++ b/frontend/apps/app/app/api/webhook/github/route.ts
@@ -1,8 +1,8 @@
 import crypto from 'node:crypto'
 import { createClient } from '@/libs/db/server'
 import { supportedEvents } from '@liam-hq/github'
-import { savePullRequestTask, createSchemaDeploymentTask } from '@liam-hq/jobs'
 import type { GitHubWebhookPayload } from '@liam-hq/github'
+import { createSchemaDeploymentTask, savePullRequestTask } from '@liam-hq/jobs'
 import { type NextRequest, NextResponse } from 'next/server'
 import { checkSchemaChanges } from './utils/checkSchemaChanges'
 

--- a/frontend/packages/github/src/api.server.ts
+++ b/frontend/packages/github/src/api.server.ts
@@ -356,3 +356,53 @@ export const getOrganizationInfo = async (
     return null
   }
 }
+
+export const createDeployment = async (
+  installationId: number,
+  owner: string,
+  repo: string,
+  params: {
+    ref: string
+    environment: string
+    description?: string
+  },
+) => {
+  const octokit = await createOctokit(installationId)
+
+  const { data } = await octokit.repos.createDeployment({
+    owner,
+    repo,
+    ref: params.ref,
+    environment: params.environment,
+    ...(params.description ? { description: params.description } : {}),
+    auto_merge: false,
+    required_contexts: [],
+  })
+
+  return data
+}
+
+export const createDeploymentStatus = async (
+  installationId: number,
+  owner: string,
+  repo: string,
+  deploymentId: number,
+  params: {
+    state: 'error' | 'failure' | 'inactive' | 'in_progress' | 'queued' | 'pending' | 'success'
+    environment_url?: string
+    log_url?: string
+  },
+) => {
+  const octokit = await createOctokit(installationId)
+
+  const { data } = await octokit.repos.createDeploymentStatus({
+    owner,
+    repo,
+    deployment_id: deploymentId,
+    state: params.state,
+    ...(params.environment_url ? { environment_url: params.environment_url } : {}),
+    ...(params.log_url ? { log_url: params.log_url } : {}),
+  })
+
+  return data
+}

--- a/frontend/packages/github/src/api.server.ts
+++ b/frontend/packages/github/src/api.server.ts
@@ -366,7 +366,7 @@ export const createDeployment = async (
     environment: string
     description?: string
   },
-) => {
+): Promise<{ id: number | null }> => {
   const octokit = await createOctokit(installationId)
 
   const { data } = await octokit.repos.createDeployment({
@@ -379,7 +379,7 @@ export const createDeployment = async (
     required_contexts: [],
   })
 
-  return data
+  return { id: 'id' in data ? data.id : null }
 }
 
 export const createDeploymentStatus = async (
@@ -388,7 +388,14 @@ export const createDeploymentStatus = async (
   repo: string,
   deploymentId: number,
   params: {
-    state: 'error' | 'failure' | 'inactive' | 'in_progress' | 'queued' | 'pending' | 'success'
+    state:
+      | 'error'
+      | 'failure'
+      | 'inactive'
+      | 'in_progress'
+      | 'queued'
+      | 'pending'
+      | 'success'
     environment_url?: string
     log_url?: string
   },
@@ -400,7 +407,9 @@ export const createDeploymentStatus = async (
     repo,
     deployment_id: deploymentId,
     state: params.state,
-    ...(params.environment_url ? { environment_url: params.environment_url } : {}),
+    ...(params.environment_url
+      ? { environment_url: params.environment_url }
+      : {}),
     ...(params.log_url ? { log_url: params.log_url } : {}),
   })
 

--- a/frontend/packages/jobs/src/index.ts
+++ b/frontend/packages/jobs/src/index.ts
@@ -8,6 +8,7 @@ export { processGenerateReview } from './tasks/review/generateReview'
 export { processSavePullRequest } from './tasks/review/savePullRequest'
 export { processSaveReview } from './tasks/review/saveReview'
 export { postComment } from './tasks/review/postComment'
+export { processCreateSchemaDeployment } from './tasks/github/createSchemaDeployment'
 
 export {
   savePullRequestTask,
@@ -15,6 +16,7 @@ export {
   saveReviewTask,
   postCommentTask,
 } from './tasks/review'
+export { createSchemaDeploymentTask } from './tasks/github'
 export {
   helloWorld,
   generateKnowledgeFromFeedbackTask,

--- a/frontend/packages/jobs/src/tasks/github/createSchemaDeployment.ts
+++ b/frontend/packages/jobs/src/tasks/github/createSchemaDeployment.ts
@@ -1,0 +1,65 @@
+import { createDeployment, createDeploymentStatus } from '@liam-hq/github'
+import { logger, task } from '@trigger.dev/sdk/v3'
+import { createClient } from '../../libs/supabase'
+
+export type CreateSchemaDeploymentPayload = {
+  installationId: number
+  owner: string
+  repo: string
+  projectId: string
+  branchRef: string
+}
+
+export const processCreateSchemaDeployment = async (
+  payload: CreateSchemaDeploymentPayload,
+): Promise<{ success: boolean }> => {
+  const supabase = createClient()
+  const { data: schemaPath } = await supabase
+    .from('schema_file_paths')
+    .select('path')
+    .eq('project_id', payload.projectId)
+    .single()
+
+  if (!schemaPath) {
+    logger.warn('No schema path found for project', {
+      projectId: payload.projectId,
+    })
+    return { success: false }
+  }
+
+  const encodedBranchRef = encodeURIComponent(payload.branchRef)
+  const environmentUrl = `${process.env['NEXT_PUBLIC_BASE_URL']}/app/projects/${payload.projectId}/ref/${encodedBranchRef}/schema/${schemaPath.path}`
+
+  const deployment = (await createDeployment(
+    payload.installationId,
+    payload.owner,
+    payload.repo,
+    {
+      ref: payload.branchRef,
+      environment: 'Preview – liam-db',
+      description: 'Liam DB schema preview',
+    },
+  )) as { id: number }
+
+  await createDeploymentStatus(
+    payload.installationId,
+    payload.owner,
+    payload.repo,
+    deployment.id,
+    {
+      state: 'success',
+      environment_url: environmentUrl,
+    },
+  )
+
+  return { success: true }
+}
+
+export const createSchemaDeploymentTask = task({
+  id: 'create-schema-deployment',
+  run: async (payload: CreateSchemaDeploymentPayload) => {
+    logger.log('Executing schema deployment task:', { payload })
+    const result = await processCreateSchemaDeployment(payload)
+    return result
+  },
+})

--- a/frontend/packages/jobs/src/tasks/github/index.ts
+++ b/frontend/packages/jobs/src/tasks/github/index.ts
@@ -1,0 +1,1 @@
+export { createSchemaDeploymentTask } from './createSchemaDeployment'


### PR DESCRIPTION
## Summary
- create `createSchemaDeploymentTask` using Trigger.dev
- call the new task from the GitHub webhook handler

## Testing
- `pnpm --filter @liam-hq/github lint:tsc`
- `pnpm --filter @liam-hq/app lint:tsc` *(fails: Cannot find module '@liam-hq/db-structure' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683d33fc36c48323957077201748b662