### PR TITLE
🔒(db-structure): Fix PostgreSQL SQL injection vulnerability

### DIFF
--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
@@ -42,14 +42,14 @@ describe('postgresqlOperationDeparser', () => {
 
       expect(result.errors).toHaveLength(0)
       expect(result.value).toMatchInlineSnapshot(`
-        "CREATE TABLE users (
-          id bigint PRIMARY KEY,
-          email varchar(255) UNIQUE NOT NULL
+        "CREATE TABLE \"users\" (
+          \"id\" bigint PRIMARY KEY,
+          \"email\" varchar(255) UNIQUE NOT NULL
         );
 
-        COMMENT ON TABLE users IS 'User table';
-        COMMENT ON COLUMN users.id IS 'User ID';
-        COMMENT ON COLUMN users.email IS 'User email';"
+        COMMENT ON TABLE \"users\" IS 'User table';
+        COMMENT ON COLUMN \"users\".\"id\" IS 'User ID';
+        COMMENT ON COLUMN \"users\".\"email\" IS 'User email';"
       `)
     })
 
@@ -101,10 +101,10 @@ describe('postgresqlOperationDeparser', () => {
 
       expect(result.errors).toHaveLength(0)
       expect(result.value).toMatchInlineSnapshot(`
-        "CREATE TABLE settings (
-          id bigint PRIMARY KEY,
-          enabled boolean NOT NULL DEFAULT TRUE,
-          title varchar(100) DEFAULT 'Default Title'
+        "CREATE TABLE \"settings\" (
+          \"id\" bigint PRIMARY KEY,
+          \"enabled\" boolean NOT NULL DEFAULT TRUE,
+          \"title\" varchar(100) DEFAULT 'Default Title'
         );"
       `)
     })
@@ -119,7 +119,7 @@ describe('postgresqlOperationDeparser', () => {
 
       expect(result.errors).toHaveLength(0)
       expect(result.value).toMatchInlineSnapshot(`
-        "DROP TABLE users;"
+        "DROP TABLE \"users\";"
       `)
     })
   })
@@ -145,9 +145,9 @@ describe('postgresqlOperationDeparser', () => {
 
       expect(result.errors).toHaveLength(0)
       expect(result.value).toMatchInlineSnapshot(`
-        "ALTER TABLE users ADD COLUMN age integer;
+        "ALTER TABLE \"users\" ADD COLUMN \"age\" integer;
 
-        COMMENT ON COLUMN users.age IS 'User age';"
+        COMMENT ON COLUMN \"users\".\"age\" IS 'User age';"
       `)
     })
 
@@ -171,7 +171,7 @@ describe('postgresqlOperationDeparser', () => {
 
       expect(result.errors).toHaveLength(0)
       expect(result.value).toMatchInlineSnapshot(`
-        "ALTER TABLE products ADD COLUMN price decimal(10,2) NOT NULL DEFAULT 0;"
+        "ALTER TABLE \"products\" ADD COLUMN \"price\" decimal(10,2) NOT NULL DEFAULT 0;"
       `)
     })
 
@@ -185,7 +185,7 @@ describe('postgresqlOperationDeparser', () => {
 
       expect(result.errors).toHaveLength(0)
       expect(result.value).toMatchInlineSnapshot(`
-        "ALTER TABLE users DROP COLUMN age;"
+        "ALTER TABLE \"users\" DROP COLUMN \"age\";"
       `)
     })
   })

--- a/frontend/packages/db-structure/src/deparser/postgresql/schemaDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/schemaDeparser.test.ts
@@ -43,9 +43,9 @@ describe('postgresqlSchemaDeparser', () => {
 
     expect(result.errors).toHaveLength(0)
     expect(result.value).toMatchInlineSnapshot(`
-      "CREATE TABLE users (
-        id bigint PRIMARY KEY,
-        email varchar(255) UNIQUE NOT NULL
+      "CREATE TABLE \"users\" (
+        \"id\" bigint PRIMARY KEY,
+        \"email\" varchar(255) UNIQUE NOT NULL
       );"
     `)
   })
@@ -80,12 +80,12 @@ describe('postgresqlSchemaDeparser', () => {
 
     expect(result.errors).toHaveLength(0)
     expect(result.value).toMatchInlineSnapshot(`
-      "CREATE TABLE products (
-        id bigint PRIMARY KEY
+      "CREATE TABLE \"products\" (
+        \"id\" bigint PRIMARY KEY
       );
 
-      COMMENT ON TABLE products IS 'Product table';
-      COMMENT ON COLUMN products.id IS 'Product ID';"
+      COMMENT ON TABLE \"products\" IS 'Product table';
+      COMMENT ON COLUMN \"products\".\"id\" IS 'Product ID';"
     `)
   })
 
@@ -149,11 +149,11 @@ describe('postgresqlSchemaDeparser', () => {
 
     expect(result.errors).toHaveLength(0)
     expect(result.value).toMatchInlineSnapshot(`
-      "CREATE TABLE settings (
-        id bigint PRIMARY KEY,
-        enabled boolean NOT NULL DEFAULT TRUE,
-        count integer DEFAULT 0,
-        title varchar(50) DEFAULT 'Default Title'
+      "CREATE TABLE \"settings\" (
+        \"id\" bigint PRIMARY KEY,
+        \"enabled\" boolean NOT NULL DEFAULT TRUE,
+        \"count\" integer DEFAULT 0,
+        \"title\" varchar(50) DEFAULT 'Default Title'
       );"
     `)
   })
@@ -189,12 +189,12 @@ describe('postgresqlSchemaDeparser', () => {
     expect(result.errors).toHaveLength(0)
     expect(result.value).toMatchInlineSnapshot(
       `
-      "CREATE TABLE test (
-        id bigint PRIMARY KEY
+      "CREATE TABLE \"test\" (
+        \"id\" bigint PRIMARY KEY
       );
 
-      COMMENT ON TABLE test IS 'Table with ''quotes'' in comment';
-      COMMENT ON COLUMN test.id IS 'Column with ''quotes'' in comment';"
+      COMMENT ON TABLE \"test\" IS 'Table with ''quotes'' in comment';
+      COMMENT ON COLUMN \"test\".\"id\" IS 'Column with ''quotes'' in comment';"
     `,
     )
   })
@@ -257,13 +257,13 @@ describe('postgresqlSchemaDeparser', () => {
 
     expect(result.errors).toHaveLength(0)
     expect(result.value).toMatchInlineSnapshot(`
-      "CREATE TABLE users (
-        id bigint PRIMARY KEY
+      "CREATE TABLE \"users\" (
+        \"id\" bigint PRIMARY KEY
       );
 
-      CREATE TABLE products (
-        id bigint PRIMARY KEY,
-        name varchar(100) NOT NULL
+      CREATE TABLE \"products\" (
+        \"id\" bigint PRIMARY KEY,
+        \"name\" varchar(100) NOT NULL
       );"
     `)
   })

--- a/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
@@ -4,7 +4,7 @@ import type { Column, Table } from '../../schema/index.js'
  * Generate column definition as DDL string
  */
 function generateColumnDefinition(column: Column): string {
-  let definition = `${column.name} ${column.type}`
+  let definition = `${escapeIdentifier(column.name)} ${column.type}`
 
   // Add constraints (following PostgreSQL common order)
   if (column.primary) {
@@ -53,6 +53,15 @@ function escapeString(str: string): string {
 }
 
 /**
+ * Escape SQL identifiers (table names, column names) for PostgreSQL
+ * Wraps identifier in double quotes and escapes internal double quotes
+ */
+function escapeIdentifier(identifier: string): string {
+  // Escape double quotes by doubling them and wrap in double quotes
+  return `"${identifier.replace(/"/g, '""')}"`
+}
+
+/**
  * Generate ADD COLUMN statement for a column
  */
 export function generateAddColumnStatement(
@@ -60,11 +69,11 @@ export function generateAddColumnStatement(
   column: Column,
 ): string {
   const columnDefinition = generateColumnDefinition(column)
-  let ddl = `ALTER TABLE ${tableName} ADD COLUMN ${columnDefinition};`
+  let ddl = `ALTER TABLE ${escapeIdentifier(tableName)} ADD COLUMN ${columnDefinition};`
 
   // Add column comment if exists
   if (column.comment) {
-    ddl += `\n\nCOMMENT ON COLUMN ${tableName}.${column.name} IS '${escapeString(column.comment)}';`
+    ddl += `\n\nCOMMENT ON COLUMN ${escapeIdentifier(tableName)}.${escapeIdentifier(column.name)} IS '${escapeString(column.comment)}';`
   }
 
   return ddl
@@ -82,11 +91,11 @@ export function generateCreateTableStatement(table: Table): string {
     .join(',\n  ')
 
   // Basic CREATE TABLE statement
-  let ddl = `CREATE TABLE ${tableName} (\n  ${columnDefinitions}\n);`
+  let ddl = `CREATE TABLE ${escapeIdentifier(tableName)} (\n  ${columnDefinitions}\n);`
 
   // Add table comment
   if (table.comment) {
-    ddl += `\n\nCOMMENT ON TABLE ${tableName} IS '${escapeString(table.comment)}';`
+    ddl += `\n\nCOMMENT ON TABLE ${escapeIdentifier(tableName)} IS '${escapeString(table.comment)}';`
   }
 
   // Add column comments
@@ -107,7 +116,7 @@ function generateColumnComments(tableName: string, table: Table): string {
   for (const column of Object.values(table.columns) as Column[]) {
     if (column.comment) {
       comments.push(
-        `COMMENT ON COLUMN ${tableName}.${column.name} IS '${escapeString(column.comment)}';`,
+        `COMMENT ON COLUMN ${escapeIdentifier(tableName)}.${escapeIdentifier(column.name)} IS '${escapeString(column.comment)}';`,
       )
     }
   }
@@ -122,12 +131,12 @@ export function generateRemoveColumnStatement(
   tableName: string,
   columnName: string,
 ): string {
-  return `ALTER TABLE ${tableName} DROP COLUMN ${columnName};`
+  return `ALTER TABLE ${escapeIdentifier(tableName)} DROP COLUMN ${escapeIdentifier(columnName)};`
 }
 
 /**
  * Generate DROP TABLE statement
  */
 export function generateRemoveTableStatement(tableName: string): string {
-  return `DROP TABLE ${tableName};`
+  return `DROP TABLE ${escapeIdentifier(tableName)};`
 }


### PR DESCRIPTION
## Issue

- resolve: SQL injection vulnerability in PostgreSQL SQL generation functions

## Why is this change needed?

The code directly interpolated table and column names into SQL statements without proper escaping or validation. In PostgreSQL SQL generation functions, tableName and column.name were directly inserted into SQL strings. If these values contain special characters, SQL keywords, or malicious content, it could lead to SQL injection vulnerabilities.

## What would you like reviewers to focus on?

- The implementation of the `escapeIdentifier` function for PostgreSQL identifier escaping
- Proper application of identifier escaping across all SQL generation functions
- Test coverage and snapshot updates to ensure the security fix doesn't break existing functionality
- Performance impact of the escaping function (should be minimal)

## Testing Verification

- All existing tests pass with updated snapshots
- TypeScript compilation succeeds without errors
- Linting passes all checks
- Manual verification that generated SQL properly escapes identifiers with double quotes

## What was done

### 🤖 Generated by PR Agent at 65e58f0212ee73b1c03855c8ba556f147b6a3d4d

- Fix PostgreSQL SQL injection vulnerability in identifier handling
- Add `escapeIdentifier` function to properly quote table/column names
- Update all SQL generation functions to use escaped identifiers
- Update test snapshots to reflect proper identifier quoting


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Add SQL identifier escaping functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/deparser/postgresql/utils.ts

<li>Add <code>escapeIdentifier</code> function to escape SQL identifiers with double <br>quotes<br> <li> Apply identifier escaping to all table and column names in SQL <br>generation functions<br> <li> Update <code>generateCreateTableStatement</code>, <code>generateAddColumnStatement</code>, <br><code>generateRemoveColumnStatement</code>, and <code>generateRemoveTableStatement</code><br> <li> Ensure proper escaping of internal double quotes by doubling them


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2136/files#diff-953bd04b5c3caedcff5d0e578ef9480183849538cf27562d74930e726ee96439">+17/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operationDeparser.test.ts</strong><dd><code>Update test snapshots for escaped identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts

<li>Update test snapshots to reflect proper identifier quoting with double <br>quotes<br> <li> Verify CREATE TABLE, DROP TABLE, ADD COLUMN, and DROP COLUMN <br>statements use escaped identifiers<br> <li> Ensure COMMENT statements properly escape table and column references


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2136/files#diff-63a015c08f79309cbc45f2832afe78224d27445c09a6a19806e57972dd58c7c3">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schemaDeparser.test.ts</strong><dd><code>Update schema deparser test snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/deparser/postgresql/schemaDeparser.test.ts

<li>Update test snapshots to show proper identifier escaping in CREATE <br>TABLE statements<br> <li> Verify table names, column names, and COMMENT statements use <br>double-quoted identifiers<br> <li> Test coverage for tables with comments and multiple tables scenarios


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2136/files#diff-1203c9741f89ee40cbbb49e3aa2a031464beb89f4046cc4e9ad49d569ad23a01">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This is a critical security fix that prevents SQL injection attacks through malicious table or column names. The fix uses PostgreSQL's standard identifier quoting mechanism (double quotes) and properly escapes any internal double quotes by doubling them.

**Security Impact Examples:**
- Malicious table name: `users; DROP TABLE sensitive_data; --` would previously allow arbitrary SQL execution
- Malicious column name: `id; INSERT INTO logs VALUES ('hacked'); --` could inject additional SQL commands

**Before:**
```sql
CREATE TABLE users (id bigint PRIMARY KEY, email varchar(255));
```

**After:**
```sql
CREATE TABLE "users" ("id" bigint PRIMARY KEY, "email" varchar(255));
```

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>