### PR TITLE
refactor: use PATH_PATTERNS constants for regex patterns

### DIFF
--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.ts
@@ -1,3 +1,4 @@
+import { PATH_PATTERNS } from '../../operation/constants.js'
 import type {
   AddColumnOperation,
   RemoveColumnOperation,
@@ -40,7 +41,7 @@ import {
  * Extract table name from operation path
  */
 function extractTableNameFromPath(path: string): string | null {
-  const match = path.match(/^\/tables\/([^/]+)/)
+  const match = path.match(PATH_PATTERNS.TABLE_BASE)
   return match?.[1] || null
 }
 
@@ -50,7 +51,7 @@ function extractTableNameFromPath(path: string): string | null {
 function extractTableAndColumnNameFromPath(
   path: string,
 ): { tableName: string; columnName: string } | null {
-  const match = path.match(/^\/tables\/([^/]+)\/columns\/([^/]+)$/)
+  const match = path.match(PATH_PATTERNS.COLUMN_BASE)
   if (!match || !match[1] || !match[2]) {
     return null
   }
@@ -66,7 +67,7 @@ function extractTableAndColumnNameFromPath(
 function extractTableAndColumnNameFromNamePath(
   path: string,
 ): { tableName: string; columnName: string } | null {
-  const match = path.match(/^\/tables\/([^/]+)\/columns\/([^/]+)\/name$/)
+  const match = path.match(PATH_PATTERNS.COLUMN_NAME)
   if (!match || !match[1] || !match[2]) {
     return null
   }
@@ -82,7 +83,7 @@ function extractTableAndColumnNameFromNamePath(
 function extractTableAndIndexNameFromPath(
   path: string,
 ): { tableName: string; indexName: string } | null {
-  const match = path.match(/^\/tables\/([^/]+)\/indexes\/([^/]+)$/)
+  const match = path.match(PATH_PATTERNS.INDEX_BASE)
   if (!match || !match[1] || !match[2]) {
     return null
   }


### PR DESCRIPTION
## Issue

- resolve: Replace hardcoded regex patterns with PATH_PATTERNS constants for better maintainability

## Why is this change needed?

This change improves code maintainability by replacing hardcoded regex patterns with centralized PATH_PATTERNS constants from operation/constants.ts. This ensures consistency across the codebase and provides a single source of truth for path patterns used in operation parsing.

## What would you like reviewers to focus on?

- Proper import of PATH_PATTERNS constants
- Correct usage of constants in all extraction functions
- Verification that no functional behavior has changed (this is purely a refactoring)

## Testing Verification

- All existing tests continue to pass
- Verified that the refactored functions use the same regex patterns as before
- No functional changes, only improved code organization
- Ran `pnpm fmt`, `pnpm lint`, and `pnpm test` - all pass successfully

## What was done

### 🤖 Generated by PR Agent at 08f12bd93ff5c4aaed964ad0828900bb61ec6875

- Replace hardcoded regex patterns with PATH_PATTERNS constants
- Import PATH_PATTERNS from operation/constants.ts module
- Update four extraction functions to use centralized patterns
- Improve code maintainability and consistency


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operationDeparser.ts</strong><dd><code>Replace hardcoded regex with PATH_PATTERNS constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.ts

<li>Import PATH_PATTERNS constants from operation/constants.ts<br> <li> Replace hardcoded regex patterns in <code>extractTableNameFromPath</code> function<br> <li> Update <code>extractTableAndColumnNameFromPath</code> to use <br><code>PATH_PATTERNS.COLUMN_BASE</code><br> <li> Replace regex patterns in <code>extractTableAndColumnNameFromNamePath</code> and <br><code>extractTableAndIndexNameFromPath</code>


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2149/files#diff-bf2a4bb4a24a003c80263365ed87ace35c899c41e176456ab5e7cc346657e0a7">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This PR depends on https://github.com/liam-hq/liam/pull/2141. This is a pure refactoring with no functional changes - the same regex patterns are now referenced from constants instead of being hardcoded.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>