### PR TITLE
♻️ refactor: implement structured output for PMAgent

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/pmAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAgent/agent.ts
@@ -38,12 +38,8 @@ export class PMAgent implements ChatAgent<PMAgentResponse> {
     })
 
     // Convert valibot schemas to JSON Schema and bind to models
-    const analysisJsonSchema = toJsonSchema(requirementsAnalysisSchema, {
-      errorMode: 'ignore',
-    })
-    const reviewJsonSchema = toJsonSchema(reviewResponseSchema, {
-      errorMode: 'ignore',
-    })
+    const analysisJsonSchema = toJsonSchema(requirementsAnalysisSchema)
+    const reviewJsonSchema = toJsonSchema(reviewResponseSchema)
 
     this.analysisModel = baseModel.withStructuredOutput(analysisJsonSchema)
     this.reviewModel = baseModel.withStructuredOutput(reviewJsonSchema)

--- a/frontend/internal-packages/agent/src/langchain/agents/pmAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAgent/agent.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai'
+import { toJsonSchema } from '@valibot/to-json-schema'
 import * as v from 'valibot'
 import { createLangfuseHandler } from '../../utils/telemetry'
 import type { BasePromptVariables, ChatAgent } from '../../utils/types'
@@ -15,46 +16,73 @@ export const requirementsAnalysisSchema = v.object({
   nonFunctionalRequirements: v.record(v.string(), v.array(v.string())),
 })
 
-export class PMAgent implements ChatAgent {
-  private model: ChatOpenAI
+// TODO: Add review schema
+const reviewResponseSchema = v.object({
+  review: v.string(),
+})
+
+type AnalysisResponse = v.InferOutput<typeof requirementsAnalysisSchema>
+type ReviewResponse = v.InferOutput<typeof reviewResponseSchema>
+
+// Union type for all possible responses
+type PMAgentResponse = AnalysisResponse | ReviewResponse
+
+export class PMAgent implements ChatAgent<PMAgentResponse> {
+  private analysisModel: ReturnType<ChatOpenAI['withStructuredOutput']>
+  private reviewModel: ReturnType<ChatOpenAI['withStructuredOutput']>
 
   constructor() {
-    this.model = new ChatOpenAI({
+    const baseModel = new ChatOpenAI({
       model: 'o3',
       callbacks: [createLangfuseHandler()],
     })
+
+    // Convert valibot schemas to JSON Schema and bind to models
+    const analysisJsonSchema = toJsonSchema(requirementsAnalysisSchema, {
+      errorMode: 'ignore',
+    })
+    const reviewJsonSchema = toJsonSchema(reviewResponseSchema, {
+      errorMode: 'ignore',
+    })
+
+    this.analysisModel = baseModel.withStructuredOutput(analysisJsonSchema)
+    this.reviewModel = baseModel.withStructuredOutput(reviewJsonSchema)
   }
 
-  async generate(variables: BasePromptVariables): Promise<string> {
+  async generate(variables: BasePromptVariables): Promise<PMAgentResponse> {
     // Default to analysis mode for backward compatibility
-    return this.generateWithMode(variables, PMAgentMode.ANALYSIS)
+    const formattedPrompt = await pmAnalysisPrompt.format(variables)
+    const rawResponse = await this.analysisModel.invoke(formattedPrompt)
+    return v.parse(requirementsAnalysisSchema, rawResponse)
   }
 
   async generateWithMode(
     variables: PMAgentVariables,
     mode: PMAgentMode,
-  ): Promise<string> {
-    const prompt =
-      mode === PMAgentMode.ANALYSIS ? pmAnalysisPrompt : pmReviewPrompt
-
-    const formattedPrompt = await prompt.format(variables)
-    const response = await this.model.invoke(formattedPrompt)
-    return response.content as string
+  ): Promise<PMAgentResponse> {
+    if (mode === PMAgentMode.ANALYSIS) {
+      const formattedPrompt = await pmAnalysisPrompt.format(variables)
+      const rawResponse = await this.analysisModel.invoke(formattedPrompt)
+      return v.parse(requirementsAnalysisSchema, rawResponse)
+    }
+    const formattedPrompt = await pmReviewPrompt.format(variables)
+    const rawResponse = await this.reviewModel.invoke(formattedPrompt)
+    return v.parse(reviewResponseSchema, rawResponse)
   }
 
   // Convenience methods
   async analyzeRequirements(
     variables: BasePromptVariables,
   ): Promise<v.InferOutput<typeof requirementsAnalysisSchema>> {
-    const response = await this.generateWithMode(
-      variables,
-      PMAgentMode.ANALYSIS,
-    )
-    const parsedResponse = JSON.parse(response)
-    return v.parse(requirementsAnalysisSchema, parsedResponse)
+    const formattedPrompt = await pmAnalysisPrompt.format(variables)
+    const rawResponse = await this.analysisModel.invoke(formattedPrompt)
+    return v.parse(requirementsAnalysisSchema, rawResponse)
   }
 
   async reviewDeliverables(variables: PMAgentVariables): Promise<string> {
-    return this.generateWithMode(variables, PMAgentMode.REVIEW)
+    const formattedPrompt = await pmReviewPrompt.format(variables)
+    const rawResponse = await this.reviewModel.invoke(formattedPrompt)
+    const response = v.parse(reviewResponseSchema, rawResponse)
+    return response.review
   }
 }


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This PR refactors the PMAgent to use LangChain's structured output feature, following the same pattern as `DatabaseSchemaBuildAgent`. This improves type safety and response reliability

- ref: https://github.com/liam-hq/liam/pull/2114

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

  Please pay special attention to:
  - The decision to use `requirementsAnalysisSchema` directly instead of wrapping it
  - Type safety around the union response type

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

✅ I confirmed that the workflow works correctly in the local environment.

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at c186ab46671473d057cb37faed2da8d4dbe9644e

- Refactor PMAgent to use LangChain structured output
- Add valibot schema validation for type safety
- Implement separate models for analysis and review modes
- Replace string responses with typed response objects


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Implement structured output with valibot validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/langchain/agents/pmAgent/agent.ts

<li>Added valibot schema conversion to JSON Schema using <code>toJsonSchema</code><br> <li> Implemented separate structured output models for analysis and review <br>modes<br> <li> Replaced string return types with typed union <code>PMAgentResponse</code><br> <li> Added schema validation using <code>v.parse()</code> for all responses


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2134/files#diff-fe8be3058cf4c564e8c53a6a82fc9e022cd8eb187c9f013f8943b79281586991">+47/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>