### PR TITLE
🔧(vercel): Skip preview builds for GitHub merge queue branches

### DIFF
--- a/frontend/apps/erd-sample/vercel.json
+++ b/frontend/apps/erd-sample/vercel.json
@@ -2,5 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../../../ && pnpm build --filter @liam-hq/erd-sample && pnpm --filter @liam-hq/erd-sample update_dist_content",
   "outputDirectory": "dist",
-  "ignoreCommand": "if [[ \"$VERCEL_GIT_COMMIT_REF\" == ignore-* ]] ; then exit 0; else exit 1; fi"
+  "ignoreCommand": "if [[ \"$VERCEL_GIT_COMMIT_REF\" == gh-readonly-queue/* ]] ; then exit 0; else exit 1; fi"
 }


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
GitHub Merge Queue branches (starting with `gh-readonly-queue/`) trigger unnecessary Vercel preview builds. These builds are not needed since the merge queue is a temporary branch used for automated testing before merging to main.

## What would you like reviewers to focus on?
- The `ignoreCommand` configuration in `vercel.json`
- The bash pattern matching for `gh-readonly-queue/*` branches

## Testing Verification
The command logic:
- Rewrote the branch to be skipped and verified that it works.

```
Running build in Washington, D.C., USA (East) – iad1
Build machine configuration: 4 cores, 8 GB
Cloning github.com/liam-hq/liam (Branch: ignore-merge-queue-branch, Commit: d68de58)
VERCEL_FORCE_NO_BUILD_CACHE is set so skipping build cache step
Cloning completed: 1.932s
Running "if [[ "$VERCEL_GIT_COMMIT_REF" == ignore-* ]] ; then exit 0; else exit 1; fi"
The Deployment has been canceled as a result of running the command defined in the "Ignored Build Step" setting.
Exiting build container
```

ref: https://vercel.com/liambx/liam-erd-sample/HywdpvnSX6CFSmWtEtFiXRzy62wC

## What was done
### 🤖 Generated by PR Agent at ef1227293f22901b0967d2d77a15fdd74cadb234

• Skip Vercel preview builds for GitHub merge queue branches
• Add ignoreCommand to prevent unnecessary builds on temporary branches
• Reduce build queue latency and resource usage


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vercel.json</strong><dd><code>Add ignoreCommand for merge queue branches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/erd-sample/vercel.json

• Added <code>ignoreCommand</code> configuration to skip builds for branches <br>starting with <code>gh-readonly-queue/</code><br> • Uses bash pattern matching to <br>identify GitHub merge queue branches<br> • Prevents unnecessary Vercel <br>preview builds on temporary branches


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2103/files#diff-b0dd9726d50b1ea520a36236a17f86799e25e157ecf1f4dc21c76b6a63af5321">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This change reduces unnecessary builds and build queue latency.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>