### PR TITLE
fix: resolve parameter mismatch in `update_building_schema` RPC call

### DIFF
--- a/frontend/internal-packages/agent/src/repositories/supabase.ts
+++ b/frontend/internal-packages/agent/src/repositories/supabase.ts
@@ -284,7 +284,6 @@ export class SupabaseSchemaRepository implements SchemaRepository {
       p_schema_version_patch: JSON.parse(JSON.stringify(patch)),
       p_schema_version_reverse_patch: JSON.parse(JSON.stringify(reversePatch)),
       p_latest_schema_version_number: actualLatestVersionNumber,
-      p_design_session_id: buildingSchema.design_session_id,
       p_message_content: messageContent,
     }
 

--- a/frontend/internal-packages/db/supabase/database.types.ts
+++ b/frontend/internal-packages/db/supabase/database.types.ts
@@ -1327,22 +1327,14 @@ export type Database = {
         Returns: undefined
       }
       update_building_schema: {
-        Args:
-          | {
-              p_schema_id: string
-              p_schema_schema: Json
-              p_schema_version_patch: Json
-              p_schema_version_reverse_patch: Json
-              p_latest_schema_version_number: number
-            }
-          | {
-              p_schema_id: string
-              p_schema_schema: Json
-              p_schema_version_patch: Json
-              p_schema_version_reverse_patch: Json
-              p_latest_schema_version_number: number
-              p_message_content: string
-            }
+        Args: {
+          p_schema_id: string
+          p_schema_schema: Json
+          p_schema_version_patch: Json
+          p_schema_version_reverse_patch: Json
+          p_latest_schema_version_number: number
+          p_message_content: string
+        }
         Returns: Json
       }
       vector_avg: {

--- a/frontend/internal-packages/db/supabase/migrations/20250616032711_drop_old_update_building_schema.sql
+++ b/frontend/internal-packages/db/supabase/migrations/20250616032711_drop_old_update_building_schema.sql
@@ -1,0 +1,16 @@
+begin;
+
+-- Drop the old 5-parameter version of update_building_schema
+-- This resolves the function overload conflict that causes 404 errors in Supabase REST API
+DROP FUNCTION IF EXISTS public.update_building_schema(
+  p_schema_id uuid,
+  p_schema_schema jsonb,
+  p_schema_version_patch jsonb,
+  p_schema_version_reverse_patch jsonb,
+  p_latest_schema_version_number integer
+);
+
+-- The 6-parameter version with p_message_content should remain
+-- (Already created in migration 20250613164943_revert_to_message_content_param.sql)
+
+commit;


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I implemented two fixes to resolve 404 errors in `update_building_schema` RPC calls:

1. **Client fix**(https://github.com/liam-hq/liam/pull/2021/commits/1b9ca0d8b141558ccf72c91dbfdfc6b063956693): Removed extra `p_design_session_id` parameter from `rpcParams` to match the 6-parameter function signature (**this resolves the 404 error**)
2. **Database cleanup**(https://github.com/liam-hq/liam/pull/2021/commits/6178aced43f98048c7cad6b999b85622dd120e7b ): Added migration to drop the old 5-parameter function version (**not related to this error**, but prevents future conflicts since `supabase db squash` would likely preserve both versions)

Both the parameter mismatch and function overload issues are now resolved.


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

✅ Confirmed update_building_schema RPC calls are now successful.

![ss 3426](https://github.com/user-attachments/assets/1c98f58f-6c63-4941-ad7a-34315b984600)


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
