### PR TITLE
🐛(app): Handle empty string for UUID fields in createSession

### DIFF
--- a/frontend/apps/app/components/SessionsNewPage/actions/createSession.ts
+++ b/frontend/apps/app/components/SessionsNewPage/actions/createSession.ts
@@ -15,9 +15,15 @@ type CreateSessionState = {
   error?: string
 }
 
+// A pipe that transforms an empty string to null.
+const emptyStringToNull = v.pipe(
+  v.string(),
+  v.transform((input) => (input === '' ? null : input)),
+)
+
 const FormDataSchema = v.object({
-  projectId: v.optional(v.nullable(v.string())),
-  parentDesignSessionId: v.optional(v.nullable(v.string())),
+  projectId: v.optional(v.nullable(emptyStringToNull)),
+  parentDesignSessionId: v.optional(v.nullable(emptyStringToNull)),
   gitSha: v.optional(v.nullable(v.string())),
 })
 
@@ -214,6 +220,7 @@ export async function createSession(
     .single()
 
   if (insertError) {
+    console.error('Error creating design session:', insertError)
     return { success: false, error: 'Failed to create design session' }
   }
 


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?
When creating a new design session without selecting a project, the `projectId` is sent as an empty string. The backend attempts to insert this empty string into a `uuid` type column in the database, which results in an `invalid input syntax for type uuid: ""` error. This change ensures that empty strings for `projectId` and `parentDesignSessionId` are converted to `null` using `valibot` before validation, preventing the error.

## What would you like reviewers to focus on?
Please review the use of `valibot` to create a custom schema (`emptyStringToNull`) for transforming empty strings to `null`. The schema was also improved to use `v.nullable()` for a cleaner implementation. Please confirm this is the correct and most efficient way to handle this transformation within our validation layer.

## Testing Verification
I have verified these changes locally by:
1. Running the application.
2. Navigating to the new session page (`/app/sessions/new`).
3. Submitting the form without selecting a project.
4. Observing that the session is created successfully without any database errors, and I am redirected to the new session page.
5. Confirmed that the `project_id` in the `design_sessions` table is correctly set to `NULL`.

## What was done
### 🤖 Generated by PR Agent at e4f6843087b42221787692bba9d68448486438df

- Convert empty string UUID fields to null before validation
- Add custom `emptyStringToNull` pipe using `valibot`
- Improve error logging for session creation failures


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createSession.ts</strong><dd><code>Handle empty string UUIDs and improve error logging in session </code><br><code>creation</code></dd></summary>
<hr>

frontend/apps/app/components/SessionsNewPage/actions/createSession.ts

<li>Added <code>emptyStringToNull</code> pipe to transform empty strings to null for <br>UUID fields<br> <li> Updated validation schema to use the new pipe for <code>projectId</code> and <br><code>parentDesignSessionId</code><br> <li> Enhanced error handling by logging insert errors to the console


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1946/files#diff-e161471691f0f50daf32e9b7b8d02855336ec30ce2d8b1783838ba9dab3e6127">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>