### PR TITLE
🔧 Fix Langfuse output logging in job environments by setting flushAt: 1

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/utils/telemetry.ts
+++ b/frontend/internal-packages/agent/src/langchain/utils/telemetry.ts
@@ -6,5 +6,7 @@ export const createLangfuseHandler = () => {
     secretKey: process.env['LANGFUSE_SECRET_KEY'] || '',
     baseUrl: process.env['LANGFUSE_BASE_URL'] || 'https://cloud.langfuse.com',
     environment: process.env['NEXT_PUBLIC_ENV_NAME'] || 'development',
+    // flushAt: 1 ensures events are sent immediately, preventing loss when job processes terminate
+    flushAt: 1,
   })
 }


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

## Problem
After moving `processChatMessage` to run as a job, Langfuse was only capturing input events but failing to save output events. This resulted in incomplete logging and loss of important AI response data.

![ss 3418](https://github.com/user-attachments/assets/29ebb227-b8f3-4b68-941f-5a9712e35d99)



## Solution
Added `flushAt: 1` configuration to the Langfuse callback handler to resolve the event loss issue in job environments.

### Job Environment Problem

```javascript
Event occurs → Accumulates in batch → Job completes → Process terminates → Events not sent!
```

**In job environments, processes terminate immediately upon completion**, causing batched events (especially outputs) to be lost before they can be sent.

### Solution

With `flushAt: 1`:

```javascript
Event occurs → Sent immediately → Job completes → Process terminates ✅
```

This ensures that events are sent to Langfuse immediately rather than being batched, preventing the loss of output logs when job processes terminate.

## Changes
- Modified `frontend/internal-packages/agent/src/langchain/utils/telemetry.ts` to include `flushAt: 1` in the LangfuseCallbackHandler configuration
- Added explanatory comment documenting why this setting is critical for job environments

This fix ensures that all Langfuse events, including AI outputs, are properly logged when chat processing runs in job environments.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

Confirmed to work in local environment✅

https://cloud.langfuse.com/project/cm8ii4o5o03fpad078o638g1d/traces/c3bc86c3-f178-4cb7-b2aa-1f77e3543809?timestamp=2025-06-13T07:24:40.461Z&display=details

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 480d42b8b105de724c9944859046521758c4fe52

• Fix Langfuse output logging in job environments
• Add flushAt: 1 configuration for immediate event sending
• Prevent event loss when job processes terminate


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>telemetry.ts</strong><dd><code>Configure immediate event flushing for Langfuse handler</code>&nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/langchain/utils/telemetry.ts

• Added <code>flushAt: 1</code> configuration to LangfuseCallbackHandler<br> • Added <br>explanatory comment about preventing event loss in job environments


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/1997/files#diff-77ce7ebbc17a2d4218142f0b14ac2bcfae2fdc11f296de84f056c2c52aa93c78">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>