### PR TITLE
🐛 fix(TableDetail): hide `DrawerContent` component when table is not set when table is not selected

### DIFF
--- a/.changeset/polite-forks-repair.md
+++ b/.changeset/polite-forks-repair.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+🐛 fix(TableDetail): hide `DrawerContent` component when table is not set when table is not selected

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -46,9 +46,11 @@ export const TableDetailDrawer: FC = () => {
 
   return (
     <DrawerPortal>
-      <DrawerContent className={styles.content} {...ariaDescribedBy}>
-        {table !== undefined && <TableDetail table={table} />}
-      </DrawerContent>
+      {table !== undefined && (
+        <DrawerContent className={styles.content} {...ariaDescribedBy}>
+          <TableDetail table={table} />
+        </DrawerContent>
+      )}
     </DrawerPortal>
   )
 }


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

When you visit the application without selecting tables, it raises the following error:

```
DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.
If you want to hide the `DialogTitle`, you can wrap it with our VisuallyHidden component.
```

This is because `DialogTitle` is missing but `DialogContent` is rendered when table is not selected.
This PR will hide `DialogContent` when table is not selected, so that the error doesn't occurs.

|||
|-|-|
|[select table](https://liam-app-git-fix-hide-overflow-text-of-table-column-liambx.vercel.app/erd/p/github.com/mastodon/mastodon/blob/1bc28709ccde4106ab7d654ad5888a14c6bb1724/db/schema.rb?active=email_domain_blocks)|![Screenshot 0007-06-17 at 21 03 03](https://github.com/user-attachments/assets/77ccf7f9-99fd-41cd-9c0b-adcb6d69f347)|
|[don't select table](https://liam-app-git-fix-hide-overflow-text-of-table-column-liambx.vercel.app/erd/p/github.com/mastodon/mastodon/blob/1bc28709ccde4106ab7d654ad5888a14c6bb1724/db/schema.rb)|![Screenshot 0007-06-17 at 21 02 45](https://github.com/user-attachments/assets/b85a40f5-9e4c-420e-9091-b4c078b703ef)|


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- this change doesn't change the other behaviours.

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

- [open the application without selecting table](https://liam-app-git-fix-table-details-title-error-liambx.vercel.app/erd/p/github.com/mastodon/mastodon/blob/1bc28709ccde4106ab7d654ad5888a14c6bb1724/db/schema.rb) and see console.

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at a152b88eae71d84eeda89f9da3372a150ecd5a04

• Fix accessibility error by conditionally rendering DrawerContent
• Prevent DialogTitle error when no table is selected
• Add changeset for patch version bump


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>polite-forks-repair.md</strong><dd><code>Add changeset for TableDetail fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/polite-forks-repair.md

• Add changeset entry for patch version bump<br> • Document fix for <br>TableDetail DrawerContent rendering issue


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2052/files#diff-ba230b7ef5339025396751954cebb9ee09be61617cc3680d91d8e1ca2d38588b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TableDetailDrawer.tsx</strong><dd><code>Conditionally render DrawerContent when table exists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx

• Wrap DrawerContent in conditional rendering based on table existence<br> <br>• Prevent rendering DrawerContent when table is undefined<br> • Fix <br>accessibility error for screen readers


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2052/files#diff-8f049a4119f11369199f62caf8ae16b0f19ab591a92004c589ae8787e4d60469">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>