### PR TITLE
🐛(db-structure): fix operations schema v.custom() validation for LangChain structured outputs

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
@@ -23,13 +23,7 @@ export class DatabaseSchemaBuildAgent implements ChatAgent<BuildAgentResponse> {
       callbacks: [createLangfuseHandler()],
     })
 
-    // Convert valibot schema to JSON Schema and bind to model
-    // FIXME: operationsSchema contains v.custom() which cannot be converted to JSON Schema
-    // This causes "The 'custom' schema cannot be converted to JSON Schema" error
-    // Need to find alternative approach for custom validation in structured outputs
-    const jsonSchema = toJsonSchema(buildAgentResponseSchema, {
-      errorMode: 'ignore',
-    })
+    const jsonSchema = toJsonSchema(buildAgentResponseSchema)
     this.model = baseModel.withStructuredOutput(jsonSchema)
   }
 

--- a/frontend/packages/db-structure/src/operation/pathValidators.ts
+++ b/frontend/packages/db-structure/src/operation/pathValidators.ts
@@ -1,6 +1,0 @@
-export const createPathValidator = (pattern: RegExp) => {
-  return (input: unknown): boolean => {
-    if (typeof input !== 'string') return false
-    return pattern.test(input)
-  }
-}

--- a/frontend/packages/db-structure/src/operation/schema/column.ts
+++ b/frontend/packages/db-structure/src/operation/schema/column.ts
@@ -1,15 +1,9 @@
 import * as v from 'valibot'
 import { columnSchema } from '../../schema/index.js'
 import { PATH_PATTERNS } from '../constants.js'
-import { createPathValidator } from '../pathValidators.js'
 import type { Operation } from './index.js'
 
-const isColumnPath = createPathValidator(PATH_PATTERNS.COLUMN_BASE)
-
-const columnPathSchema = v.custom<`/tables/${string}/columns/${string}`>(
-  isColumnPath,
-  'Path must match the pattern /tables/{tableName}/columns/{columnName}',
-)
+const columnPathSchema = v.pipe(v.string(), v.regex(PATH_PATTERNS.COLUMN_BASE))
 
 // Add column operation
 const addColumnOperationSchema = v.object({

--- a/frontend/packages/db-structure/src/operation/schema/index-operations.ts
+++ b/frontend/packages/db-structure/src/operation/schema/index-operations.ts
@@ -1,15 +1,9 @@
 import * as v from 'valibot'
 import { indexSchema } from '../../schema/index.js'
 import { PATH_PATTERNS } from '../constants.js'
-import { createPathValidator } from '../pathValidators.js'
 import type { Operation } from './index.js'
 
-const isIndexPath = createPathValidator(PATH_PATTERNS.INDEX_BASE)
-
-const indexPathSchema = v.custom<`/tables/${string}/indexes/${string}`>(
-  isIndexPath,
-  'Path must match the pattern /tables/{tableName}/indexes/{indexName}',
-)
+const indexPathSchema = v.pipe(v.string(), v.regex(PATH_PATTERNS.INDEX_BASE))
 
 // Add index operation
 const addIndexOperationSchema = v.object({

--- a/frontend/packages/db-structure/src/operation/schema/table.ts
+++ b/frontend/packages/db-structure/src/operation/schema/table.ts
@@ -1,15 +1,9 @@
 import * as v from 'valibot'
 import { tableSchema } from '../../schema/index.js'
 import { PATH_PATTERNS } from '../constants.js'
-import { createPathValidator } from '../pathValidators.js'
 import type { Operation } from './index.js'
 
-const isTablePath = createPathValidator(PATH_PATTERNS.TABLE_BASE)
-
-const tablePathSchema = v.custom<`/tables/${string}`>(
-  isTablePath,
-  'Path must match the pattern /tables/{tableName}',
-)
+const tablePathSchema = v.pipe(v.string(), v.regex(PATH_PATTERNS.TABLE_BASE))
 
 const addTableOperationSchema = v.object({
   op: v.literal('add'),


### PR DESCRIPTION
## Issue

- resolve: operationsSchema v.custom() validation cannot be converted to JSON Schema in LangChain withStructuredOutput()

## Why is this change needed?

The current operationsSchema uses `v.custom()` for path validation, which gets lost when converting to JSON Schema via LangChain's structured outputs (`withStructuredOutput()`). When `v.custom()` is converted to JSON Schema, it becomes `path: {}` (unknown type), causing LangChain to accept invalid path values and losing the benefits of structured outputs.

## What would you like reviewers to focus on?

- Proper replacement of `v.custom()` with `v.pipe(v.string(), v.regex())` for path validations
- Verification that regex patterns are correctly preserved in JSON Schema conversion
- Removal of FIXME comment in DatabaseSchemaBuildAgent is appropriate
- Deletion of unused pathValidators.ts file is safe

## Testing Verification

- All tests pass (`pnpm test:turbo`)
- Linter checks pass (`pnpm lint`)
- Manual verification of JSON Schema conversion with regex patterns

## What was done

### 🤖 Generated by PR Agent at e56aaa2ac810ba1c72bf20a6d4c06ecb3200388b

- Replace `v.custom()` with `v.pipe(v.string(), v.regex())` for path validation
- Fix LangChain structured outputs JSON Schema conversion compatibility
- Remove unused pathValidators.ts file and helper functions
- Update DatabaseSchemaBuildAgent to remove FIXME comment


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Remove FIXME comment and simplify schema conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts

<li>Remove FIXME comment about v.custom() JSON Schema conversion issue<br> <li> Simplify toJsonSchema call by removing errorMode parameter


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2135/files#diff-31f2c91208c3ca40dd1deb90d323eb52ba6f5ab3d5e271b76072b50045eda8a9">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>column.ts</strong><dd><code>Replace custom validation with regex pipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/operation/schema/column.ts

<li>Replace v.custom() with v.pipe(v.string(), v.regex()) for column path <br>validation<br> <li> Remove import and usage of createPathValidator function


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2135/files#diff-3d0b61c97b479ff09d3eae35a03a9f639040fe4d496dfd453ec11666001ff47a">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index-operations.ts</strong><dd><code>Replace custom validation with regex pipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/operation/schema/index-operations.ts

<li>Replace v.custom() with v.pipe(v.string(), v.regex()) for index path <br>validation<br> <li> Remove import and usage of createPathValidator function


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2135/files#diff-41d418632435290ab24ec82970b8f851510a53adf770f7e651ef57d0793c5796">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>table.ts</strong><dd><code>Replace custom validation with regex pipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/operation/schema/table.ts

<li>Replace v.custom() with v.pipe(v.string(), v.regex()) for table path <br>validation<br> <li> Remove import and usage of createPathValidator function


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2135/files#diff-c9ea6ff484d3cceeeeeb8f00fa31a52f251a142b6c9cd7853b95c7a9e29da904">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pathValidators.ts</strong><dd><code>Remove unused pathValidators file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/operation/pathValidators.ts

- Delete entire file containing createPathValidator helper function


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2135/files#diff-bce8301ec8214acf1b7ba51a3732f0ac8158d62b09f482677810da9dd3589974">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This fix ensures that when using operationsSchema with LangChain's structured outputs, path regex patterns are properly preserved in JSON Schema conversion, maintaining type safety and validation.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>