### PR TITLE
feat(sessions): enhance SessionsNewPage with project and branch selection

### DIFF
--- a/frontend/apps/app/app/(app)/app/design_sessions/new/page.tsx
+++ b/frontend/apps/app/app/(app)/app/design_sessions/new/page.tsx
@@ -1,5 +1,10 @@
+import { getProjects } from '@/components/CommonLayout/AppBar/ProjectsDropdownMenu/services/getProjects'
 import { SessionsNewPage } from '@/components/SessionsNewPage'
+import { getOrganizationId } from '@/features/organizations/services/getOrganizationId'
 
 export default async function Page() {
-  return <SessionsNewPage />
+  const organizationId = await getOrganizationId()
+  const { data: projects } = await getProjects(organizationId)
+
+  return <SessionsNewPage projects={projects} />
 }

--- a/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.module.css
+++ b/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.module.css
@@ -122,3 +122,31 @@
   font-size: var(--font-size-3);
   margin-top: var(--spacing-2);
 }
+
+.select {
+  background-color: var(--global-background);
+  color: var(--global-foreground);
+  border: 1px solid var(--global-border);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-3) var(--spacing-4);
+  font-size: var(--font-size-4);
+  font-family: inherit;
+  line-height: 1.5;
+  width: 100%;
+}
+
+.select:focus {
+  outline: none;
+  border-color: var(--button-primary-background);
+}
+
+.select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loading {
+  font-size: var(--font-size-3);
+  color: var(--global-mute-text);
+  margin-top: var(--spacing-2);
+}

--- a/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.tsx
+++ b/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export const SessionsNewPage: FC<Props> = ({ projects }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const [_isPending, startTransition] = useTransition()
+  const [, startTransition] = useTransition()
   const [state, formAction, isPending] = useActionState(createSession, {
     success: false,
   })
@@ -88,7 +88,7 @@ export const SessionsNewPage: FC<Props> = ({ projects }) => {
                   >
                     <option value="">Select a branch...</option>
                     {branchesState.branches.map((branch) => (
-                      <option key={branch.name} value={branch.sha}>
+                      <option key={branch.sha} value={branch.sha}>
                         {branch.name}
                         {branch.protected && ' (production)'}
                       </option>

--- a/frontend/apps/app/components/SessionsNewPage/actions/getBranches.ts
+++ b/frontend/apps/app/components/SessionsNewPage/actions/getBranches.ts
@@ -1,0 +1,76 @@
+'use server'
+
+import { createClient } from '@/libs/db/server'
+import { getRepositoryBranches } from '@liam-hq/github'
+import * as v from 'valibot'
+
+type BranchWithSha = {
+  name: string
+  protected: boolean
+  sha: string
+}
+
+type GetBranchesState = {
+  branches: BranchWithSha[]
+  loading: boolean
+  error?: string
+}
+
+const FormDataSchema = v.object({
+  projectId: v.string(),
+})
+
+export async function getBranches(
+  _prevState: GetBranchesState,
+  formData: FormData,
+): Promise<GetBranchesState> {
+  const rawData = {
+    projectId: formData.get('projectId'),
+  }
+
+  const parseResult = v.safeParse(FormDataSchema, rawData)
+  if (!parseResult.success) {
+    return { branches: [], loading: false, error: 'Invalid project ID' }
+  }
+
+  const { projectId } = parseResult.output
+
+  if (!projectId) {
+    return { branches: [], loading: false }
+  }
+
+  const supabase = await createClient()
+  const { data: mapping, error } = await supabase
+    .from('project_repository_mappings')
+    .select(`
+      github_repositories(
+        id, name, owner, github_installation_identifier
+      )
+    `)
+    .eq('project_id', projectId)
+    .single()
+
+  if (error || !mapping) {
+    console.error('Error fetching branches', error)
+    return {
+      branches: [],
+      loading: false,
+      error: 'Failed to fetch project information',
+    }
+  }
+
+  const repository = mapping.github_repositories
+  const branches = await getRepositoryBranches(
+    Number(repository.github_installation_identifier),
+    repository.owner,
+    repository.name,
+  )
+
+  const branchesWithSha: BranchWithSha[] = branches.map((branch) => ({
+    name: branch.name,
+    protected: branch.protected,
+    sha: branch.commit.sha,
+  }))
+
+  return { branches: branchesWithSha, loading: false }
+}


### PR DESCRIPTION
## Issue

- resolve: Add project and branch selection functionality to SessionsNewPage

## Why is this change needed?

Currently, SessionsNewPage creates sessions without associating them with specific projects. There is a need to start sessions based on specific project schemas, allowing users to work with existing database schemas from their repositories.

## What would you like reviewers to focus on?

- Implementation of useActionState with server actions for branch fetching
- Proper use of useTransition for action calls
- Form data validation using valibot
- Error handling and user feedback
- Accessibility and UX of the dropdown selections

## Testing Verification


https://github.com/user-attachments/assets/118dddef-8854-42bf-91d6-1c49c4baae4c

Currently I get an error when I select Project and try to create it.
The goal of this PR is to get to the point where the branch can be sent over the data fetch, and the error will be corrected in the next PR.

## What was done

### 🤖 Generated by PR Agent at 95064f20a04c86bf4b3283cf6484a1819e3e63ae

- Add project and branch selection to `SessionsNewPage`
  - Fetch and display projects for selection
  - Dynamically load branches based on selected project
  - Show loading and error states for branch fetching
- Improve form UI and accessibility with new styles
- Integrate backend logic for branch retrieval via server action


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getBranches.ts</strong><dd><code>Add server action for fetching project branches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/SessionsNewPage/actions/getBranches.ts

<li>Introduced new server action to fetch branches for a selected project<br> <li> Validates input and handles errors for branch retrieval<br> <li> Maps branch data to include name, protection status, and SHA


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1912/files#diff-8b555cc97cfee9b37fba8f00e2a70ec0571a25fa6a1040457e06721bd0aac864">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SessionsNewPage.module.css</strong><dd><code>Add and update styles for selects and loading states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/SessionsNewPage/SessionsNewPage.module.css

<li>Added styles for select dropdowns and loading state<br> <li> Improved UI consistency for form elements<br> <li> Enhanced accessibility and disabled state visuals


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1912/files#diff-7f19a8e2cc870be28929080df9972b684f058a30fe72573fe7fb21ba1ae3ba0a">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Fetch and provide projects to SessionsNewPage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/app/(app)/app/design_sessions/new/page.tsx

<li>Fetches organization ID and projects on page load<br> <li> Passes projects as props to <code>SessionsNewPage</code>


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1912/files#diff-27454a8a0a768c9902dfd8cf65139b81e33ad13d87d8eb32bcddeca9a79c3d6c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SessionsNewPage.tsx</strong><dd><code>Add project and branch selection logic to SessionsNewPage</code></dd></summary>
<hr>

frontend/apps/app/components/SessionsNewPage/SessionsNewPage.tsx

<li>Added project dropdown and dynamic branch dropdown to form<br> <li> Integrated branch fetching logic with loading and error handling<br> <li> Updated form to accept and use project and branch selections<br> <li> Improved user experience and accessibility for new fields


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1912/files#diff-49d6f68aa49ed1d465494e1f03aa2e4086467e6fd70f61ffdfb0bc27ff66b054">+71/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

- Maintains backward compatibility - sessions can still be created without project selection
- Uses modern Next.js patterns with useActionState and server actions
- Follows existing code patterns and styling conventions
- No changes needed to existing createSession action (already supports projectId/gitSha)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>