### PR TITLE
feat: implement RENAME TABLE operation support

### DIFF
--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
@@ -137,7 +137,6 @@ describe('postgresqlOperationDeparser', () => {
         "ALTER TABLE \"users\" RENAME TO \"user_accounts\";"
       `)
     })
-
   })
 
   describe('column operations', () => {

--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
@@ -122,6 +122,22 @@ describe('postgresqlOperationDeparser', () => {
         "DROP TABLE \"users\";"
       `)
     })
+
+    it('should generate RENAME TABLE statement from replace operation', () => {
+      const operation: Operation = {
+        op: 'replace',
+        path: '/tables/users/name',
+        value: 'user_accounts',
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"users\" RENAME TO \"user_accounts\";"
+      `)
+    })
+
   })
 
   describe('column operations', () => {

--- a/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
@@ -153,6 +153,16 @@ export function generateRemoveTableStatement(tableName: string): string {
 }
 
 /**
+ * Generate RENAME TABLE statement
+ */
+export function generateRenameTableStatement(
+  oldTableName: string,
+  newTableName: string,
+): string {
+  return `ALTER TABLE ${escapeIdentifier(oldTableName)} RENAME TO ${escapeIdentifier(newTableName)};`
+}
+
+/**
  * Generate CREATE INDEX statement for an index
  */
 export function generateCreateIndexStatement(

--- a/frontend/packages/db-structure/src/operation/schema/table.ts
+++ b/frontend/packages/db-structure/src/operation/schema/table.ts
@@ -4,6 +4,10 @@ import { PATH_PATTERNS } from '../constants.js'
 import type { Operation } from './index.js'
 
 const tablePathSchema = v.pipe(v.string(), v.regex(PATH_PATTERNS.TABLE_BASE))
+const tableNamePathSchema = v.pipe(
+  v.string(),
+  v.regex(PATH_PATTERNS.TABLE_NAME),
+)
 
 const addTableOperationSchema = v.object({
   op: v.literal('add'),
@@ -16,9 +20,18 @@ const removeTableOperationSchema = v.object({
   path: tablePathSchema,
 })
 
+const replaceTableNameOperationSchema = v.object({
+  op: v.literal('replace'),
+  path: tableNamePathSchema,
+  value: v.string(),
+})
+
 export type AddTableOperation = v.InferOutput<typeof addTableOperationSchema>
 export type RemoveTableOperation = v.InferOutput<
   typeof removeTableOperationSchema
+>
+export type ReplaceTableNameOperation = v.InferOutput<
+  typeof replaceTableNameOperationSchema
 >
 
 export const isAddTableOperation = (
@@ -33,7 +46,14 @@ export const isRemoveTableOperation = (
   return v.safeParse(removeTableOperationSchema, operation).success
 }
 
+export const isReplaceTableNameOperation = (
+  operation: Operation,
+): operation is ReplaceTableNameOperation => {
+  return v.safeParse(replaceTableNameOperationSchema, operation).success
+}
+
 export const tableOperations = [
   addTableOperationSchema,
   removeTableOperationSchema,
+  replaceTableNameOperationSchema,
 ]


### PR DESCRIPTION
~This PR depends on #2149. Once #2149 is merged, this PR will be ready for review and the WIP prefix will be removed.~

## Issue

- resolve: Implement support for RENAME TABLE operations in the database schema operation system

## Why is this change needed?

This change adds support for the `replace` operation on table names (path: `/tables/{tableName}/name`), allowing users to generate `ALTER TABLE {oldName} RENAME TO {newName}` DDL statements through the operation system.

## What would you like reviewers to focus on?

- Schema definition for ReplaceTableNameOperation in `table.ts`
- DDL generation logic in `generateRenameTableStatement` function
- Integration with the operation deparser using TABLE_NAME path pattern
- Test coverage for the new functionality

## Testing Verification

- All existing tests continue to pass
- New comprehensive test added for rename table operation
- Verified DDL generation produces correct `ALTER TABLE {oldName} RENAME TO {newName};` statements
- Ran quality checks: `pnpm fmt`, `pnpm lint`, and `pnpm test` all pass

## What was done

- Added `ReplaceTableNameOperation` schema with proper path validation using `PATH_PATTERNS.TABLE_NAME`
- Implemented `generateRenameTableStatement` utility function with proper identifier escaping
- Added `extractTableNameFromNamePath` helper function for path parsing
- Integrated rename table support into the PostgreSQL operation deparser
- Added comprehensive test coverage following existing patterns

## Additional Notes

This implementation follows the established operation support pattern and maintains consistency with existing table operations. The rename operation uses the `replace` operation type with `/tables/{tableName}/name` path pattern, consistent with column rename operations.

🤖 Generated with [Claude Code](https://claude.ai/code)