### PR TITLE
⚙️(renovate): Add dev-tools automerge group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,13 +21,6 @@
       ]
     },
     {
-      "groupName": "langfuse",
-      "matchPackageNames": [
-        "/^langfuse$/",
-        "/^langfuse-langchain$/"
-      ]
-    },
-    {
       "matchUpdateTypes": [
         "patch"
       ],
@@ -40,7 +33,9 @@
       "description": "Automerge dependencies only used by internal packages",
       "matchPackageNames": [
         "@modelcontextprotocol/sdk",
-        "style-dictionary"
+        "style-dictionary",
+        "/^langfuse$/",
+        "/^langfuse-langchain$/"
       ],
       "matchPaths": ["frontend/internal-packages/**"],
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,33 @@
       ],
       "matchPaths": ["frontend/internal-packages/**"],
       "automerge": true
+    },
+    {
+      "groupName": "dev-tools",
+      "description": "Automerge development tools that only need CI to pass",
+      "matchPackageNames": [
+        "eslint",
+        "/^eslint-/",
+        "/^@eslint/",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser",
+        "biome",
+        "@biomejs/biome",
+        "typescript",
+        "turbo",
+        "@types/node",
+        "/^@types/",
+        "vitest",
+        "/^@vitest/",
+        "playwright",
+        "@playwright/test",
+        "pnpm",
+        "knip"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Issue

- N/A

## Why is this change needed?
To improve dependency management efficiency by automatically merging development tool updates that only need CI to pass.

## What would you like reviewers to focus on?
- The list of packages included in the `dev-tools` automerge group
- Whether any critical build tools were inadvertently included (vite packages have been intentionally excluded)

## Testing Verification
The JSON file has been validated and follows the existing Renovate configuration patterns.

## What was done
pr_agent:summary

## Detailed Changes
pr_agent:walkthrough

## Additional Notes
- Added a new `dev-tools` automerge group for development dependencies that only need CI to pass
- Consolidated the langfuse packages into the internal packages automerge rule since they're used by internal packages
