### PR TITLE
feat: implement ADD and REMOVE CONSTRAINT operation support

### DIFF
--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
@@ -344,4 +344,86 @@ describe('postgresqlOperationDeparser', () => {
       `)
     })
   })
+
+  describe('constraint operations', () => {
+    it('should generate ADD CONSTRAINT PRIMARY KEY statement', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/users/constraints/pk_users_id',
+        value: {
+          type: 'PRIMARY KEY',
+          name: 'pk_users_id',
+          columnName: 'id',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"users\" ADD CONSTRAINT \"pk_users_id\" PRIMARY KEY (\"id\");"
+      `)
+    })
+
+    it('should generate ADD CONSTRAINT FOREIGN KEY statement', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/orders/constraints/fk_orders_user_id',
+        value: {
+          type: 'FOREIGN KEY',
+          name: 'fk_orders_user_id',
+          columnName: 'user_id',
+          targetTableName: 'users',
+          targetColumnName: 'id',
+          updateConstraint: 'CASCADE',
+          deleteConstraint: 'SET_NULL',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"orders\" ADD CONSTRAINT \"fk_orders_user_id\" FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\") ON UPDATE CASCADE ON DELETE SET_NULL;"
+      `)
+    })
+
+    it('should generate ADD CONSTRAINT UNIQUE statement', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/users/constraints/uk_users_email',
+        value: {
+          type: 'UNIQUE',
+          name: 'uk_users_email',
+          columnName: 'email',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"users\" ADD CONSTRAINT \"uk_users_email\" UNIQUE (\"email\");"
+      `)
+    })
+
+    it('should generate ADD CONSTRAINT CHECK statement', () => {
+      const operation: Operation = {
+        op: 'add',
+        path: '/tables/products/constraints/ck_products_price_positive',
+        value: {
+          type: 'CHECK',
+          name: 'ck_products_price_positive',
+          detail: 'price > 0',
+        },
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"products\" ADD CONSTRAINT \"ck_products_price_positive\" CHECK (price > 0);"
+      `)
+    })
+  })
 })

--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.test.ts
@@ -425,5 +425,47 @@ describe('postgresqlOperationDeparser', () => {
         "ALTER TABLE \"products\" ADD CONSTRAINT \"ck_products_price_positive\" CHECK (price > 0);"
       `)
     })
+
+    it('should generate DROP CONSTRAINT statement', () => {
+      const operation: Operation = {
+        op: 'remove',
+        path: '/tables/users/constraints/pk_users_id',
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"users\" DROP CONSTRAINT \"pk_users_id\";"
+      `)
+    })
+
+    it('should generate DROP CONSTRAINT for complex constraint name', () => {
+      const operation: Operation = {
+        op: 'remove',
+        path: '/tables/orders/constraints/fk_orders_user_id',
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"orders\" DROP CONSTRAINT \"fk_orders_user_id\";"
+      `)
+    })
+
+    it('should generate DROP CONSTRAINT for table with complex name', () => {
+      const operation: Operation = {
+        op: 'remove',
+        path: '/tables/user_profiles/constraints/uk_user_profiles_email',
+      }
+
+      const result = postgresqlOperationDeparser(operation)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.value).toMatchInlineSnapshot(`
+        "ALTER TABLE \"user_profiles\" DROP CONSTRAINT \"uk_user_profiles_email\";"
+      `)
+    })
   })
 })

--- a/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/operationDeparser.ts
@@ -9,8 +9,14 @@ import {
   isRemoveColumnOperation,
   isRenameColumnOperation,
 } from '../../operation/schema/column.js'
-import type { AddConstraintOperation } from '../../operation/schema/constraint.js'
-import { isAddConstraintOperation } from '../../operation/schema/constraint.js'
+import type {
+  AddConstraintOperation,
+  RemoveConstraintOperation,
+} from '../../operation/schema/constraint.js'
+import {
+  isAddConstraintOperation,
+  isRemoveConstraintOperation,
+} from '../../operation/schema/constraint.js'
 import type { Operation } from '../../operation/schema/index.js'
 import type {
   AddIndexOperation,
@@ -37,6 +43,7 @@ import {
   generateCreateIndexStatement,
   generateCreateTableStatement,
   generateRemoveColumnStatement,
+  generateRemoveConstraintStatement,
   generateRemoveIndexStatement,
   generateRemoveTableStatement,
   generateRenameColumnStatement,
@@ -251,6 +258,23 @@ function generateAddConstraintFromOperation(
   return generateAddConstraintStatement(pathInfo.tableName, operation.value)
 }
 
+/**
+ * Generate DROP CONSTRAINT DDL from constraint removal operation
+ */
+function generateRemoveConstraintFromOperation(
+  operation: RemoveConstraintOperation,
+): string {
+  const pathInfo = extractTableAndConstraintNameFromPath(operation.path)
+  if (!pathInfo) {
+    throw new Error(`Invalid constraint path: ${operation.path}`)
+  }
+
+  return generateRemoveConstraintStatement(
+    pathInfo.tableName,
+    pathInfo.constraintName,
+  )
+}
+
 export const postgresqlOperationDeparser: OperationDeparser = (
   operation: Operation,
 ) => {
@@ -298,6 +322,11 @@ export const postgresqlOperationDeparser: OperationDeparser = (
 
   if (isAddConstraintOperation(operation)) {
     const value = generateAddConstraintFromOperation(operation)
+    return { value, errors }
+  }
+
+  if (isRemoveConstraintOperation(operation)) {
+    const value = generateRemoveConstraintFromOperation(operation)
     return { value, errors }
   }
 

--- a/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
@@ -212,3 +212,13 @@ export function generateAddConstraintStatement(
       return constraint satisfies never
   }
 }
+
+/**
+ * Generate DROP CONSTRAINT statement
+ */
+export function generateRemoveConstraintStatement(
+  tableName: string,
+  constraintName: string,
+): string {
+  return `ALTER TABLE ${escapeIdentifier(tableName)} DROP CONSTRAINT ${escapeIdentifier(constraintName)};`
+}

--- a/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/db-structure/src/deparser/postgresql/utils.ts
@@ -1,4 +1,4 @@
-import type { Column, Index, Table } from '../../schema/index.js'
+import type { Column, Constraint, Index, Table } from '../../schema/index.js'
 
 /**
  * Generate column definition as DDL string
@@ -183,4 +183,32 @@ export function generateCreateIndexStatement(
  */
 export function generateRemoveIndexStatement(indexName: string): string {
   return `DROP INDEX ${escapeIdentifier(indexName)};`
+}
+
+/**
+ * Generate ADD CONSTRAINT statement for a constraint
+ */
+export function generateAddConstraintStatement(
+  tableName: string,
+  constraint: Constraint,
+): string {
+  const constraintName = escapeIdentifier(constraint.name)
+  const tableNameEscaped = escapeIdentifier(tableName)
+
+  switch (constraint.type) {
+    case 'PRIMARY KEY':
+      return `ALTER TABLE ${tableNameEscaped} ADD CONSTRAINT ${constraintName} PRIMARY KEY (${escapeIdentifier(constraint.columnName)});`
+
+    case 'FOREIGN KEY':
+      return `ALTER TABLE ${tableNameEscaped} ADD CONSTRAINT ${constraintName} FOREIGN KEY (${escapeIdentifier(constraint.columnName)}) REFERENCES ${escapeIdentifier(constraint.targetTableName)} (${escapeIdentifier(constraint.targetColumnName)}) ON UPDATE ${constraint.updateConstraint} ON DELETE ${constraint.deleteConstraint};`
+
+    case 'UNIQUE':
+      return `ALTER TABLE ${tableNameEscaped} ADD CONSTRAINT ${constraintName} UNIQUE (${escapeIdentifier(constraint.columnName)});`
+
+    case 'CHECK':
+      return `ALTER TABLE ${tableNameEscaped} ADD CONSTRAINT ${constraintName} CHECK (${constraint.detail});`
+
+    default:
+      return constraint satisfies never
+  }
 }

--- a/frontend/packages/db-structure/src/operation/schema/constraint.ts
+++ b/frontend/packages/db-structure/src/operation/schema/constraint.ts
@@ -24,4 +24,22 @@ export const isAddConstraintOperation = (
   return v.safeParse(addConstraintOperationSchema, operation).success
 }
 
-export const constraintOperations = [addConstraintOperationSchema]
+const removeConstraintOperationSchema = v.object({
+  op: v.literal('remove'),
+  path: constraintPathSchema,
+})
+
+export type RemoveConstraintOperation = v.InferOutput<
+  typeof removeConstraintOperationSchema
+>
+
+export const isRemoveConstraintOperation = (
+  operation: Operation,
+): operation is RemoveConstraintOperation => {
+  return v.safeParse(removeConstraintOperationSchema, operation).success
+}
+
+export const constraintOperations = [
+  addConstraintOperationSchema,
+  removeConstraintOperationSchema,
+]

--- a/frontend/packages/db-structure/src/operation/schema/constraint.ts
+++ b/frontend/packages/db-structure/src/operation/schema/constraint.ts
@@ -1,0 +1,27 @@
+import * as v from 'valibot'
+import { constraintSchema } from '../../schema/index.js'
+import { PATH_PATTERNS } from '../constants.js'
+import type { Operation } from './index.js'
+
+const constraintPathSchema = v.pipe(
+  v.string(),
+  v.regex(PATH_PATTERNS.CONSTRAINT_BASE),
+)
+
+const addConstraintOperationSchema = v.object({
+  op: v.literal('add'),
+  path: constraintPathSchema,
+  value: constraintSchema,
+})
+
+export type AddConstraintOperation = v.InferOutput<
+  typeof addConstraintOperationSchema
+>
+
+export const isAddConstraintOperation = (
+  operation: Operation,
+): operation is AddConstraintOperation => {
+  return v.safeParse(addConstraintOperationSchema, operation).success
+}
+
+export const constraintOperations = [addConstraintOperationSchema]

--- a/frontend/packages/db-structure/src/operation/schema/index.ts
+++ b/frontend/packages/db-structure/src/operation/schema/index.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot'
 import { columnOperations } from './column.js'
+import { constraintOperations } from './constraint.js'
 import { indexOperations } from './index-operations.js'
 import { tableOperations } from './table.js'
 
@@ -42,6 +43,7 @@ const operationSchema = v.union([
   ...tableOperations,
   ...columnOperations,
   ...indexOperations,
+  ...constraintOperations,
   addOperationSchema,
   removeOperationSchema,
   replaceOperationSchema,


### PR DESCRIPTION
~This PR depends on #2151. Once #2151 is merged, this PR will be ready for review and the WIP prefix will be removed.~

## Issue

- resolve: Implement support for ADD and REMOVE CONSTRAINT operations in the database schema operation system

## Why is this change needed?

This change adds support for both `add` and `remove` operations on constraints, allowing users to:
- Generate `ALTER TABLE ADD CONSTRAINT` DDL statements for all constraint types (PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK)
- Generate `ALTER TABLE DROP CONSTRAINT` DDL statements for removing constraints

## What would you like reviewers to focus on?

- Schema definitions for AddConstraintOperation and RemoveConstraintOperation in `constraint.ts`
- DDL generation logic in `generateAddConstraintStatement` and `generateRemoveConstraintStatement` functions
- Integration with the operation deparser for both operations
- Test coverage for all constraint types and both add/remove operations

## Testing Verification

- All existing tests continue to pass
- New comprehensive tests added for both ADD and REMOVE constraint operations
- Verified DDL generation produces correct statements:
  - `ALTER TABLE ADD CONSTRAINT` for all constraint types
  - `ALTER TABLE DROP CONSTRAINT` for constraint removal
- Ran quality checks: `pnpm fmt`, `pnpm lint`, and `pnpm test` all pass

## What was done

### ADD CONSTRAINT Support
- Add support for ADD CONSTRAINT operations in database schema system
- Implement DDL generation for PRIMARY KEY, FOREIGN KEY, UNIQUE, and CHECK constraints
- Add comprehensive test coverage for all constraint types

### REMOVE CONSTRAINT Support
- Add RemoveConstraintOperation schema and type guard to constraint.ts
- Implement generateRemoveConstraintStatement utility function
- Support DROP CONSTRAINT DDL generation in operationDeparser
- Add comprehensive tests for remove constraint operations

## Additional Notes

This implementation follows the established operation support pattern and maintains consistency with existing table, column, and index operations. The constraint system now supports both adding and removing all four PostgreSQL constraint types with proper SQL generation.

🤖 Generated with [Claude Code](https://claude.ai/code)