### PR TITLE
✨(storybook): Add Inter and Montserrat fonts to match main app

### DIFF
--- a/frontend/internal-packages/storybook/.storybook/preview-head.html
+++ b/frontend/internal-packages/storybook/.storybook/preview-head.html
@@ -1,4 +1,14 @@
 <link rel="stylesheet" href="@liam-hq/ui/src/styles/globals.css" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 <style>
-  /* Add any additional global styles for Storybook here */
+  /* Apply fonts to match main app layout.tsx exactly */
+  .sb-show-main {
+    font-family: Inter, sans-serif;
+  }
+
+  :root {
+    --message-font: Montserrat;
+  }
 </style>


### PR DESCRIPTION
## Issue

- resolve: Storybook components were not using the same fonts as the main application

## Why is this change needed?
Storybook should visually match the main application to provide accurate component previews. The main app uses Inter and Montserrat fonts, but Storybook was using default fonts, creating inconsistency between development preview and production.

## What would you like reviewers to focus on?
- Font loading implementation using Google Fonts preconnect
- CSS application targeting Storybook's specific selectors
- Consistency with main app font configuration

## Testing Verification
- Verified Storybook components now display with Inter font family
- Confirmed Montserrat is available for message components via CSS variable
- Tested that fonts load properly in Storybook preview

## What was done
### 🤖 Generated by PR Agent at 115ee372350ad9cdb330ab7a91cc02bb64494c28

• Add Inter and Montserrat fonts to Storybook preview
• Configure Google Fonts preconnect for performance
• Apply font styling to match main application
• Set CSS variables for consistent typography


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>preview-head.html</strong><dd><code>Configure Google Fonts for Storybook preview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/storybook/.storybook/preview-head.html

• Added Google Fonts preconnect links for Inter and Montserrat<br> • <br>Applied Inter font family to <code>.sb-show-main</code> selector<br> • Set <br><code>--message-font</code> CSS variable to Montserrat<br> • Replaced placeholder <br>comment with actual font configuration


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2060/files#diff-5f8dc34211a368b20ad1a392af385f2de0ead37bd074de47e257d783f84292fe">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This change ensures Storybook accurately represents the visual appearance of components as they would appear in the main application.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>