### PR TITLE
🔧 Fix turbo cache for @liam-hq/db-structure#gen task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -57,6 +57,11 @@
       "dependsOn": ["^gen"],
       "outputLogs": "errors-only"
     },
+    "@liam-hq/db-structure#gen": {
+      "dependsOn": ["^gen"],
+      "outputs": ["src/parser/tbls/schema.generated.ts"],
+      "outputLogs": "errors-only"
+    },
     "lint": {
       "dependsOn": ["gen", "^build", "^lint"],
       "outputLogs": "errors-only"


### PR DESCRIPTION
## Issue

- resolve: Fix build failures caused by missing outputs configuration in Turborepo cache

## Why is this change needed?

The `@liam-hq/db-structure#gen` task was being cached by Turborepo without proper outputs configuration. This caused subsequent builds to fail with "Cannot find module './schema.generated.js'" errors because the generated files weren't properly tracked in the cache.

## What would you like reviewers to focus on?

- Verify the outputs path `src/parser/tbls/schema.generated.ts` is correct
- Ensure this resolves the build cache issues in CI/CD

## Testing Verification

- Verified the generated file path matches the actual output location
- Build errors should no longer occur when the task is cached

## What was done

pr_agent:summary

## Detailed Changes

pr_agent:walkthrough

## Additional Notes

This fix ensures Turborepo properly caches the generated schema file, preventing build failures in dependent packages.