### PR TITLE
🐛(erd-core): fix CSS specificity for RelationshipEdge hovered state

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/RelationshipEdge/RelationshipEdge.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/RelationshipEdge/RelationshipEdge.module.css
@@ -9,6 +9,6 @@
   opacity: 0;
 }
 
-.hovered {
+.edge.hovered {
   stroke: var(--node-layout);
 }


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
The organize imports feature (PR #2076) changed CSS loading order, causing ReactFlow's default styles to override the `.hovered` class due to equal CSS specificity. This resulted in edge hover styles not being properly applied.

## What would you like reviewers to focus on?
- Verify that the CSS specificity fix resolves the hover state issue
- Confirm that edge hover styles are now properly applied
- Check that the change doesn't introduce any visual regressions

## Testing Verification
Tested locally that RelationshipEdge hover styles now work correctly after the CSS specificity increase. The `.edge.hovered` selector has higher specificity than ReactFlow's default styles.

|before|after|
| --- | --- |
| <img width="1496" alt="image" src="https://github.com/user-attachments/assets/9f4c768a-0af1-4a1e-86ab-15dcc435d264" /> | <img width="1496" alt="image" src="https://github.com/user-attachments/assets/5f2d9420-bbc8-4899-be33-90d328e39f26" /> |





## What was done
### 🤖 Generated by PR Agent at 870c73df39bab8d0ac0365de1d6712019017b134

• Fix CSS specificity for RelationshipEdge hover state
• Resolve regression from organize imports feature
• Ensure edge hover styles override ReactFlow defaults


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RelationshipEdge.module.css</strong><dd><code>Increase CSS specificity for hover selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDContent/components/RelationshipEdge/RelationshipEdge.module.css

• Changed <code>.hovered</code> selector to <code>.edge.hovered</code> to increase CSS <br>specificity<br> • Ensures hover styles properly override ReactFlow's <br>default styles


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2091/files#diff-f50a03713c9876159fb18ac7a742ae81d27d021959fcd54cd9a7dad1585b0a2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This is a targeted fix for the regression introduced by the organize imports changes. The solution increases CSS specificity without changing the visual appearance or functionality.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>