### PR TITLE
✨ feat(command palette): support table display in ERD on option selection

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
@@ -2,7 +2,7 @@ import { aTable } from '@liam-hq/db-structure'
 import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReactFlowProvider } from '@xyflow/react'
-import { NuqsAdapter } from 'nuqs/adapters/react'
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
 import { type FC, type ReactNode, useContext } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { SchemaProvider, UserEditingProvider } from '@/stores'
@@ -39,14 +39,14 @@ const ActiveTableNameDisplay: FC = () => {
 }
 
 const wrapper = ({ children }: { children: ReactNode }) => (
-  <NuqsAdapter>
+  <NuqsTestingAdapter>
     <ReactFlowProvider>
       <UserEditingProvider>
         <ActiveTableNameDisplay />
         <SchemaProvider schema={schema}>{children}</SchemaProvider>
       </UserEditingProvider>
     </ReactFlowProvider>
-  </NuqsAdapter>
+  </NuqsTestingAdapter>
 )
 
 const prepareCommandPalette = async () => {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
@@ -31,7 +31,7 @@ const ActiveTableNameDisplay: FC = () => {
   const userEditing = useContext(UserEditingContext)
 
   return (
-    //  The currently selected table name is displayed via Context, and used in tests for assertions.
+    // The currently active table name is displayed via Context. This component is used in tests for assertions only.
     <div data-testid="test-active-table-name-display">
       {userEditing?.activeTableName}
     </div>
@@ -61,7 +61,15 @@ const prepareCommandPalette = async () => {
   const searchCombobox = within(dialog).getByRole('combobox')
   const preview = within(dialog).getByTestId('CommandPalettePreview')
 
-  return { user, elements: { dialog, searchCombobox, preview } }
+  const activeTableNameDisplay = screen.getByTestId(
+    'test-active-table-name-display',
+  )
+
+  return {
+    user,
+    elements: { dialog, searchCombobox, preview },
+    testElements: { activeTableNameDisplay },
+  }
 }
 
 it('displays nothing by default', () => {
@@ -177,29 +185,25 @@ describe('go to ERD with option select', () => {
     const {
       user,
       elements: { dialog },
+      testElements: { activeTableNameDisplay },
     } = await prepareCommandPalette()
 
-    expect(
-      screen.getByTestId('test-active-table-name-display'),
-    ).toBeEmptyDOMElement()
+    expect(activeTableNameDisplay).toBeEmptyDOMElement()
 
     await user.click(within(dialog).getByRole('option', { name: 'follows' }))
 
-    expect(
-      screen.getByTestId('test-active-table-name-display'),
-    ).toHaveTextContent('follows')
     expect(dialog).not.toBeInTheDocument()
+    expect(activeTableNameDisplay).toHaveTextContent('follows')
   })
 
   it('go to the table of selected option by typing Enter key and close dialog', async () => {
     const {
       user,
       elements: { dialog, preview },
+      testElements: { activeTableNameDisplay },
     } = await prepareCommandPalette()
 
-    expect(
-      screen.getByTestId('test-active-table-name-display'),
-    ).toBeEmptyDOMElement()
+    expect(activeTableNameDisplay).toBeEmptyDOMElement()
 
     // select "posts" option by typing Enter key
     await user.keyboard('{ArrowDown}')
@@ -207,8 +211,6 @@ describe('go to ERD with option select', () => {
     await user.keyboard('{Enter}')
 
     expect(dialog).not.toBeInTheDocument()
-    expect(
-      screen.getByTestId('test-active-table-name-display'),
-    ).toHaveTextContent('posts')
+    expect(activeTableNameDisplay).toHaveTextContent('posts')
   })
 })

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
@@ -193,7 +193,7 @@ describe('go to ERD with option select', () => {
     await user.click(within(dialog).getByRole('option', { name: 'follows' }))
 
     expect(dialog).not.toBeInTheDocument()
-    expect(activeTableNameDisplay).toHaveTextContent('follows')
+    expect(activeTableNameDisplay).toHaveTextContent(/^follows$/)
   })
 
   it('go to the table of selected option by typing Enter key and close dialog', async () => {
@@ -211,6 +211,6 @@ describe('go to ERD with option select', () => {
     await user.keyboard('{Enter}')
 
     expect(dialog).not.toBeInTheDocument()
-    expect(activeTableNameDisplay).toHaveTextContent('posts')
+    expect(activeTableNameDisplay).toHaveTextContent(/^posts$/)
   })
 })

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
@@ -1,6 +1,7 @@
 import { aTable } from '@liam-hq/db-structure'
 import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { ReactFlowProvider } from '@xyflow/react'
 import { NuqsAdapter } from 'nuqs/adapters/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -27,9 +28,11 @@ const schema: SchemaStore = {
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <NuqsAdapter>
-    <UserEditingProvider>
-      <SchemaProvider schema={schema}>{children}</SchemaProvider>
-    </UserEditingProvider>
+    <ReactFlowProvider>
+      <UserEditingProvider>
+        <SchemaProvider schema={schema}>{children}</SchemaProvider>
+      </UserEditingProvider>
+    </ReactFlowProvider>
   </NuqsAdapter>
 )
 

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
@@ -3,7 +3,7 @@
 import { Search, Table2 } from '@liam-hq/ui'
 import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
 import { Command } from 'cmdk'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, useCallback, useEffect, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
 import { useSchema } from '@/stores'
 import { TableNode } from '../../ERDContent/components'
@@ -16,6 +16,14 @@ export const CommandPalette: FC = () => {
   const [tableName, setTableName] = useState<string | null>(null)
   const table = schema.current.tables[tableName ?? '']
   const { selectTable } = useTableSelection()
+
+  const goToERD = useCallback(
+    (tableName: string) => {
+      selectTable({ tableId: tableName, displayArea: 'main' })
+      setOpen(false)
+    },
+    [selectTable],
+  )
 
   // Toggle the menu when ⌘K is pressed
   useEffect(() => {
@@ -55,7 +63,11 @@ export const CommandPalette: FC = () => {
           <Command.Empty>No results found.</Command.Empty>
           <Command.Group heading="Suggestions">
             {Object.values(schema.current.tables).map((table) => (
-              <Command.Item key={table.name} value={table.name}>
+              <Command.Item
+                key={table.name}
+                value={table.name}
+                onSelect={() => goToERD(table.name)}
+              >
                 <Table2 className={styles.itemIcon} />
                 {table.name}
               </Command.Item>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
@@ -2,9 +2,9 @@
 
 import { Search, Table2 } from '@liam-hq/ui'
 import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
-import { ReactFlowProvider } from '@xyflow/react'
 import { Command } from 'cmdk'
 import { type FC, useEffect, useState } from 'react'
+import { useTableSelection } from '@/features/erd/hooks'
 import { useSchema } from '@/stores'
 import { TableNode } from '../../ERDContent/components'
 import styles from './CommandPalette.module.css'
@@ -15,6 +15,7 @@ export const CommandPalette: FC = () => {
   const schema = useSchema()
   const [tableName, setTableName] = useState<string | null>(null)
   const table = schema.current.tables[tableName ?? '']
+  const { selectTable } = useTableSelection()
 
   // Toggle the menu when ⌘K is pressed
   useEffect(() => {
@@ -67,26 +68,24 @@ export const CommandPalette: FC = () => {
         >
           <div className={styles.previewBackground}>
             {table && (
-              <ReactFlowProvider>
-                <TableNode
-                  id=""
-                  type="table"
-                  data={{
-                    table: table,
-                    isActiveHighlighted: false,
-                    isHighlighted: false,
-                    isTooltipVisible: false,
-                    sourceColumnName: undefined,
-                    targetColumnCardinalities: undefined,
-                    showMode: 'ALL_FIELDS',
-                  }}
-                  dragging={false}
-                  isConnectable={false}
-                  positionAbsoluteX={0}
-                  positionAbsoluteY={0}
-                  zIndex={0}
-                />
-              </ReactFlowProvider>
+              <TableNode
+                id=""
+                type="table"
+                data={{
+                  table: table,
+                  isActiveHighlighted: false,
+                  isHighlighted: false,
+                  isTooltipVisible: false,
+                  sourceColumnName: undefined,
+                  targetColumnCardinalities: undefined,
+                  showMode: 'ALL_FIELDS',
+                }}
+                dragging={false}
+                isConnectable={false}
+                positionAbsoluteX={0}
+                positionAbsoluteY={0}
+                zIndex={0}
+              />
             )}
           </div>
         </div>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/ERDRenderer.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/ERDRenderer.tsx
@@ -187,8 +187,8 @@ const ERDRendererInner: FC<InnerProps> = ({
               </main>
             </ResizablePanel>
           </ResizablePanelGroup>
+          <CommandPalette />
         </ReactFlowProvider>
-        <CommandPalette />
       </ToastProvider>
     </SidebarProvider>
   )


### PR DESCRIPTION
## Issue

~- resolve:~
relate to https://github.com/liam-hq/liam/issues/507

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This PR adds support for navigating to tables in the ERD upon option selection. When a user selects an option by clicking or pressing Enter, the CommandPalette closes and focuses on the selected table in the ERD.

Here is a demo:

https://github.com/user-attachments/assets/166320dd-196e-4775-bf13-db01d17603b4


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- The use of `selectTable` function
- Some updates of the Provider hierarchies ([description 1](https://github.com/liam-hq/liam/pull/2098#discussion_r2156805974), [desctription 2](https://github.com/liam-hq/liam/pull/2098#discussion_r2156813922))
- Test approach to check the Provider state ([desctiption](https://github.com/liam-hq/liam/pull/2098#discussion_r2156873319))

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

- Added some tests
- In the application:
  1. go to app https://liam-app-git-feat-jump-to-erd-liambx.vercel.app/
  2. show command palette by ⌘K
  3. select option by clicking or pressing Enter
  4. it displays selected table

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at ba91e41db690ad53d3cf1373e0833f34abffbc44

• Add table navigation functionality to command palette
• Enable ERD focus when selecting table options
• Implement click and Enter key selection support
• Add comprehensive test coverage for option selection


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.test.tsx</strong><dd><code>Add comprehensive tests for table selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx

• Add test component <code>ActiveTableNameDisplay</code> for assertion verification<br> <br>• Update test wrapper to include <code>ReactFlowProvider</code> and <br><code>NuqsTestingAdapter</code><br> • Add comprehensive tests for option selection via <br>click and Enter key<br> • Verify dialog closure and table navigation <br>functionality


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2098/files#diff-f53994cdb096610f6aa2e5a3c90d29817dd97b7d67ec42a0c513abc0cf2f5ed0">+67/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Implement table selection and navigation functionality</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx

• Add <code>useTableSelection</code> hook for table navigation<br> • Implement <code>goToERD</code> <br>callback function for option selection<br> • Add <code>onSelect</code> handler to <br>Command.Item components<br> • Remove redundant <code>ReactFlowProvider</code> wrapper <br>from preview


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2098/files#diff-94c7028698d83655392638264848d9a70ea1e476877bee9806d9e5d7b61e1780">+34/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ERDRenderer.tsx</strong><dd><code>Fix provider hierarchy for command palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/ERDRenderer.tsx

• Move <code>CommandPalette</code> component inside <code>ReactFlowProvider</code><br> • Ensure <br>proper provider hierarchy for table selection hooks


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2098/files#diff-4488341e17d72940cdd8cc9a1c66022941ad5170f0930359d3081572a75f97ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>