### PR TITLE
🗑️(deps): Remove unused Vercel AI SDK dependency

### DIFF
--- a/frontend/apps/app/package.json
+++ b/frontend/apps/app/package.json
@@ -31,7 +31,6 @@
     "@trigger.dev/sdk": "3.3.17",
     "@types/react-syntax-highlighter": "15.5.13",
     "@vercel/otel": "1.12.0",
-    "ai": "4.3.16",
     "cheerio": "1.0.0",
     "clsx": "2.1.1",
     "codemirror": "6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       '@vercel/otel':
         specifier: 1.12.0
         version: 1.12.0(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
-      ai:
-        specifier: 4.3.16
-        version: 4.3.16(react@18.3.1)(zod@3.23.8)
       cheerio:
         specifier: 1.0.0
         version: 1.0.0


### PR DESCRIPTION
## Issue

- resolve: route06/liam-internal#4876

## Why is this change needed?

Vercel AI SDK (`ai` package v4.3.16) was installed as a dependency but not actually used anywhere in the codebase. All AI functionality is implemented using LangChain instead. This creates unnecessary dependency bloat and potential security risks.

## What would you like reviewers to focus on?

- Verify that no code actually imports or uses the `ai` package
- Confirm that the application builds and runs correctly after removal
- Check that AI/chat functionality still works as expected (powered by LangChain)

## Testing Verification

- ✅ Verified no imports of `ai` package exist in the codebase
- ✅ Application builds successfully (`pnpm build`)
- ✅ All existing AI functionality remains intact (uses LangChain)
- ✅ No breaking changes introduced

Note: The `ai` package still appears as a peer dependency of `langfuse-vercel` (used for telemetry), which is expected and harmless.

## What was done

pr_agent:summary

## Detailed Changes

pr_agent:walkthrough

## Additional Notes

- The package was likely added during initial development but never actually used
- All AI functionality (chat, agents, workflows) is implemented with LangChain
- This removal simplifies the dependency tree and reduces bundle size
- Future AI integrations should consider using LangChain to maintain consistency