### PR TITLE
🔧 add "root": false to biome configuration files

### DIFF
--- a/frontend/apps/app/biome.jsonc
+++ b/frontend/apps/app/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/apps/docs/biome.jsonc
+++ b/frontend/apps/docs/biome.jsonc
@@ -1,5 +1,6 @@
 {
   "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false,
   "linter": {
     "rules": {
       "style": {

--- a/frontend/internal-packages/agent/biome.jsonc
+++ b/frontend/internal-packages/agent/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/internal-packages/db/biome.jsonc
+++ b/frontend/internal-packages/db/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/internal-packages/e2e/biome.jsonc
+++ b/frontend/internal-packages/e2e/biome.jsonc
@@ -1,5 +1,6 @@
 {
   "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false,
   "files": {
     "includes": ["**", "!**/test-results"]
   },

--- a/frontend/internal-packages/figma-to-css-variables/biome.jsonc
+++ b/frontend/internal-packages/figma-to-css-variables/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/internal-packages/github/biome.jsonc
+++ b/frontend/internal-packages/github/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/internal-packages/jobs/biome.jsonc
+++ b/frontend/internal-packages/jobs/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/internal-packages/mcp-server/biome.jsonc
+++ b/frontend/internal-packages/mcp-server/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }

--- a/frontend/packages/cli/biome.jsonc
+++ b/frontend/packages/cli/biome.jsonc
@@ -1,5 +1,6 @@
 {
   "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false,
   "linter": {
     "rules": {
       "correctness": {

--- a/frontend/packages/db-structure/biome.jsonc
+++ b/frontend/packages/db-structure/biome.jsonc
@@ -1,5 +1,6 @@
 {
   "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false,
   "files": {
     "includes": ["**", "!**/src/parser/schemarb/parser.js"]
   },

--- a/frontend/packages/erd-core/biome.jsonc
+++ b/frontend/packages/erd-core/biome.jsonc
@@ -1,5 +1,6 @@
 {
   "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false,
   "linter": {
     "rules": {
       "correctness": {

--- a/frontend/packages/pglite-server/biome.jsonc
+++ b/frontend/packages/pglite-server/biome.jsonc
@@ -1,5 +1,6 @@
 {
   "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false,
   "files": {
     "includes": ["**", "!**/dist/**"]
   }

--- a/frontend/packages/ui/biome.jsonc
+++ b/frontend/packages/ui/biome.jsonc
@@ -1,3 +1,4 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "root": false
 }


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

When I updated to Biome v2, the formatting by Biome in VSCode stopped applying according to the rules in `/internal-packages/configs/biome.jsonc`. 

I was able to fix this by adding `"root": false` to the `biome.jsonc` in each package.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f0cd35ad-4530-4be9-8d88-0d7f9e817182" /> | <video src="https://github.com/user-attachments/assets/b2e6c099-c515-4cba-a5be-dcf3ed7e087b" /> | 


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
