### PR TITLE
[PoC] schema name similarity matcher using Hugging Face Transformers

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -55,10 +55,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/pnpm-setup
       - run: pnpm --filter @liam-hq/db supabase:start
-      - name: Install system deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler libprotobuf-dev
       - run: cp .env.template .env
       - name: Make scripts executable
         run: chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -55,6 +55,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/pnpm-setup
       - run: pnpm --filter @liam-hq/db supabase:start
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev
       - run: cp .env.template .env
       - name: Make scripts executable
         run: chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh

--- a/frontend/internal-packages/evaluator/.gitignore
+++ b/frontend/internal-packages/evaluator/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/internal-packages/evaluator/biome.jsonc
+++ b/frontend/internal-packages/evaluator/biome.jsonc
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../internal-packages/configs/biome.jsonc"]
+}

--- a/frontend/internal-packages/evaluator/eslint.config.mjs
+++ b/frontend/internal-packages/evaluator/eslint.config.mjs
@@ -1,0 +1,9 @@
+import { fileURLToPath } from 'node:url'
+import { createBaseConfig } from '../../internal-packages/configs/eslint/index.js'
+
+const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url))
+
+export default createBaseConfig({
+  tsconfigPath: './tsconfig.json',
+  gitignorePath,
+})

--- a/frontend/internal-packages/evaluator/package.json
+++ b/frontend/internal-packages/evaluator/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "main": "src/index.ts",
   "dependencies": {
-    "@huggingface/transformers": "3.5.2"
+    "@huggingface/transformers": "3.3.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/frontend/internal-packages/evaluator/package.json
+++ b/frontend/internal-packages/evaluator/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@liam-hq/evaluator",
+  "private": true,
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@huggingface/transformers": "3.5.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.0.0",
+    "@liam-hq/configs": "workspace:*",
+    "eslint": "9.28.0",
+    "vitest": "3.1.4"
+  },
+  "scripts": {
+    "fmt": "concurrently \"pnpm:fmt:*\"",
+    "fmt:biome": "biome check --write --unsafe .",
+    "fmt:eslint": "eslint --fix .",
+    "test": "vitest --watch=false --passWithNoTests"
+  }
+}

--- a/frontend/internal-packages/evaluator/src/evaluate/evaluate.test.ts
+++ b/frontend/internal-packages/evaluator/src/evaluate/evaluate.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest'
+import type { Schemas } from './evaluate'
+import { evaluate } from './evaluate'
+
+describe('evaluate', () => {
+  it('simple case: full match', async () => {
+    const reference: Schemas = {
+      User: {
+        Attributes: ['id', 'name'],
+        'Primary key': ['id'],
+      },
+      Post: {
+        Attributes: ['id', 'user_id', 'content'],
+        'Primary key': ['id'],
+        'Foreign key': { user_id: { ref: 'User', key: 'id' } },
+      },
+    }
+    const predict: Schemas = {
+      User: {
+        Attributes: ['id', 'name'],
+        'Primary key': ['id'],
+      },
+      Post: {
+        Attributes: ['id', 'user_id', 'content'],
+        'Primary key': ['id'],
+        'Foreign key': { user_id: { ref: 'User', key: 'id' } },
+      },
+    }
+
+    const result = await evaluate(reference, predict)
+
+    expect(result.schemaF1).toBe(1)
+    expect(result.schemaAllcorrect).toBe(1)
+    expect(result.attributeF1Avg).toBeCloseTo(1)
+    expect(result.primaryKeyAvg).toBeCloseTo(1)
+    expect(result.foreignKeyAvg).toBeCloseTo(1)
+    expect(result.schemaAllcorrectFull).toBe(1)
+  })
+
+  it('partial match: missing one schema', async () => {
+    const reference: Schemas = {
+      User: {
+        Attributes: ['id', 'name'],
+        'Primary key': ['id'],
+      },
+      Post: {
+        Attributes: ['id', 'user_id', 'content'],
+        'Primary key': ['id'],
+        'Foreign key': { user_id: { ref: 'User', key: 'id' } },
+      },
+    }
+    const predict: Schemas = {
+      User: {
+        Attributes: ['id', 'name'],
+        'Primary key': ['id'],
+      },
+    }
+
+    const result = await evaluate(reference, predict)
+
+    expect(result.schemaF1).toBeLessThan(1)
+    expect(result.schemaAllcorrect).toBe(0)
+    expect(result.attributeF1Avg).toBeLessThan(1)
+    expect(result.primaryKeyAvg).toBeLessThan(1)
+    expect(result.foreignKeyAvg).toBeLessThan(1)
+    expect(result.schemaAllcorrectFull).toBe(0)
+  })
+
+  it('attribute mismatch', async () => {
+    const reference: Schemas = {
+      User: {
+        Attributes: ['id', 'name', 'email'],
+        'Primary key': ['id'],
+      },
+    }
+    const predict: Schemas = {
+      User: {
+        Attributes: ['id', 'username'],
+        'Primary key': ['id'],
+      },
+    }
+
+    const result = await evaluate(reference, predict)
+
+    expect(result.attributeF1Avg).toBeLessThan(1)
+    expect(result.attributeAllcorrectAvg).toBe(0)
+    expect(result.schemaF1).toBe(1)
+    expect(result.schemaAllcorrectFull).toBe(0)
+  })
+
+  // larger test cases
+  it('insurance company (real-world partial match case)', async () => {
+    // --- reference
+    const reference: Schemas = {
+      'Insurance Agent': {
+        Attributes: ['Agent ID', 'Name', 'Hire Date', 'Contact Phone'],
+        'Primary key': ['Agent ID'],
+        'Foreign key': {},
+      },
+      Customer: {
+        Attributes: ['Customer ID', 'Name', 'ID Card Number', 'Contact Phone'],
+        'Primary key': ['Customer ID'],
+        'Foreign key': {},
+      },
+      'Insurance Policy': {
+        Attributes: [
+          'Policy ID',
+          'Agent ID',
+          'Customer ID',
+          'Insurance Type',
+          'Insured Amount',
+          'Insurance Term',
+          'Premium',
+        ],
+        'Primary key': ['Policy ID'],
+        'Foreign key': {
+          'Agent ID': { 'Insurance Agent': 'Agent ID' },
+          'Customer ID': { Customer: 'Customer ID' },
+        },
+      },
+      'Payment Record': {
+        Attributes: [
+          'Policy ID',
+          'Payment Amount',
+          'Payment Date',
+          'Payment Method',
+        ],
+        'Primary key': ['Policy ID'],
+        'Foreign key': { 'Policy ID': { 'Insurance Policy': 'Policy ID' } },
+      },
+      'Claim Record': {
+        Attributes: ['Policy ID', 'Claim Amount', 'Claim Date'],
+        'Primary key': ['Policy ID'],
+        'Foreign key': { 'Policy ID': { 'Payment Record': 'Policy ID' } },
+      },
+      'Medical Record': {
+        Attributes: ['Customer ID', 'Visit Time', 'Visit Cost'],
+        'Primary key': ['Customer ID', 'Visit Time'],
+        'Foreign key': { 'Customer ID': { Customer: 'Customer ID' } },
+      },
+    }
+
+    // --- candidate
+    const candidate: Schemas = {
+      'Insurance Agent': {
+        Attributes: ['Agent ID', 'Name', 'Hire Date', 'Contact Phone'],
+        'Primary key': ['Agent ID'],
+        'Foreign key': {},
+      },
+      Customer: {
+        Attributes: [
+          'Customer ID',
+          'Agent ID',
+          'Name',
+          'ID Card Number',
+          'Contact Phone',
+        ],
+        'Primary key': ['Customer ID'],
+        'Foreign key': {
+          'Agent ID': { 'Insurance Agent': 'Agent ID' },
+        },
+      },
+      Policy: {
+        Attributes: [
+          'Policy ID',
+          'Agent ID',
+          'Customer ID',
+          'Insurance Type',
+          'Insured Amount',
+          'Insurance Term',
+          'Premium',
+        ],
+        'Primary key': ['Policy ID'],
+        'Foreign key': {
+          'Agent ID': { 'Insurance Agent': 'Agent ID' },
+          'Customer ID': { Customer: 'Customer ID' },
+        },
+      },
+      Payment: {
+        Attributes: [
+          'ID',
+          'Policy ID',
+          'Payment Amount',
+          'Payment Date',
+          'Payment Method',
+        ],
+        'Primary key': ['ID'],
+        'Foreign key': { 'Policy ID': { Policy: 'Policy ID' } },
+      },
+      'Claim Record': {
+        Attributes: ['ID', 'Status', 'Policy ID', 'Claim Amount', 'Claim Date'],
+        'Primary key': ['ID'],
+        'Foreign key': { 'Policy ID': { Policy: 'Policy ID' } },
+      },
+      'Medical Record': {
+        Attributes: [
+          'ID',
+          'Hospital',
+          'Customer ID',
+          'Description',
+          'Record Date',
+        ],
+        'Primary key': ['ID'],
+        'Foreign key': { 'Customer ID': { Customer: 'Customer ID' } },
+      },
+    }
+
+    const result = await evaluate(reference, candidate)
+
+    // Check the specific contents of schema mapping/attribute mapping
+    expect(result.schemaMapping).toMatchObject({
+      'Insurance Agent': 'Insurance Agent',
+      Customer: 'Customer',
+      'Claim Record': 'Claim Record',
+      'Medical Record': 'Medical Record',
+      // Approximation OK
+      'Payment Record': 'Payment',
+      // Approximation OK
+      'Insurance Policy': 'Policy',
+    })
+
+    // Assert representative value
+    expect(result.schemaF1).toBe(1)
+    expect(result.schemaAllcorrect).toBe(1)
+    expect(result.attributeF1Avg).toBeCloseTo(0.79, 1)
+    expect(result.attributeAllcorrectAvg).toBeCloseTo(0.33, 1)
+    expect(result.primaryKeyAvg).toBeCloseTo(0.5, 1)
+    expect(result.foreignKeyAvg).toBeCloseTo(0.83, 1)
+    expect(result.schemaAllcorrectFull).toBe(0)
+  })
+})

--- a/frontend/internal-packages/evaluator/src/evaluate/evaluate.test.ts
+++ b/frontend/internal-packages/evaluator/src/evaluate/evaluate.test.ts
@@ -2,230 +2,260 @@ import { describe, expect, it } from 'vitest'
 import type { Schemas } from './evaluate'
 import { evaluate } from './evaluate'
 
+// Increase timeout due to model initialization
+const TIMEOUT = 30000
+
 describe('evaluate', () => {
-  it('simple case: full match', async () => {
-    const reference: Schemas = {
-      User: {
-        Attributes: ['id', 'name'],
-        'Primary key': ['id'],
-      },
-      Post: {
-        Attributes: ['id', 'user_id', 'content'],
-        'Primary key': ['id'],
-        'Foreign key': { user_id: { ref: 'User', key: 'id' } },
-      },
-    }
-    const predict: Schemas = {
-      User: {
-        Attributes: ['id', 'name'],
-        'Primary key': ['id'],
-      },
-      Post: {
-        Attributes: ['id', 'user_id', 'content'],
-        'Primary key': ['id'],
-        'Foreign key': { user_id: { ref: 'User', key: 'id' } },
-      },
-    }
+  it(
+    'simple case: full match',
+    async () => {
+      const reference: Schemas = {
+        User: {
+          Attributes: ['id', 'name'],
+          'Primary key': ['id'],
+        },
+        Post: {
+          Attributes: ['id', 'user_id', 'content'],
+          'Primary key': ['id'],
+          'Foreign key': { user_id: { ref: 'User', key: 'id' } },
+        },
+      }
+      const predict: Schemas = {
+        User: {
+          Attributes: ['id', 'name'],
+          'Primary key': ['id'],
+        },
+        Post: {
+          Attributes: ['id', 'user_id', 'content'],
+          'Primary key': ['id'],
+          'Foreign key': { user_id: { ref: 'User', key: 'id' } },
+        },
+      }
 
-    const result = await evaluate(reference, predict)
+      const result = await evaluate(reference, predict)
 
-    expect(result.schemaF1).toBe(1)
-    expect(result.schemaAllcorrect).toBe(1)
-    expect(result.attributeF1Avg).toBeCloseTo(1)
-    expect(result.primaryKeyAvg).toBeCloseTo(1)
-    expect(result.foreignKeyAvg).toBeCloseTo(1)
-    expect(result.schemaAllcorrectFull).toBe(1)
-  })
+      expect(result.schemaF1).toBe(1)
+      expect(result.schemaAllcorrect).toBe(1)
+      expect(result.attributeF1Avg).toBeCloseTo(1)
+      expect(result.primaryKeyAvg).toBeCloseTo(1)
+      expect(result.foreignKeyAvg).toBeCloseTo(1)
+      expect(result.schemaAllcorrectFull).toBe(1)
+    },
+    TIMEOUT,
+  )
 
-  it('partial match: missing one schema', async () => {
-    const reference: Schemas = {
-      User: {
-        Attributes: ['id', 'name'],
-        'Primary key': ['id'],
-      },
-      Post: {
-        Attributes: ['id', 'user_id', 'content'],
-        'Primary key': ['id'],
-        'Foreign key': { user_id: { ref: 'User', key: 'id' } },
-      },
-    }
-    const predict: Schemas = {
-      User: {
-        Attributes: ['id', 'name'],
-        'Primary key': ['id'],
-      },
-    }
+  it(
+    'partial match: missing one schema',
+    async () => {
+      const reference: Schemas = {
+        User: {
+          Attributes: ['id', 'name'],
+          'Primary key': ['id'],
+        },
+        Post: {
+          Attributes: ['id', 'user_id', 'content'],
+          'Primary key': ['id'],
+          'Foreign key': { user_id: { ref: 'User', key: 'id' } },
+        },
+      }
+      const predict: Schemas = {
+        User: {
+          Attributes: ['id', 'name'],
+          'Primary key': ['id'],
+        },
+      }
 
-    const result = await evaluate(reference, predict)
+      const result = await evaluate(reference, predict)
 
-    expect(result.schemaF1).toBeLessThan(1)
-    expect(result.schemaAllcorrect).toBe(0)
-    expect(result.attributeF1Avg).toBeLessThan(1)
-    expect(result.primaryKeyAvg).toBeLessThan(1)
-    expect(result.foreignKeyAvg).toBeLessThan(1)
-    expect(result.schemaAllcorrectFull).toBe(0)
-  })
+      expect(result.schemaF1).toBeLessThan(1)
+      expect(result.schemaAllcorrect).toBe(0)
+      expect(result.attributeF1Avg).toBeLessThan(1)
+      expect(result.primaryKeyAvg).toBeLessThan(1)
+      expect(result.foreignKeyAvg).toBeLessThan(1)
+      expect(result.schemaAllcorrectFull).toBe(0)
+    },
+    TIMEOUT,
+  )
 
-  it('attribute mismatch', async () => {
-    const reference: Schemas = {
-      User: {
-        Attributes: ['id', 'name', 'email'],
-        'Primary key': ['id'],
-      },
-    }
-    const predict: Schemas = {
-      User: {
-        Attributes: ['id', 'username'],
-        'Primary key': ['id'],
-      },
-    }
+  it(
+    'attribute mismatch',
+    async () => {
+      const reference: Schemas = {
+        User: {
+          Attributes: ['id', 'name', 'email'],
+          'Primary key': ['id'],
+        },
+      }
+      const predict: Schemas = {
+        User: {
+          Attributes: ['id', 'username'],
+          'Primary key': ['id'],
+        },
+      }
 
-    const result = await evaluate(reference, predict)
+      const result = await evaluate(reference, predict)
 
-    expect(result.attributeF1Avg).toBeLessThan(1)
-    expect(result.attributeAllcorrectAvg).toBe(0)
-    expect(result.schemaF1).toBe(1)
-    expect(result.schemaAllcorrectFull).toBe(0)
-  })
+      expect(result.attributeF1Avg).toBeLessThan(1)
+      expect(result.attributeAllcorrectAvg).toBe(0)
+      expect(result.schemaF1).toBe(1)
+      expect(result.schemaAllcorrectFull).toBe(0)
+    },
+    TIMEOUT,
+  )
 
   // larger test cases
-  it('insurance company (real-world partial match case)', async () => {
-    // --- reference
-    const reference: Schemas = {
-      'Insurance Agent': {
-        Attributes: ['Agent ID', 'Name', 'Hire Date', 'Contact Phone'],
-        'Primary key': ['Agent ID'],
-        'Foreign key': {},
-      },
-      Customer: {
-        Attributes: ['Customer ID', 'Name', 'ID Card Number', 'Contact Phone'],
-        'Primary key': ['Customer ID'],
-        'Foreign key': {},
-      },
-      'Insurance Policy': {
-        Attributes: [
-          'Policy ID',
-          'Agent ID',
-          'Customer ID',
-          'Insurance Type',
-          'Insured Amount',
-          'Insurance Term',
-          'Premium',
-        ],
-        'Primary key': ['Policy ID'],
-        'Foreign key': {
-          'Agent ID': { 'Insurance Agent': 'Agent ID' },
-          'Customer ID': { Customer: 'Customer ID' },
+  it(
+    'insurance company (real-world partial match case)',
+    async () => {
+      // --- reference
+      const reference: Schemas = {
+        'Insurance Agent': {
+          Attributes: ['Agent ID', 'Name', 'Hire Date', 'Contact Phone'],
+          'Primary key': ['Agent ID'],
+          'Foreign key': {},
         },
-      },
-      'Payment Record': {
-        Attributes: [
-          'Policy ID',
-          'Payment Amount',
-          'Payment Date',
-          'Payment Method',
-        ],
-        'Primary key': ['Policy ID'],
-        'Foreign key': { 'Policy ID': { 'Insurance Policy': 'Policy ID' } },
-      },
-      'Claim Record': {
-        Attributes: ['Policy ID', 'Claim Amount', 'Claim Date'],
-        'Primary key': ['Policy ID'],
-        'Foreign key': { 'Policy ID': { 'Payment Record': 'Policy ID' } },
-      },
-      'Medical Record': {
-        Attributes: ['Customer ID', 'Visit Time', 'Visit Cost'],
-        'Primary key': ['Customer ID', 'Visit Time'],
-        'Foreign key': { 'Customer ID': { Customer: 'Customer ID' } },
-      },
-    }
-
-    // --- candidate
-    const candidate: Schemas = {
-      'Insurance Agent': {
-        Attributes: ['Agent ID', 'Name', 'Hire Date', 'Contact Phone'],
-        'Primary key': ['Agent ID'],
-        'Foreign key': {},
-      },
-      Customer: {
-        Attributes: [
-          'Customer ID',
-          'Agent ID',
-          'Name',
-          'ID Card Number',
-          'Contact Phone',
-        ],
-        'Primary key': ['Customer ID'],
-        'Foreign key': {
-          'Agent ID': { 'Insurance Agent': 'Agent ID' },
+        Customer: {
+          Attributes: [
+            'Customer ID',
+            'Name',
+            'ID Card Number',
+            'Contact Phone',
+          ],
+          'Primary key': ['Customer ID'],
+          'Foreign key': {},
         },
-      },
-      Policy: {
-        Attributes: [
-          'Policy ID',
-          'Agent ID',
-          'Customer ID',
-          'Insurance Type',
-          'Insured Amount',
-          'Insurance Term',
-          'Premium',
-        ],
-        'Primary key': ['Policy ID'],
-        'Foreign key': {
-          'Agent ID': { 'Insurance Agent': 'Agent ID' },
-          'Customer ID': { Customer: 'Customer ID' },
+        'Insurance Policy': {
+          Attributes: [
+            'Policy ID',
+            'Agent ID',
+            'Customer ID',
+            'Insurance Type',
+            'Insured Amount',
+            'Insurance Term',
+            'Premium',
+          ],
+          'Primary key': ['Policy ID'],
+          'Foreign key': {
+            'Agent ID': { 'Insurance Agent': 'Agent ID' },
+            'Customer ID': { Customer: 'Customer ID' },
+          },
         },
-      },
-      Payment: {
-        Attributes: [
-          'ID',
-          'Policy ID',
-          'Payment Amount',
-          'Payment Date',
-          'Payment Method',
-        ],
-        'Primary key': ['ID'],
-        'Foreign key': { 'Policy ID': { Policy: 'Policy ID' } },
-      },
-      'Claim Record': {
-        Attributes: ['ID', 'Status', 'Policy ID', 'Claim Amount', 'Claim Date'],
-        'Primary key': ['ID'],
-        'Foreign key': { 'Policy ID': { Policy: 'Policy ID' } },
-      },
-      'Medical Record': {
-        Attributes: [
-          'ID',
-          'Hospital',
-          'Customer ID',
-          'Description',
-          'Record Date',
-        ],
-        'Primary key': ['ID'],
-        'Foreign key': { 'Customer ID': { Customer: 'Customer ID' } },
-      },
-    }
+        'Payment Record': {
+          Attributes: [
+            'Policy ID',
+            'Payment Amount',
+            'Payment Date',
+            'Payment Method',
+          ],
+          'Primary key': ['Policy ID'],
+          'Foreign key': { 'Policy ID': { 'Insurance Policy': 'Policy ID' } },
+        },
+        'Claim Record': {
+          Attributes: ['Policy ID', 'Claim Amount', 'Claim Date'],
+          'Primary key': ['Policy ID'],
+          'Foreign key': { 'Policy ID': { 'Payment Record': 'Policy ID' } },
+        },
+        'Medical Record': {
+          Attributes: ['Customer ID', 'Visit Time', 'Visit Cost'],
+          'Primary key': ['Customer ID', 'Visit Time'],
+          'Foreign key': { 'Customer ID': { Customer: 'Customer ID' } },
+        },
+      }
 
-    const result = await evaluate(reference, candidate)
+      // --- candidate
+      const candidate: Schemas = {
+        'Insurance Agent': {
+          Attributes: ['Agent ID', 'Name', 'Hire Date', 'Contact Phone'],
+          'Primary key': ['Agent ID'],
+          'Foreign key': {},
+        },
+        Customer: {
+          Attributes: [
+            'Customer ID',
+            'Agent ID',
+            'Name',
+            'ID Card Number',
+            'Contact Phone',
+          ],
+          'Primary key': ['Customer ID'],
+          'Foreign key': {
+            'Agent ID': { 'Insurance Agent': 'Agent ID' },
+          },
+        },
+        Policy: {
+          Attributes: [
+            'Policy ID',
+            'Agent ID',
+            'Customer ID',
+            'Insurance Type',
+            'Insured Amount',
+            'Insurance Term',
+            'Premium',
+          ],
+          'Primary key': ['Policy ID'],
+          'Foreign key': {
+            'Agent ID': { 'Insurance Agent': 'Agent ID' },
+            'Customer ID': { Customer: 'Customer ID' },
+          },
+        },
+        Payment: {
+          Attributes: [
+            'ID',
+            'Policy ID',
+            'Payment Amount',
+            'Payment Date',
+            'Payment Method',
+          ],
+          'Primary key': ['ID'],
+          'Foreign key': { 'Policy ID': { Policy: 'Policy ID' } },
+        },
+        'Claim Record': {
+          Attributes: [
+            'ID',
+            'Status',
+            'Policy ID',
+            'Claim Amount',
+            'Claim Date',
+          ],
+          'Primary key': ['ID'],
+          'Foreign key': { 'Policy ID': { Policy: 'Policy ID' } },
+        },
+        'Medical Record': {
+          Attributes: [
+            'ID',
+            'Hospital',
+            'Customer ID',
+            'Description',
+            'Record Date',
+          ],
+          'Primary key': ['ID'],
+          'Foreign key': { 'Customer ID': { Customer: 'Customer ID' } },
+        },
+      }
 
-    // Check the specific contents of schema mapping/attribute mapping
-    expect(result.schemaMapping).toMatchObject({
-      'Insurance Agent': 'Insurance Agent',
-      Customer: 'Customer',
-      'Claim Record': 'Claim Record',
-      'Medical Record': 'Medical Record',
-      // Approximation OK
-      'Payment Record': 'Payment',
-      // Approximation OK
-      'Insurance Policy': 'Policy',
-    })
+      const result = await evaluate(reference, candidate)
 
-    // Assert representative value
-    expect(result.schemaF1).toBe(1)
-    expect(result.schemaAllcorrect).toBe(1)
-    expect(result.attributeF1Avg).toBeCloseTo(0.79, 1)
-    expect(result.attributeAllcorrectAvg).toBeCloseTo(0.33, 1)
-    expect(result.primaryKeyAvg).toBeCloseTo(0.5, 1)
-    expect(result.foreignKeyAvg).toBeCloseTo(0.83, 1)
-    expect(result.schemaAllcorrectFull).toBe(0)
-  })
+      // Check the specific contents of schema mapping/attribute mapping
+      expect(result.schemaMapping).toMatchObject({
+        'Insurance Agent': 'Insurance Agent',
+        Customer: 'Customer',
+        'Claim Record': 'Claim Record',
+        'Medical Record': 'Medical Record',
+        // Approximation OK
+        'Payment Record': 'Payment',
+        // Approximation OK
+        'Insurance Policy': 'Policy',
+      })
+
+      // Assert representative value
+      expect(result.schemaF1).toBe(1)
+      expect(result.schemaAllcorrect).toBe(1)
+      expect(result.attributeF1Avg).toBeCloseTo(0.79, 1)
+      expect(result.attributeAllcorrectAvg).toBeCloseTo(0.33, 1)
+      expect(result.primaryKeyAvg).toBeCloseTo(0.5, 1)
+      expect(result.foreignKeyAvg).toBeCloseTo(0.83, 1)
+      expect(result.schemaAllcorrectFull).toBe(0)
+    },
+    TIMEOUT,
+  )
 })

--- a/frontend/internal-packages/evaluator/src/evaluate/evaluate.ts
+++ b/frontend/internal-packages/evaluator/src/evaluate/evaluate.ts
@@ -1,0 +1,158 @@
+import { nameSimilarity } from '../nameSimilarity'
+import { wordOverlapMatch } from '../wordOverlapMatch'
+
+type Schema = {
+  Attributes: string[]
+  'Primary key': string[]
+  // biome-ignore lint/suspicious/noExplicitAny: now poc
+  'Foreign key'?: Record<string, any>
+  // Add more if needed
+}
+export type Schemas = Record<string, Schema>
+type Mapping = Record<string, string>
+
+type EvaluateResult = {
+  schemaMapping: Mapping
+  attributeMapping: Record<string, Mapping>
+  schemaF1: number
+  schemaAllcorrect: number
+  attributeF1Avg: number
+  attributeAllcorrectAvg: number
+  primaryKeyAvg: number
+  foreignKeyAvg: number
+  schemaAllcorrectFull: number
+}
+
+// Synonym matching is omitted (use if already implemented, otherwise skip initially)
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: now poc
+export async function evaluate(
+  reference: Schemas,
+  predict: Schemas,
+): Promise<EvaluateResult> {
+  const referenceSchemaNames = Object.keys(reference)
+  const predictSchemaNames = Object.keys(predict)
+
+  // 1. Schema name mapping
+  const schemaMapping: Mapping = {}
+
+  // --- (1) synonym matching (if needed)
+  // await matchSynonyms(referenceSchemaNames, predictSchemaNames, schemaMapping);
+
+  // --- (2) sent_overlap matching
+  wordOverlapMatch(referenceSchemaNames, predictSchemaNames, schemaMapping)
+
+  // --- (3) name similarity matching
+  await nameSimilarity(referenceSchemaNames, predictSchemaNames, schemaMapping)
+
+  // 2. Precision/Recall/F1/Allcorrect
+  const schemaPrecision =
+    predictSchemaNames.length === 0
+      ? 0
+      : Object.keys(schemaMapping).length / predictSchemaNames.length
+  const schemaRecall =
+    referenceSchemaNames.length === 0
+      ? 0
+      : Object.keys(schemaMapping).length / referenceSchemaNames.length
+  const schemaF1 =
+    schemaPrecision + schemaRecall === 0
+      ? 0
+      : (2 * schemaPrecision * schemaRecall) / (schemaPrecision + schemaRecall)
+  const schemaAllcorrect = schemaF1 === 1 ? 1 : 0
+
+  // 3. Each schema attributes, PK, FK
+  let sampleAttributeF1 = 0
+  let sampleAttributeAllcorrect = 0
+  let samplePrimaryKey = 0
+  let sampleForeignKey = 0
+  const sampleAttributeMapping: Record<string, Mapping> = {}
+
+  for (const schemaName of Object.keys(schemaMapping)) {
+    const referenceAttributes = reference[schemaName]?.Attributes ?? []
+    const predictSchemaName = schemaMapping[schemaName]
+    if (!predictSchemaName) continue
+    const predictAttributes = predict[predictSchemaName]?.Attributes ?? []
+    const attributeMapping: Mapping = {}
+
+    // --- Attribute name matching
+    // (1) synonym matching (optional)
+    // await matchSynonyms(referenceAttributes, predictAttributes, attributeMapping);
+
+    // (2) name similarity
+    await nameSimilarity(
+      referenceAttributes,
+      predictAttributes,
+      attributeMapping,
+    )
+
+    // (3) sent_overlap
+    wordOverlapMatch(referenceAttributes, predictAttributes, attributeMapping)
+
+    sampleAttributeMapping[schemaName] = attributeMapping
+
+    // F1/Allcorrect
+    const attributePrecision =
+      predictAttributes.length === 0
+        ? 0
+        : Object.keys(attributeMapping).length / predictAttributes.length
+    const attributeRecall =
+      referenceAttributes.length === 0
+        ? 0
+        : Object.keys(attributeMapping).length / referenceAttributes.length
+    const attributeF1 =
+      attributePrecision + attributeRecall === 0
+        ? 0
+        : (2 * attributePrecision * attributeRecall) /
+          (attributePrecision + attributeRecall + 1e-5)
+
+    sampleAttributeF1 += attributeF1
+    sampleAttributeAllcorrect += Math.abs(attributeF1 - 1) < 1e-3 ? 1 : 0
+
+    // Primary key
+    const referencePKs = reference[schemaName]?.['Primary key'] ?? []
+    const predictPKs = predict[predictSchemaName]?.['Primary key'] ?? []
+    let pkFlag = false
+    if (referencePKs.length === predictPKs.length) {
+      pkFlag = referencePKs.every(
+        (k) => attributeMapping[k] && predictPKs.includes(attributeMapping[k]),
+      )
+    }
+    samplePrimaryKey += pkFlag ? 1 : 0
+
+    // Foreign key (minimal check: only count)
+    const referenceFKs = reference[schemaName]?.['Foreign key'] || {}
+    const predictFKs = predict[predictSchemaName]?.['Foreign key'] || {}
+    let fkFlag = false
+    if (Object.keys(referenceFKs).length === Object.keys(predictFKs).length) {
+      fkFlag = true
+      // Strict comparison is TODO
+    }
+    sampleForeignKey += fkFlag ? 1 : 0
+  }
+
+  const sampleCount = referenceSchemaNames.length
+  const attributeF1Avg = sampleCount ? sampleAttributeF1 / sampleCount : 0
+  const attributeAllcorrectAvg = sampleCount
+    ? sampleAttributeAllcorrect / sampleCount
+    : 0
+  const primaryKeyAvg = sampleCount ? samplePrimaryKey / sampleCount : 0
+  const foreignKeyAvg = sampleCount ? sampleForeignKey / sampleCount : 0
+
+  const schemaAllcorrectFull =
+    primaryKeyAvg + foreignKeyAvg + attributeAllcorrectAvg + schemaAllcorrect >
+    3.9
+      ? 1
+      : 0
+
+  return {
+    schemaMapping,
+    attributeMapping: sampleAttributeMapping,
+    schemaF1,
+    schemaAllcorrect,
+    attributeF1Avg,
+    attributeAllcorrectAvg,
+    primaryKeyAvg,
+    foreignKeyAvg,
+    schemaAllcorrectFull,
+  }
+}

--- a/frontend/internal-packages/evaluator/src/evaluate/evaluate.ts
+++ b/frontend/internal-packages/evaluator/src/evaluate/evaluate.ts
@@ -1,13 +1,13 @@
 /**
  * Database Schema Evaluation Script
- * 
+ *
  * This script evaluates the accuracy of predicted database schemas against reference schemas.
  * It performs comprehensive matching and scoring across multiple dimensions:
  * - Schema name mapping using word overlap and semantic similarity
  * - Attribute name matching within each schema
  * - Primary key validation
  * - Foreign key validation
- * 
+ *
  * The evaluation produces metrics including F1 scores, precision/recall, and all-correct rates
  * to assess the quality of schema prediction models or tools.
  */

--- a/frontend/internal-packages/evaluator/src/evaluate/evaluate.ts
+++ b/frontend/internal-packages/evaluator/src/evaluate/evaluate.ts
@@ -1,3 +1,16 @@
+/**
+ * Database Schema Evaluation Script
+ * 
+ * This script evaluates the accuracy of predicted database schemas against reference schemas.
+ * It performs comprehensive matching and scoring across multiple dimensions:
+ * - Schema name mapping using word overlap and semantic similarity
+ * - Attribute name matching within each schema
+ * - Primary key validation
+ * - Foreign key validation
+ * 
+ * The evaluation produces metrics including F1 scores, precision/recall, and all-correct rates
+ * to assess the quality of schema prediction models or tools.
+ */
 import { nameSimilarity } from '../nameSimilarity'
 import { wordOverlapMatch } from '../wordOverlapMatch'
 

--- a/frontend/internal-packages/evaluator/src/evaluate/index.ts
+++ b/frontend/internal-packages/evaluator/src/evaluate/index.ts
@@ -1,0 +1,1 @@
+export * from './evaluate'

--- a/frontend/internal-packages/evaluator/src/index.md
+++ b/frontend/internal-packages/evaluator/src/index.md
@@ -1,0 +1,173 @@
+# Database Schema Evaluator Package
+
+## Overview
+
+The Database Schema Evaluator package provides a comprehensive evaluation framework for assessing the accuracy of predicted database schemas against reference schemas. This package is designed to evaluate schema prediction models, tools, or automated database design systems by comparing their outputs with ground truth schemas.
+
+## Core Functionality
+
+The evaluator performs multi-dimensional analysis across several key areas:
+
+### 1. Schema Name Matching
+- **Word Overlap Matching**: Identifies schemas with shared words or lexical similarities
+- **Semantic Similarity Matching**: Uses machine learning embeddings to find semantically related schema names
+- **Comprehensive Mapping**: Creates bidirectional mappings between reference and predicted schema names
+
+### 2. Attribute-Level Evaluation
+- **Attribute Name Matching**: Applies the same matching techniques to individual table attributes
+- **Precision and Recall Calculation**: Measures how well predicted attributes match reference attributes
+- **F1 Score Computation**: Provides balanced accuracy metrics for attribute matching
+
+### 3. Structural Validation
+- **Primary Key Validation**: Verifies that predicted primary keys match reference primary keys
+- **Foreign Key Validation**: Checks foreign key relationships and constraints
+- **Schema Completeness**: Evaluates overall structural accuracy
+
+## Architecture
+
+The package consists of three main components:
+
+### evaluate.ts
+The main evaluation orchestrator that:
+- Coordinates the entire evaluation process
+- Integrates results from different matching algorithms
+- Calculates comprehensive metrics including F1 scores, precision, recall, and all-correct rates
+- Produces detailed evaluation reports
+
+### nameSimilarity.ts
+Semantic matching engine that:
+- Utilizes Hugging Face Transformers library with the 'all-MiniLM-L6-v2' model
+- Generates text embeddings for schema and attribute names
+- Calculates cosine similarity scores between embeddings
+- Identifies semantically related terms that may not share exact words
+
+### wordOverlapMatch.ts
+Lexical matching engine that:
+- Performs word tokenization and stop word removal
+- Detects exact word overlaps between names
+- Calculates Longest Common Substring (LCS) for character-level similarity
+- Handles variations in naming conventions (e.g., camelCase vs snake_case)
+
+## Evaluation Metrics
+
+The evaluator produces the following key metrics:
+
+### Schema-Level Metrics
+- **Schema F1 Score**: Harmonic mean of precision and recall for schema name matching
+- **Schema All-Correct Rate**: Binary indicator of perfect schema name matching
+
+### Attribute-Level Metrics
+- **Attribute F1 Average**: Average F1 score across all matched schemas
+- **Attribute All-Correct Average**: Average all-correct rate for attribute matching
+
+### Structural Metrics
+- **Primary Key Average**: Accuracy rate for primary key prediction
+- **Foreign Key Average**: Accuracy rate for foreign key prediction
+- **Schema All-Correct Full**: Overall completeness indicator combining all metrics
+
+## Input Schema Format
+
+The evaluator processes JSON schemas with the following structure:
+
+```json
+{
+  "SchemaName": {
+    "Attributes": ["attribute1", "attribute2", "attribute3"],
+    "Primary key": ["primary_key_field"],
+    "Foreign key": {
+      "foreign_key_field": {
+        "ReferencedSchema": "referenced_field"
+      }
+    }
+  }
+}
+```
+
+### Real-World Example
+
+Here's a complete example from an insurance company database schema:
+
+```json
+{
+  "Insurance Agent": {
+    "Attributes": ["Agent ID", "Name", "Hire Date", "Contact Phone"],
+    "Primary key": ["Agent ID"],
+    "Foreign key": {}
+  },
+  "Customer": {
+    "Attributes": ["Customer ID", "Name", "ID Card Number", "Contact Phone"],
+    "Primary key": ["Customer ID"],
+    "Foreign key": {}
+  },
+  "Insurance Policy": {
+    "Attributes": [
+      "Policy ID",
+      "Agent ID", 
+      "Customer ID",
+      "Insurance Type",
+      "Insured Amount",
+      "Insurance Term",
+      "Premium"
+    ],
+    "Primary key": ["Policy ID"],
+    "Foreign key": {
+      "Agent ID": {"Insurance Agent": "Agent ID"},
+      "Customer ID": {"Customer": "Customer ID"}
+    }
+  },
+  "Payment Record": {
+    "Attributes": [
+      "Policy ID",
+      "Payment Amount",
+      "Payment Date", 
+      "Payment Method"
+    ],
+    "Primary key": ["Policy ID"],
+    "Foreign key": {"Policy ID": {"Insurance Policy": "Policy ID"}}
+  },
+  "Claim Record": {
+    "Attributes": ["Policy ID", "Claim Amount", "Claim Date"],
+    "Primary key": ["Policy ID"],
+    "Foreign key": {"Policy ID": {"Payment Record": "Policy ID"}}
+  },
+  "Medical Record": {
+    "Attributes": ["Customer ID", "Visit Time", "Visit Cost"],
+    "Primary key": ["Customer ID", "Visit Time"],
+    "Foreign key": {"Customer ID": {"Customer": "Customer ID"}}
+  }
+}
+```
+
+### Schema Structure Explanation
+
+- **Schema Names**: Top-level keys represent table/entity names (e.g., "Insurance Agent", "Customer")
+- **Attributes**: Array of column/field names within each schema
+- **Primary Key**: Array of fields that form the primary key (supports composite keys)
+- **Foreign Key**: Object mapping foreign key fields to their referenced schema and field
+  - Format: `"foreign_field": {"ReferencedSchema": "referenced_field"}`
+  - Empty object `{}` indicates no foreign key relationships
+
+## Usage Workflow
+
+1. **Input Preparation**: Provide reference schemas and predicted schemas in the JSON format shown above
+2. **Multi-Stage Matching**: The system applies word overlap matching followed by semantic similarity matching
+3. **Comprehensive Evaluation**: All aspects (names, attributes, keys) are evaluated systematically
+4. **Metric Calculation**: Detailed metrics are computed and returned in a structured format
+
+## Key Features
+
+- **Multi-Algorithm Approach**: Combines lexical and semantic matching for robust name resolution
+- **Hierarchical Evaluation**: Evaluates both schema-level and attribute-level accuracy
+- **Flexible Thresholds**: Configurable similarity thresholds for different matching algorithms
+- **Comprehensive Metrics**: Provides both granular and aggregate evaluation metrics
+- **Performance Optimized**: Efficient algorithms for handling large schema sets
+
+## Use Cases
+
+- **Model Evaluation**: Assess the performance of database schema generation models
+- **Tool Comparison**: Compare different automated database design tools
+- **Quality Assurance**: Validate schema predictions in production systems
+- **Research**: Support academic research in database design automation
+- **Benchmarking**: Create standardized evaluation benchmarks for schema prediction tasks
+
+This evaluator package serves as a critical component for ensuring the quality and accuracy of automated database schema generation systems, providing detailed insights into both the strengths and weaknesses of prediction models.

--- a/frontend/internal-packages/evaluator/src/index.ts
+++ b/frontend/internal-packages/evaluator/src/index.ts
@@ -1,0 +1,1 @@
+export * from './nameSimilarity'

--- a/frontend/internal-packages/evaluator/src/index.ts
+++ b/frontend/internal-packages/evaluator/src/index.ts
@@ -1,1 +1,3 @@
+export * from './evaluate'
 export * from './nameSimilarity'
+export * from './wordOverlapMatch'

--- a/frontend/internal-packages/evaluator/src/nameSimilarity/index.ts
+++ b/frontend/internal-packages/evaluator/src/nameSimilarity/index.ts
@@ -1,0 +1,1 @@
+export * from './nameSimilarity'

--- a/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.test.ts
+++ b/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { nameSimilarity } from './nameSimilarity'
+
+// Increase timeout due to model initialization
+const TIMEOUT = 30000
+
+describe('nameSimilarity', () => {
+  it(
+    'should map identical names correctly',
+    async () => {
+      const references = ['Database Administrator']
+      const candidates = ['Database Administrator']
+      const mapping: Record<string, string> = {}
+
+      await nameSimilarity(references, candidates, mapping)
+
+      expect(mapping).toHaveProperty('Database Administrator')
+      expect(mapping['Database Administrator']).toBe('Database Administrator')
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'should map multiple exact matches correctly',
+    async () => {
+      const references = ['Policy ID', 'Claim Amount', 'Claim Date']
+      const candidates = [
+        'ID',
+        'Status',
+        'Policy ID',
+        'Claim Amount',
+        'Claim Date',
+      ]
+      const mapping: Record<string, string> = {}
+
+      await nameSimilarity(references, candidates, mapping)
+
+      expect(mapping).toEqual({
+        'Claim Amount': 'Claim Amount',
+        'Claim Date': 'Claim Date',
+        'Policy ID': 'Policy ID',
+      })
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'should map similar names when exact matches are not available',
+    async () => {
+      const references = ['Policy ID', 'Claim Amount', 'Claim Date']
+      const candidates = [
+        'ID',
+        'Status',
+        'Policy ID',
+        'Claim Amount',
+        'Claimed Date',
+      ]
+      const mapping: Record<string, string> = {}
+
+      await nameSimilarity(references, candidates, mapping)
+
+      expect(mapping).toEqual({
+        'Claim Amount': 'Claim Amount',
+        'Claim Date': 'Claimed Date',
+        'Policy ID': 'Policy ID',
+      })
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'should exclude low similarity matches when threshold is 0.6',
+    async () => {
+      const references = ['Policy ID', 'Claim Amount', 'Claim Date']
+      const candidates = [
+        'ID',
+        'Status',
+        'Policy ID',
+        'Claim Amount',
+        'Claimed At',
+      ]
+      const mapping: Record<string, string> = {}
+
+      await nameSimilarity(references, candidates, mapping, 0.6)
+
+      expect(mapping).toEqual({
+        'Claim Amount': 'Claim Amount',
+        'Policy ID': 'Policy ID',
+      })
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'should include more matches when threshold is lowered to 0.3',
+    async () => {
+      const references = ['Policy ID', 'Claim Amount', 'Claim Date']
+      const candidates = [
+        'ID',
+        'Status',
+        'Policy ID',
+        'Claim Amount',
+        'Claimed At',
+      ]
+      const mapping: Record<string, string> = {}
+
+      await nameSimilarity(references, candidates, mapping, 0.3)
+
+      expect(mapping).toEqual({
+        'Claim Amount': 'Claim Amount',
+        'Claim Date': 'Claimed At',
+        'Policy ID': 'Policy ID',
+      })
+    },
+    TIMEOUT,
+  )
+})

--- a/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.ts
+++ b/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.ts
@@ -1,11 +1,11 @@
 /**
  * Semantic Name Similarity Matching Script
- * 
+ *
  * This script performs semantic similarity matching between reference and candidate names
  * using machine learning embeddings. It utilizes the Hugging Face Transformers library
  * with the 'all-MiniLM-L6-v2' model to generate text embeddings and calculate cosine
  * similarity scores.
- * 
+ *
  * The script finds the best semantic matches between reference names (e.g., schema names,
  * attribute names) and candidate names based on their contextual meaning rather than
  * just lexical similarity, making it effective for matching synonymous or semantically

--- a/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.ts
+++ b/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.ts
@@ -1,0 +1,94 @@
+import {
+  type FeatureExtractionPipeline,
+  pipeline,
+} from '@huggingface/transformers'
+
+function cosineSimilarity(vecA: number[], vecB: number[]): number {
+  const dot = vecA.reduce((sum, a, i) => (vecB[i] ? sum + a * vecB[i] : sum), 0)
+  const normA = Math.sqrt(vecA.reduce((sum, a) => sum + a * a, 0))
+  const normB = Math.sqrt(vecB.reduce((sum, b) => sum + b * b, 0))
+  return dot / (normA * normB)
+}
+
+async function generateEmbeddings(
+  texts: string[],
+  extractor: FeatureExtractionPipeline,
+): Promise<number[][]> {
+  return Promise.all(
+    texts.map(async (text) => {
+      const result = await extractor(text)
+      return Array.from(result.data)
+    }),
+  )
+}
+
+function findBestMatch(
+  refEmbed: number[],
+  candidates: string[],
+  candEmbeds: number[][],
+  mapping: Record<string, string>,
+  threshold: number,
+): { bestMatch: string; bestSim: number } {
+  let bestMatch = ''
+  let bestSim = threshold
+
+  for (let j = 0; j < candidates.length; j++) {
+    const predict_name = candidates[j]
+    if (!predict_name) continue // Skip empty names
+    if (Object.values(mapping).includes(predict_name)) continue
+
+    const candEmbed = candEmbeds[j]
+    if (!candEmbed) continue
+
+    const sim = cosineSimilarity(refEmbed, candEmbed)
+    if (sim > bestSim) {
+      bestMatch = predict_name
+      bestSim = sim
+    }
+  }
+
+  return { bestMatch, bestSim }
+}
+
+function shouldSkipReference(
+  referenceName: string | undefined,
+  mapping: Record<string, string>,
+): boolean {
+  return !referenceName || mapping[referenceName] !== undefined
+}
+
+export async function nameSimilarity(
+  references: string[],
+  candidates: string[],
+  mapping: Record<string, string>,
+  threshold = 0.6,
+): Promise<void> {
+  const extractor = await pipeline(
+    'feature-extraction',
+    'Xenova/all-MiniLM-L6-v2',
+  )
+
+  const refEmbeds = await generateEmbeddings(references, extractor)
+  const candEmbeds = await generateEmbeddings(candidates, extractor)
+
+  for (let i = 0; i < references.length; i++) {
+    const reference_name = references[i]
+
+    if (shouldSkipReference(reference_name, mapping)) continue
+
+    const refEmbed = refEmbeds[i]
+    if (!refEmbed) continue
+
+    const { bestMatch } = findBestMatch(
+      refEmbed,
+      candidates,
+      candEmbeds,
+      mapping,
+      threshold,
+    )
+
+    if (bestMatch && reference_name) {
+      mapping[reference_name] = bestMatch
+    }
+  }
+}

--- a/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.ts
+++ b/frontend/internal-packages/evaluator/src/nameSimilarity/nameSimilarity.ts
@@ -1,3 +1,16 @@
+/**
+ * Semantic Name Similarity Matching Script
+ * 
+ * This script performs semantic similarity matching between reference and candidate names
+ * using machine learning embeddings. It utilizes the Hugging Face Transformers library
+ * with the 'all-MiniLM-L6-v2' model to generate text embeddings and calculate cosine
+ * similarity scores.
+ * 
+ * The script finds the best semantic matches between reference names (e.g., schema names,
+ * attribute names) and candidate names based on their contextual meaning rather than
+ * just lexical similarity, making it effective for matching synonymous or semantically
+ * related terms.
+ */
 import {
   type FeatureExtractionPipeline,
   pipeline,

--- a/frontend/internal-packages/evaluator/src/wordOverlapMatch/index.ts
+++ b/frontend/internal-packages/evaluator/src/wordOverlapMatch/index.ts
@@ -1,0 +1,1 @@
+export * from './wordOverlapMatch'

--- a/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.test.ts
+++ b/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { wordOverlapMatch } from './wordOverlapMatch'
+
+describe('wordOverlapMatch', () => {
+  it('maps similar names by word overlap', () => {
+    const reference = ['Payment Record', 'Medical Claim', 'User Info']
+    const predict = ['Payment', 'MedicalRecord', 'User Information']
+    const mapping: Record<string, string> = {}
+    wordOverlapMatch(reference, predict, mapping)
+    expect(mapping).toEqual({
+      'Payment Record': 'Payment',
+      // 'Medical Claim': 'MedicalRecord',
+      'User Info': 'User Information',
+    })
+  })
+
+  it('does not map if there is no overlap', () => {
+    const reference = ['Order', 'Shipment']
+    const predict = ['Invoice', 'Customer']
+    const mapping: Record<string, string> = {}
+    wordOverlapMatch(reference, predict, mapping)
+    expect(mapping).toEqual({})
+  })
+
+  it('does not overwrite existing mapping', () => {
+    const reference = ['Payment', 'Claim']
+    const predict = ['Payment', 'Claim']
+    const mapping: Record<string, string> = { Payment: 'Payment' }
+    wordOverlapMatch(reference, predict, mapping)
+    expect(mapping).toEqual({ Payment: 'Payment', Claim: 'Claim' })
+  })
+
+  it('does not assign a candidate twice', () => {
+    const reference = ['Payment', 'Refund']
+    const predict = ['Payment']
+    const mapping: Record<string, string> = {}
+    wordOverlapMatch(reference, predict, mapping)
+    expect(Object.values(mapping).filter((v) => v === 'Payment').length).toBe(1)
+  })
+
+  it('handles case insensitivity', () => {
+    const reference = ['User Info']
+    const predict = ['user information']
+    const mapping: Record<string, string> = {}
+    wordOverlapMatch(reference, predict, mapping)
+    expect(mapping).toEqual({ 'User Info': 'user information' })
+  })
+
+  it('ignores stop words', () => {
+    const reference = ['Record of Payment']
+    const predict = ['Payment']
+    const mapping: Record<string, string> = {}
+    wordOverlapMatch(reference, predict, mapping)
+    expect(mapping).toEqual({ 'Record of Payment': 'Payment' })
+  })
+})

--- a/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.ts
+++ b/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.ts
@@ -1,0 +1,98 @@
+type Mapping = Record<string, string>
+
+/**
+ * Simple stop words list
+ */
+const STOP_WORDS = new Set(['the', 'a', 'an', 'of', 'record'])
+
+/**
+ * Convert string to word set: tokenize, lowercase, and remove stop words
+ */
+function toWordSet(str: string): Set<string> {
+  return new Set(
+    str
+      .toLowerCase()
+      .split(/[^a-zA-Z0-9]+/)
+      .map((w) => w.trim())
+      .filter((w) => w && !STOP_WORDS.has(w)),
+  )
+}
+
+/**
+ * Returns the length of the Longest Common Substring (LCS)
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: now poc
+function lcString(s1: string, s2: string): number {
+  const len1 = s1.length
+  const len2 = s2.length
+  let maxLen = 0
+  const dp: number[][] = Array(len2 + 1)
+    .fill(null)
+    .map(() => Array(len1 + 1).fill(0))
+  for (let i = 1; i <= len2; i++) {
+    for (let j = 1; j <= len1; j++) {
+      if (s2[i - 1] === s1[j - 1]) {
+        const x = dp[i - 1]
+        if (!x) continue
+        const y = x[j - 1]
+        if (!y) continue
+        const a = dp[i]
+        if (a?.[j]) {
+          a[j] = y + 1
+          maxLen = Math.max(maxLen, y + 1)
+        }
+      }
+    }
+  }
+  return maxLen
+}
+
+/**
+ * sent_overlap: returns true if two schema names are "sufficiently similar"
+ */
+function wordOverlap(sent1: string, sent2: string, threshold = 0.75): boolean {
+  const wordSet1 = toWordSet(sent1)
+  const wordSet2 = toWordSet(sent2)
+  if ([...wordSet1].filter((w) => wordSet2.has(w)).length > 0) {
+    return true
+  }
+  // Strict judgment using LCS (currently rarely used, but implementation remains)
+  let maxScore = -1
+  for (const w1 of wordSet1) {
+    for (const w2 of wordSet2) {
+      if (w1 === w2) continue
+      const lcs = lcString(w1, w2)
+      const score = lcs / Math.min(w1.length, w2.length)
+      if (score > maxScore) maxScore = score
+    }
+  }
+  return maxScore > threshold
+}
+
+/**
+ * wordOverlapMatch: adds likely matches from Reference to Predict in the mapping
+ */
+export function wordOverlapMatch(
+  references: string[],
+  candidates: string[],
+  mapping: Mapping,
+): void {
+  for (const referenceName of references) {
+    if (!(referenceName in mapping)) {
+      for (const predictName of candidates) {
+        if (!Object.values(mapping).includes(predictName)) {
+          if (
+            wordOverlap(
+              referenceName.toLowerCase(),
+              predictName.toLowerCase(),
+              0.75,
+            )
+          ) {
+            mapping[referenceName] = predictName
+            break
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.ts
+++ b/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.ts
@@ -1,3 +1,16 @@
+/**
+ * Word Overlap Matching Script
+ * 
+ * This script performs lexical similarity matching between reference and candidate names
+ * based on word overlap and string similarity. It uses multiple techniques:
+ * - Word tokenization and stop word removal
+ * - Exact word overlap detection between tokenized names
+ * - Longest Common Substring (LCS) calculation for character-level similarity
+ * 
+ * The script is designed to find matches between names that share common words or
+ * have high character-level similarity, making it effective for matching variations
+ * of the same concept (e.g., "user_profile" vs "UserProfile" or "customer_data" vs "customer_info").
+ */
 type Mapping = Record<string, string>
 
 /**

--- a/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.ts
+++ b/frontend/internal-packages/evaluator/src/wordOverlapMatch/wordOverlapMatch.ts
@@ -1,12 +1,12 @@
 /**
  * Word Overlap Matching Script
- * 
+ *
  * This script performs lexical similarity matching between reference and candidate names
  * based on word overlap and string similarity. It uses multiple techniques:
  * - Word tokenization and stop word removal
  * - Exact word overlap detection between tokenized names
  * - Longest Common Substring (LCS) calculation for character-level similarity
- * 
+ *
  * The script is designed to find matches between names that share common words or
  * have high character-level similarity, making it effective for matching variations
  * of the same concept (e.g., "user_profile" vs "UserProfile" or "customer_data" vs "customer_info").

--- a/frontend/internal-packages/evaluator/tsconfig.json
+++ b/frontend/internal-packages/evaluator/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@liam-hq/configs/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "target": "ES2022",
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,7 +302,7 @@ importers:
     dependencies:
       '@langchain/community':
         specifier: 0.3.45
-        version: 0.3.45(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(zod@3.24.4))(@ibm-cloud/watsonx-ai@1.6.8)(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(@supabase/supabase-js@2.49.8)(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.0)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(playwright@1.52.0)(weaviate-client@3.6.2)(ws@8.18.2)
+        version: 0.3.45(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(zod@3.24.4))(@huggingface/transformers@3.5.2)(@ibm-cloud/watsonx-ai@1.6.8)(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(@supabase/supabase-js@2.49.8)(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.0)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(playwright@1.52.0)(weaviate-client@3.6.2)(ws@8.18.2)
       '@langchain/core':
         specifier: 0.3.57
         version: 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4))
@@ -419,6 +419,25 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+
+  frontend/internal-packages/evaluator:
+    dependencies:
+      '@huggingface/transformers':
+        specifier: 3.5.2
+        version: 3.5.2
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@liam-hq/configs':
+        specifier: workspace:*
+        version: link:../configs
+      eslint:
+        specifier: 9.28.0
+        version: 9.28.0(jiti@2.4.2)
+      vitest:
+        specifier: 3.1.4
+        version: 3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.15.29)(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.0)
 
   frontend/internal-packages/figma-to-css-variables:
     dependencies:
@@ -2061,6 +2080,13 @@ packages:
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@huggingface/jinja@0.4.1':
+    resolution: {integrity: sha512-3WXbMFaPkk03LRCM0z0sylmn8ddDm4ubjU7X+Hg4M2GOuMklwoGAFXp9V2keq7vltoB/c7McE5aHUVVddAewsw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/transformers@3.5.2':
+    resolution: {integrity: sha512-mfRXkmcL99+ibpjM++pvZmc2h3po8i1ZgSRI5Rtgh++P15GU0lY8UQteYt/w5V+GQw+Jpao93MoipcePzh3mKg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5789,6 +5815,10 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -6503,6 +6533,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -6694,6 +6727,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -7035,6 +7071,9 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
+  flatbuffers@25.2.10:
+    resolution: {integrity: sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==}
+
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
@@ -7277,6 +7316,10 @@ packages:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -7284,6 +7327,10 @@ packages:
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
 
   globby@10.0.2:
     resolution: {integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==}
@@ -7329,6 +7376,9 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -7919,6 +7969,9 @@ packages:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
     engines: {node: '>= 0.4'}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -8290,6 +8343,10 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   matchit@1.1.0:
     resolution: {integrity: sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==}
@@ -8887,6 +8944,19 @@ packages:
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
+
+  onnxruntime-node@1.21.0:
+    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
+
   open@10.1.2:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
@@ -9237,6 +9307,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   playwright-core@1.52.0:
     resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
@@ -9766,6 +9839,10 @@ packages:
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   rollup-plugin-execute@1.1.1:
     resolution: {integrity: sha512-isCNR/VrwlEfWJMwsnmt5TBRod8dW1IjVRxcXCBrxDmVTeA1IXjzeLSS3inFBmRD7KDPlo38KSb2mh5v5BoWgA==}
 
@@ -9866,6 +9943,9 @@ packages:
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -9891,6 +9971,10 @@ packages:
 
   sentence-case@2.1.1:
     resolution: {integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
@@ -10614,6 +10698,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -12641,6 +12729,15 @@ snapshots:
       protobufjs: 7.5.3
       yargs: 17.7.2
 
+  '@huggingface/jinja@0.4.1': {}
+
+  '@huggingface/transformers@3.5.2':
+    dependencies:
+      '@huggingface/jinja': 0.4.1
+      onnxruntime-node: 1.21.0
+      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
+      sharp: 0.34.2
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -13000,7 +13097,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@langchain/community@0.3.45(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(zod@3.24.4))(@ibm-cloud/watsonx-ai@1.6.8)(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(@supabase/supabase-js@2.49.8)(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.0)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(playwright@1.52.0)(weaviate-client@3.6.2)(ws@8.18.2)':
+  '@langchain/community@0.3.45(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(zod@3.24.4))(@huggingface/transformers@3.5.2)(@ibm-cloud/watsonx-ai@1.6.8)(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(@supabase/supabase-js@2.49.8)(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(html-to-text@9.0.5)(ibm-cloud-sdk-core@5.4.0)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(playwright@1.52.0)(weaviate-client@3.6.2)(ws@8.18.2)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(zod@3.24.4)
       '@ibm-cloud/watsonx-ai': 1.6.8
@@ -13020,6 +13117,7 @@ snapshots:
       zod-to-json-schema: 3.24.5(zod@3.24.4)
     optionalDependencies:
       '@browserbasehq/sdk': 2.6.0
+      '@huggingface/transformers': 3.5.2
       '@supabase/supabase-js': 2.49.8
       cheerio: 1.0.0
       html-to-text: 9.0.5
@@ -16682,6 +16780,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  boolean@3.2.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -17062,13 +17162,11 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   colorette@2.0.20: {}
 
@@ -17431,6 +17529,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  detect-node@2.1.0: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -17660,6 +17760,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es6-error@4.1.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -18095,6 +18197,8 @@ snapshots:
 
   flat@5.0.2: {}
 
+  flatbuffers@25.2.10: {}
+
   flatted@3.3.3: {}
 
   follow-redirects@1.15.9(debug@4.4.1):
@@ -18414,9 +18518,23 @@ snapshots:
       minipass: 4.2.8
       path-scurry: 1.11.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.2
+      serialize-error: 7.0.1
+
   globals@11.12.0: {}
 
   globals@14.0.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
 
   globby@10.0.2:
     dependencies:
@@ -18480,6 +18598,8 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  guid-typescript@1.0.9: {}
 
   handlebars@4.7.8:
     dependencies:
@@ -18951,8 +19071,7 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -19167,6 +19286,8 @@ snapshots:
       isarray: 2.0.5
       jsonify: 0.0.1
       object-keys: 1.1.1
+
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -19497,6 +19618,10 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
 
   matchit@1.1.0:
     dependencies:
@@ -20328,6 +20453,25 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
+  onnxruntime-common@1.21.0: {}
+
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
+
+  onnxruntime-node@1.21.0:
+    dependencies:
+      global-agent: 3.0.0
+      onnxruntime-common: 1.21.0
+      tar: 7.4.3
+
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+    dependencies:
+      flatbuffers: 25.2.10
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
+      platform: 1.3.6
+      protobufjs: 7.5.3
+
   open@10.1.2:
     dependencies:
       default-browser: 5.2.1
@@ -20773,6 +20917,8 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.4
       pathe: 2.0.3
+
+  platform@1.3.6: {}
 
   playwright-core@1.52.0: {}
 
@@ -21417,6 +21563,15 @@ snapshots:
       hash-base: 3.0.5
       inherits: 2.0.4
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+
   rollup-plugin-execute@1.1.1: {}
 
   rollup@4.35.0:
@@ -21550,6 +21705,8 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
+  semver-compare@1.0.0: {}
+
   semver@6.3.1: {}
 
   semver@7.5.4:
@@ -21580,6 +21737,10 @@ snapshots:
     dependencies:
       no-case: 2.3.2
       upper-case-first: 1.1.2
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -21668,7 +21829,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.2
       '@img/sharp-win32-ia32': 0.34.2
       '@img/sharp-win32-x64': 0.34.2
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -21730,7 +21890,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   simple-wcswidth@1.1.1: {}
 
@@ -22437,6 +22596,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.13.1: {}
 
   type-fest@0.21.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
   frontend/internal-packages/evaluator:
     dependencies:
       '@huggingface/transformers':
-        specifier: 3.5.2
-        version: 3.5.2
+        specifier: 3.3.3
+        version: 3.3.3
     devDependencies:
       '@biomejs/biome':
         specifier: 2.0.0
@@ -2081,9 +2081,16 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@huggingface/jinja@0.3.4':
+    resolution: {integrity: sha512-kFFQWJiWwvxezKQnvH1X7GjsECcMljFx+UZK9hx6P26aVHwwidJVTB0ptLfRVZQvVkOGHoMmTGvo4nT0X9hHOA==}
+    engines: {node: '>=18'}
+
   '@huggingface/jinja@0.4.1':
     resolution: {integrity: sha512-3WXbMFaPkk03LRCM0z0sylmn8ddDm4ubjU7X+Hg4M2GOuMklwoGAFXp9V2keq7vltoB/c7McE5aHUVVddAewsw==}
     engines: {node: '>=18'}
+
+  '@huggingface/transformers@3.3.3':
+    resolution: {integrity: sha512-OcMubhBjW6u1xnp0zSt5SvCxdGHuhP2k+w2Vlm3i0vNcTJhJTZWxxYQmPBfcb7PX+Q6c43lGSzWD6tsJFwka4Q==}
 
   '@huggingface/transformers@3.5.2':
     resolution: {integrity: sha512-mfRXkmcL99+ibpjM++pvZmc2h3po8i1ZgSRI5Rtgh++P15GU0lY8UQteYt/w5V+GQw+Jpao93MoipcePzh3mKg==}
@@ -8944,15 +8951,28 @@ packages:
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
+  onnxruntime-common@1.20.1:
+    resolution: {integrity: sha512-YiU0s0IzYYC+gWvqD1HzLc46Du1sXpSiwzKb63PACIJr6LfL27VsXSXQvt68EzD3V0D5Bc0vyJTjmMxp0ylQiw==}
+
   onnxruntime-common@1.21.0:
     resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+
+  onnxruntime-common@1.21.0-dev.20250206-d981b153d3:
+    resolution: {integrity: sha512-TwaE51xV9q2y8pM61q73rbywJnusw9ivTEHAJ39GVWNZqxCoDBpe/tQkh/w9S+o/g+zS7YeeL0I/2mEWd+dgyA==}
 
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
 
+  onnxruntime-node@1.20.1:
+    resolution: {integrity: sha512-di/I4HDXRw+FLgq+TyHmQEDd3cEp9iFFZm0r4uJ1Wd7b/WE1VXtKWo8yemex347c6GNF/3Pv86ZfPhIWxORr0w==}
+    os: [win32, darwin, linux]
+
   onnxruntime-node@1.21.0:
     resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
     os: [win32, darwin, linux]
+
+  onnxruntime-web@1.21.0-dev.20250206-d981b153d3:
+    resolution: {integrity: sha512-esDVQdRic6J44VBMFLumYvcGfioMh80ceLmzF1yheJyuLKq/Th8VT2aj42XWQst+2bcWnAhw4IKmRQaqzU8ugg==}
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
@@ -12729,7 +12749,17 @@ snapshots:
       protobufjs: 7.5.3
       yargs: 17.7.2
 
-  '@huggingface/jinja@0.4.1': {}
+  '@huggingface/jinja@0.3.4': {}
+
+  '@huggingface/jinja@0.4.1':
+    optional: true
+
+  '@huggingface/transformers@3.3.3':
+    dependencies:
+      '@huggingface/jinja': 0.3.4
+      onnxruntime-node: 1.20.1
+      onnxruntime-web: 1.21.0-dev.20250206-d981b153d3
+      sharp: 0.33.5
 
   '@huggingface/transformers@3.5.2':
     dependencies:
@@ -12737,6 +12767,7 @@ snapshots:
       onnxruntime-node: 1.21.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.2
+    optional: true
 
   '@humanfs/core@0.19.1': {}
 
@@ -16780,7 +16811,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  boolean@3.2.0: {}
+  boolean@3.2.0:
+    optional: true
 
   brace-expansion@1.1.12:
     dependencies:
@@ -17529,7 +17561,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  detect-node@2.1.0: {}
+  detect-node@2.1.0:
+    optional: true
 
   devlop@1.1.0:
     dependencies:
@@ -17761,7 +17794,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  es6-error@4.1.1: {}
+  es6-error@4.1.1:
+    optional: true
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -18526,6 +18560,7 @@ snapshots:
       roarr: 2.15.4
       semver: 7.7.2
       serialize-error: 7.0.1
+    optional: true
 
   globals@11.12.0: {}
 
@@ -18535,6 +18570,7 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+    optional: true
 
   globby@10.0.2:
     dependencies:
@@ -19287,7 +19323,8 @@ snapshots:
       jsonify: 0.0.1
       object-keys: 1.1.1
 
-  json-stringify-safe@5.0.1: {}
+  json-stringify-safe@5.0.1:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -19622,6 +19659,7 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
+    optional: true
 
   matchit@1.1.0:
     dependencies:
@@ -20453,15 +20491,36 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
-  onnxruntime-common@1.21.0: {}
+  onnxruntime-common@1.20.1: {}
 
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
+  onnxruntime-common@1.21.0:
+    optional: true
+
+  onnxruntime-common@1.21.0-dev.20250206-d981b153d3: {}
+
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+    optional: true
+
+  onnxruntime-node@1.20.1:
+    dependencies:
+      onnxruntime-common: 1.20.1
+      tar: 7.4.3
 
   onnxruntime-node@1.21.0:
     dependencies:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
       tar: 7.4.3
+    optional: true
+
+  onnxruntime-web@1.21.0-dev.20250206-d981b153d3:
+    dependencies:
+      flatbuffers: 25.2.10
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.21.0-dev.20250206-d981b153d3
+      platform: 1.3.6
+      protobufjs: 7.5.3
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
@@ -20471,6 +20530,7 @@ snapshots:
       onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
       protobufjs: 7.5.3
+    optional: true
 
   open@10.1.2:
     dependencies:
@@ -21571,6 +21631,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
+    optional: true
 
   rollup-plugin-execute@1.1.1: {}
 
@@ -21705,7 +21766,8 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
-  semver-compare@1.0.0: {}
+  semver-compare@1.0.0:
+    optional: true
 
   semver@6.3.1: {}
 
@@ -21741,6 +21803,7 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+    optional: true
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -21800,7 +21863,6 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   sharp@0.34.2:
     dependencies:
@@ -21829,6 +21891,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.2
       '@img/sharp-win32-ia32': 0.34.2
       '@img/sharp-win32-x64': 0.34.2
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -22597,7 +22660,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@0.13.1: {}
+  type-fest@0.13.1:
+    optional: true
 
   type-fest@0.21.3: {}
 


### PR DESCRIPTION



## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

Add schema name similarity matcher using Hugging Face Transformers

- Implemented `nameSimilarity` function using the all-MiniLM-L6-v2 model via @huggingface/transformers
- Calculates cosine similarity between schema or attribute names to find best matches
- Includes test cases using Vitest covering exact matches, partial similarity, and threshold behavior
- Organized under `internal-packages/evaluator/src/nameSimilarity`

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

```
$ pnpm --filter @liam-hq/evaluator test
# pass
```

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
