### PR TITLE
feat: implement ADD INDEX operation support

### DIFF
--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
@@ -189,4 +189,86 @@ describe('postgresqlOperationDeparser', () => {
       `)
     })
   })
+
+  describe('index operations', () => {
+    it('should generate CREATE INDEX statement from add operation', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/users/indexes/idx_users_email',
+        value: {
+          name: 'idx_users_email',
+          unique: false,
+          columns: ['email'],
+          type: 'BTREE',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "CREATE INDEX idx_users_email ON users USING BTREE (email);"
+      `)
+    })
+
+    it('should generate CREATE UNIQUE INDEX statement', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/users/indexes/idx_users_username_unique',
+        value: {
+          name: 'idx_users_username_unique',
+          unique: true,
+          columns: ['username'],
+          type: 'BTREE',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "CREATE UNIQUE INDEX idx_users_username_unique ON users USING BTREE (username);"
+      `)
+    })
+
+    it('should generate CREATE INDEX with multiple columns', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/orders/indexes/idx_orders_user_date',
+        value: {
+          name: 'idx_orders_user_date',
+          unique: false,
+          columns: ['user_id', 'created_at'],
+          type: 'BTREE',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "CREATE INDEX idx_orders_user_date ON orders USING BTREE (user_id, created_at);"
+      `)
+    })
+
+    it('should generate CREATE INDEX without index type', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/products/indexes/idx_products_category',
+        value: {
+          name: 'idx_products_category',
+          unique: false,
+          columns: ['category_id'],
+          type: '',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "CREATE INDEX idx_products_category ON products (category_id);"
+      `)
+    })
+  })
 })

--- a/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
@@ -1,4 +1,4 @@
-import type { Column, Table } from '../../schema/index.js'
+import type { Column, Index, Table } from '../../schema/index.js'
 
 /**
  * Generate column definition as DDL string
@@ -130,4 +130,18 @@ export function generateRemoveColumnStatement(
  */
 export function generateRemoveTableStatement(tableName: string): string {
   return `DROP TABLE ${tableName};`
+}
+
+/**
+ * Generate CREATE INDEX statement for an index
+ */
+export function generateCreateIndexStatement(
+  tableName: string,
+  index: Index,
+): string {
+  const uniqueKeyword = index.unique ? ' UNIQUE' : ''
+  const indexMethod = index.type ? ` USING ${index.type}` : ''
+  const columnList = index.columns.join(', ')
+
+  return `CREATE${uniqueKeyword} INDEX ${index.name} ON ${tableName}${indexMethod} (${columnList});`
 }

--- a/frontend/packages/db-structure/src/operation/schema/index-operations.ts
+++ b/frontend/packages/db-structure/src/operation/schema/index-operations.ts
@@ -1,0 +1,30 @@
+import * as v from 'valibot'
+import { indexSchema } from '../../schema/index.js'
+import { PATH_PATTERNS } from '../constants.js'
+import { createPathValidator } from '../pathValidators.js'
+import type { Operation } from './index.js'
+
+const isIndexPath = createPathValidator(PATH_PATTERNS.INDEX_BASE)
+
+const indexPathSchema = v.custom<`/tables/${string}/indexes/${string}`>(
+  isIndexPath,
+  'Path must match the pattern /tables/{tableName}/indexes/{indexName}',
+)
+
+// Add index operation
+const addIndexOperationSchema = v.object({
+  op: v.literal('add'),
+  path: indexPathSchema,
+  value: indexSchema,
+})
+
+export type AddIndexOperation = v.InferOutput<typeof addIndexOperationSchema>
+
+export const isAddIndexOperation = (
+  operation: Operation,
+): operation is AddIndexOperation => {
+  return v.safeParse(addIndexOperationSchema, operation).success
+}
+
+// Export all index operations
+export const indexOperations = [addIndexOperationSchema]

--- a/frontend/packages/db-structure/src/operation/schema/index.ts
+++ b/frontend/packages/db-structure/src/operation/schema/index.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot'
 import { columnOperations } from './column.js'
+import { indexOperations } from './index-operations.js'
 import { tableOperations } from './table.js'
 
 const addOperationSchema = v.object({
@@ -40,6 +41,7 @@ const testOperationSchema = v.object({
 const operationSchema = v.union([
   ...tableOperations,
   ...columnOperations,
+  ...indexOperations,
   addOperationSchema,
   removeOperationSchema,
   replaceOperationSchema,


### PR DESCRIPTION
~This PR depends on https://github.com/liam-hq/liam/pull/2110 . Once https://github.com/liam-hq/liam/pull/2110 is merged, this PR will be ready for review and the WIP prefix will be removed.~

## Issue

- resolve: Implement support for ADD INDEX operations in the database schema operation system

## Summary

- Add comprehensive support for CREATE INDEX operations
- Support unique indexes, multiple columns, and index types
- Generate correct PostgreSQL CREATE INDEX DDL statements

## Test plan

- All existing tests continue to pass
- New comprehensive tests added for index operations
- Verified DDL generation produces correct CREATE INDEX statements
- Ran quality checks: `pnpm fmt`, `pnpm lint`, and `pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.ai/code)