### PR TITLE
🔧 fix(agent): fix createVersion validation error by updating response schema 

### DIFF
--- a/frontend/internal-packages/agent/src/repositories/supabase.ts
+++ b/frontend/internal-packages/agent/src/repositories/supabase.ts
@@ -20,7 +20,8 @@ import type {
 const updateBuildingSchemaResultSchema = v.union([
   v.object({
     success: v.literal(true),
-    versionNumber: v.number(),
+    messageId: v.string(),
+    versionId: v.string(),
   }),
   v.object({
     success: v.literal(false),


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This PR fixes the validation error in the `createVersion` method that was causing "Invalid response from server" errors.

The `updateBuildingSchemaResultSchema` was expecting a different response format than what the Supabase RPC `update_building_schema` actually returns.

**Expected response (old schema):**
```json
{
   "success": true,
   "versionNumber": 123
}
```

Actual response from RPC:
```json
{
   "success": true,
   "messageId": "79b25cc3-a769-4d97-94ad-3039a98d67f8",
   "versionId": "3101e2b3-1377-447e-9333-b8045d805869"
}
```

Updated updateBuildingSchemaResultSchema to match the actual RPC response:
- Removed versionNumber: v.number()
- Added messageId: v.string()
- Added versionId: v.string()

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->


I confirmed that the workflow works correctly in the local environment ✅

before
![ss 3453](https://github.com/user-attachments/assets/18664c37-0341-424d-82ca-030fb757dbbc)


after
![ss 3454](https://github.com/user-attachments/assets/ae80c82f-c2e5-4cd3-8b27-1769bf71cd5f)



## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 529aaeeab2d3478b36bb09320756397f77eb66b1

• Fix validation error in `createVersion` method by updating response schema
• Replace `versionNumber` field with `messageId` and `versionId` fields
• Align schema with actual Supabase RPC response format
• Resolve "Invalid response from server" errors


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>supabase.ts</strong><dd><code>Update schema validation for RPC response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/repositories/supabase.ts

• Updated <code>updateBuildingSchemaResultSchema</code> to match actual RPC <br>response<br> • Replaced <code>versionNumber: v.number()</code> with <code>messageId: </code><br><code>v.string()</code> and <code>versionId: v.string()</code><br> • Fixed validation mismatch <br>causing server response errors


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2068/files#diff-ed3762a807ca099d58aa326390fab5b78aa063bfcb42965c7e1bf90376a22825">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>