### PR TITLE
🔧(turbo): Configure outputLogs errors-only to reduce AI agent token usage

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,8 @@
         "NEXT_PUBLIC_ENV_NAME",
         "TRIGGER_ACCESS_TOKEN",
         "TRIGGER_PROJECT_ID"
-      ]
+      ],
+      "outputLogs": "errors-only"
     },
     "@liam-hq/jobs#deploy": {
       "dependsOn": ["^build"],
@@ -53,12 +54,16 @@
       "persistent": true
     },
     "gen": {
-      "dependsOn": ["^gen"]
+      "dependsOn": ["^gen"],
+      "outputLogs": "errors-only"
     },
     "lint": {
-      "dependsOn": ["gen", "^build", "^lint"]
+      "dependsOn": ["gen", "^build", "^lint"],
+      "outputLogs": "errors-only"
     },
-    "fmt": {},
+    "fmt": {
+      "outputLogs": "errors-only"
+    },
     "test": {
       "dependsOn": ["^build", "gen"],
       "outputs": []


### PR DESCRIPTION
## Issue

- resolve: Reduce token usage when AI agents run lint commands while maintaining error visibility

## Why is this change needed?

When AI agents execute build tools like lint, gen, and fmt through Turborepo, the verbose output consumes significant tokens. By configuring `outputLogs: "errors-only"`, we maintain error visibility for debugging while dramatically reducing unnecessary output that agents don't need to process.

## What would you like reviewers to focus on?

- Verify that error output is still properly displayed for debugging
- Confirm that the configuration covers all relevant build tasks
- Check that this doesn't break any existing CI/CD workflows

## Testing Verification

### Success
```sh
❯ pnpm lint:turbo --force

> liam-frontend@0.0.1 lint:turbo /Users/mh4gf/ghq/github.com/liam-hq/liam
> turbo lint --force

────────────────────────────────────────────────────────────────────

                  Update available v2.5.3 ≫ v2.5.4
 Changelog: https://github.com/vercel/turborepo/releases/tag/v2.5.4
       Run "pnpm dlx @turbo/codemod@latest update" to update

       Follow @turborepo for updates: https://x.com/turborepo
────────────────────────────────────────────────────────────────────
turbo 2.5.3

• Packages in scope: @liam-hq/agent, @liam-hq/app, @liam-hq/cli, @liam-hq/configs, @liam-hq/db, @liam-hq/db-structure, @liam-hq/docs, @liam-hq/e2e, @liam-hq/erd-core, @liam-hq/erd-sample, @liam-hq/figma-to-css-variables, @liam-hq/github, @liam-hq/jobs, @liam-hq/mcp-server, @liam-hq/pglite-server, @liam-hq/storybook, @liam-hq/ui
• Running lint in 17 packages
• Remote caching disabled

 Tasks:    24 successful, 24 total
Cached:    0 cached, 24 total
  Time:    19.754s
```

### Failure

```sh
❯ pnpm lint:turbo

> liam-frontend@0.0.1 lint:turbo /Users/mh4gf/ghq/github.com/liam-hq/liam
> turbo lint

────────────────────────────────────────────────────────────────────

                  Update available v2.5.3 ≫ v2.5.4
 Changelog: https://github.com/vercel/turborepo/releases/tag/v2.5.4
       Run "pnpm dlx @turbo/codemod@latest update" to update

       Follow @turborepo for updates: https://x.com/turborepo
────────────────────────────────────────────────────────────────────
turbo 2.5.3

• Packages in scope: @liam-hq/agent, @liam-hq/app, @liam-hq/cli, @liam-hq/configs, @liam-hq/db, @liam-hq/db-structure, @liam-hq/docs, @liam-hq/e2e, @liam-hq/erd-core, @liam-hq/erd-sample, @liam-hq/figma-to-css-variables, @liam-hq/github, @liam-hq/jobs, @liam-hq/mcp-server, @liam-hq/pglite-server, @liam-hq/storybook, @liam-hq/ui
• Running lint in 17 packages
• Remote caching disabled
@liam-hq/agent:lint: cache miss, executing 74fc4e76a3a16063
@liam-hq/agent:lint:
@liam-hq/agent:lint:
@liam-hq/agent:lint: > @liam-hq/agent@0.1.0 lint /Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/internal-packages/agent
@liam-hq/agent:lint: > concurrently "pnpm:lint:*"
@liam-hq/agent:lint:
@liam-hq/agent:lint: [eslint]
@liam-hq/agent:lint: [eslint] > @liam-hq/agent@0.1.0 lint:eslint /Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/internal-packages/agent
@liam-hq/agent:lint: [eslint] > eslint .
@liam-hq/agent:lint: [eslint]
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome] > @liam-hq/agent@0.1.0 lint:biome /Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/internal-packages/agent
@liam-hq/agent:lint: [biome] > biome check .
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [tsc]
@liam-hq/agent:lint: [tsc] > @liam-hq/agent@0.1.0 lint:tsc /Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/internal-packages/agent
@liam-hq/agent:lint: [tsc] > tsc --noEmit
@liam-hq/agent:lint: [tsc]
@liam-hq/agent:lint: [biome] ./src/chat/workflow/shared/stateManager.ts organizeImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome]   × Import statements could be sorted:
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome]       1   1 │   import { schemaSchema } from '@liam-hq/db-structure'
@liam-hq/agent:lint: [biome]       2     │ - import·type·{·WorkflowState·}·from·'../types'
@liam-hq/agent:lint: [biome]       3     │ - import·*·as·v·from·'valibot'
@liam-hq/agent:lint: [biome]           2 │ + import·*·as·v·from·'valibot'
@liam-hq/agent:lint: [biome]           3 │ + import·type·{·WorkflowState·}·from·'../types'
@liam-hq/agent:lint: [biome]       4   4 │
@liam-hq/agent:lint: [biome]       5   5 │   /**
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome] check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome]   × Some errors were emitted while running checks.
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome] Skipped 1 suggested fixes.
@liam-hq/agent:lint: [biome] If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
@liam-hq/agent:lint: [biome]
@liam-hq/agent:lint: [biome] Checked 35 files in 8ms. No fixes applied.
@liam-hq/agent:lint: [biome] Found 1 error.
@liam-hq/agent:lint: [biome]  ELIFECYCLE  Command failed with exit code 1.
@liam-hq/agent:lint: [biome] pnpm run lint:biome exited with code 1
@liam-hq/agent:lint: [tsc] pnpm run lint:tsc exited with code 0
@liam-hq/agent:lint: [eslint] pnpm run lint:eslint exited with code 0
@liam-hq/agent:lint:  ELIFECYCLE  Command failed with exit code 1.
@liam-hq/agent:lint: ERROR: command finished with error: command (/Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/internal-packages/agent) /Users/mh4gf/.asdf/installs/nodejs/22.16.0/bin/pnpm run lint exited (1)
@liam-hq/agent#lint: command (/Users/mh4gf/ghq/github.com/liam-hq/liam/frontend/internal-packages/agent) /Users/mh4gf/.asdf/installs/nodejs/22.16.0/bin/pnpm run lint exited (1)

 Tasks:    22 successful, 23 total
Cached:    21 cached, 23 total
  Time:    2.847s
Failed:    @liam-hq/agent#lint

 ERROR  run failed: command  exited (1)
 ELIFECYCLE  Command failed with exit code 1.
```

## What was done

### 🤖 Generated by PR Agent at 4049ba47d9858d737e085712f2f6f03dae52795f

• Configure `outputLogs: "errors-only"` for build tools to reduce AI agent token usage
• Apply setting to build, gen, lint, and fmt tasks in turbo.json
• Maintain error visibility while minimizing verbose output


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>turbo.json</strong><dd><code>Configure outputLogs errors-only for build tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

turbo.json

• Added <code>"outputLogs": "errors-only"</code> to build, gen, lint, and fmt tasks<br> <br>• Modified fmt task from empty object to explicit configuration<br> • <br>Maintained all existing dependencies and configurations


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1994/files#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This change specifically targets AI agent efficiency while preserving developer experience for error handling.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>