### PR TITLE
refactor: extract shared path schemas to reduce duplication

### DIFF
--- a/frontend/packages/db-structure/src/operation/schema/column.ts
+++ b/frontend/packages/db-structure/src/operation/schema/column.ts
@@ -6,13 +6,15 @@ import type { Operation } from './index.js'
 
 const isColumnPath = createPathValidator(PATH_PATTERNS.COLUMN_BASE)
 
+const columnPathSchema = v.custom<`/tables/${string}/columns/${string}`>(
+  isColumnPath,
+  'Path must match the pattern /tables/{tableName}/columns/{columnName}',
+)
+
 // Add column operation
 const addColumnOperationSchema = v.object({
   op: v.literal('add'),
-  path: v.custom<`/tables/${string}/columns/${string}`>(
-    isColumnPath,
-    'Path must match the pattern /tables/{tableName}/columns/{columnName}',
-  ),
+  path: columnPathSchema,
   value: columnSchema,
 })
 
@@ -27,10 +29,7 @@ export const isAddColumnOperation = (
 // Remove column operation
 const removeColumnOperationSchema = v.object({
   op: v.literal('remove'),
-  path: v.custom<`/tables/${string}/columns/${string}`>(
-    isColumnPath,
-    'Path must match the pattern /tables/{tableName}/columns/{columnName}',
-  ),
+  path: columnPathSchema,
 })
 
 export type RemoveColumnOperation = v.InferOutput<

--- a/frontend/packages/db-structure/src/operation/schema/table.ts
+++ b/frontend/packages/db-structure/src/operation/schema/table.ts
@@ -6,21 +6,20 @@ import type { Operation } from './index.js'
 
 const isTablePath = createPathValidator(PATH_PATTERNS.TABLE_BASE)
 
+const tablePathSchema = v.custom<`/tables/${string}`>(
+  isTablePath,
+  'Path must match the pattern /tables/{tableName}',
+)
+
 const addTableOperationSchema = v.object({
   op: v.literal('add'),
-  path: v.custom<`/tables/${string}`>(
-    isTablePath,
-    'Path must match the pattern /tables/{tableName}',
-  ),
+  path: tablePathSchema,
   value: tableSchema,
 })
 
 const removeTableOperationSchema = v.object({
   op: v.literal('remove'),
-  path: v.custom<`/tables/${string}`>(
-    isTablePath,
-    'Path must match the pattern /tables/{tableName}',
-  ),
+  path: tablePathSchema,
 })
 
 export type AddTableOperation = v.InferOutput<typeof addTableOperationSchema>


### PR DESCRIPTION
~This PR depends on https://github.com/liam-hq/liam/pull/2109. Once https://github.com/liam-hq/liam/pull/2109 is merged, this PR will be ready for review and the WIP prefix will be removed.~

## Issue

- resolve: Extract duplicate path schemas in operation schema files

## Why is this change needed?
Both column.ts and table.ts had duplicate path schema definitions that were used across multiple operation types. This refactoring extracts these schemas into shared constants to reduce code duplication and improve maintainability.

## What would you like reviewers to focus on?
- The extracted path schemas maintain the same functionality
- All operation schemas correctly use the shared schemas
- No breaking changes to existing type definitions

## Testing Verification
- All existing tests should continue to pass
- Type definitions remain unchanged

## What was done
### 🤖 Generated by PR Agent at 43fd24965bee6bb5cc862e43b733f178332129e7

• Extract duplicate path schemas into shared constants
• Reduce code duplication in column and table operation schemas
• Improve maintainability without functional changes


## Detailed Changes
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>column.ts</strong><dd><code>Extract shared column path schema constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/operation/schema/column.ts

• Extract <code>columnPathSchema</code> constant from duplicate path validation<br> • <br>Replace inline path schemas in add/remove operations with shared <br>schema<br> • Maintain same validation logic and type definitions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2110/files#diff-3d0b61c97b479ff09d3eae35a03a9f639040fe4d496dfd453ec11666001ff47a">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>table.ts</strong><dd><code>Extract shared table path schema constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/operation/schema/table.ts

• Extract <code>tablePathSchema</code> constant from duplicate path validation<br> • <br>Replace inline path schemas in add/remove operations with shared <br>schema<br> • Maintain same validation logic and type definitions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2110/files#diff-c9ea6ff484d3cceeeeeb8f00fa31a52f251a142b6c9cd7853b95c7a9e29da904">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This is a pure refactoring change with no functional modifications.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>