### PR TITLE
【BugFix】Error when buildAgent takes more than 15 seconds to respond.

### DIFF
--- a/frontend/apps/app/app/api/chat/route.ts
+++ b/frontend/apps/app/app/api/chat/route.ts
@@ -1,6 +1,9 @@
 import { processChatMessage } from '@liam-hq/agent'
 import { NextResponse } from 'next/server'
 
+// Keep maxDuration at 15 to avoid charges
+export const maxDuration = 15
+
 export async function POST(request: Request) {
   const {
     message,
@@ -28,8 +31,40 @@ export async function POST(request: Request) {
   const stream = new ReadableStream({
     async start(controller) {
       const encoder = new TextEncoder()
+      let lastActivityTime = Date.now()
+      let keepAliveInterval: NodeJS.Timeout | null = null
+
+      // Keep-alive mechanism to prevent timeout
+      // TODO: Remove this keep-alive implementation once ProcessIndicator provides a better solution
+      const startKeepAlive = () => {
+        keepAliveInterval = setInterval(() => {
+          const timeSinceLastActivity = Date.now() - lastActivityTime
+          // Send heartbeat if no activity for 8 seconds
+          if (timeSinceLastActivity > 8000) {
+            const elapsed = Math.floor(timeSinceLastActivity / 1000)
+            controller.enqueue(
+              encoder.encode(
+                `${JSON.stringify({
+                  type: 'heartbeat',
+                  content: `⏳ Processing... (${elapsed}s)`,
+                })}\n`,
+              ),
+            )
+            lastActivityTime = Date.now()
+          }
+        }, 5000) // Check every 5 seconds
+      }
+
+      const stopKeepAlive = () => {
+        if (keepAliveInterval) {
+          clearInterval(keepAliveInterval)
+          keepAliveInterval = null
+        }
+      }
 
       try {
+        startKeepAlive()
+
         // Process the chat message with streaming
         for await (const chunk of processChatMessage({
           message,
@@ -40,6 +75,8 @@ export async function POST(request: Request) {
           buildingSchemaId,
           latestVersionNumber,
         })) {
+          lastActivityTime = Date.now() // Update activity time
+
           if (chunk.type === 'text') {
             // Encode and enqueue the text chunk as JSON
             controller.enqueue(
@@ -71,6 +108,8 @@ export async function POST(request: Request) {
       } catch (error) {
         // Handle any unexpected errors
         controller.error(error)
+      } finally {
+        stopKeepAlive()
       }
     },
   })

--- a/frontend/apps/app/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/Chat/Chat.tsx
@@ -203,6 +203,16 @@ export const Chat: FC<Props> = ({ schemaData, tableGroups, designSession }) => {
               setProgressMessages((prev) =>
                 updateProgressMessages(prev, parsed.content),
               )
+            } else if (parsed.type === 'heartbeat') {
+              // Handle heartbeat messages to maintain connection
+              // TODO: Remove this heartbeat handling once ProcessIndicator provides a better solution
+              // Update progress messages with heartbeat content
+              setProgressMessages((prev) => {
+                const filtered = prev.filter(
+                  (msg) => !msg.includes('Processing...'),
+                )
+                return [...filtered, parsed.content]
+              })
             } else if (parsed.type === 'error') {
               // Handle error message
               console.error('Stream error:', parsed.content)

--- a/frontend/apps/app/components/Chat/services/aiMessageService.ts
+++ b/frontend/apps/app/components/Chat/services/aiMessageService.ts
@@ -135,9 +135,7 @@ const processStreamLine = (
       // TODO: Remove this heartbeat handling once ProcessIndicator provides a better solution
       // Update progress messages with heartbeat content
       setProgressMessages((prev) => {
-        const filtered = prev.filter(
-          (msg) => !msg.includes('Processing...'),
-        )
+        const filtered = prev.filter((msg) => !msg.includes('Processing...'))
         return [...filtered, parsed.content]
       })
     } else if (parsed.type === 'error') {


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

Add a temporary keep-alive mechanism to prevent Vercel's 15-second timeout limit during long-running AI processing, particularly with the o3 model in Build mode.

- **API Route (`/api/chat/route.ts`)**:
  - Added `maxDuration = 15` to stay within free tier limits
  - Implemented heartbeat mechanism that sends keep-alive messages every 5 seconds when no activity for 8+ seconds
  - Added proper cleanup with `finally` block

- **Frontend (`frontend/apps/app/components/Chat/services/aiMessageService.ts)**:
  - Added handling for `heartbeat` message type
  - Updates progress messages to show processing status with elapsed time
  - Filters duplicate "Processing..." messages

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
