### PR TITLE
🧪 test(command palette): create E2E test of CommandPalette component

### DIFF
--- a/frontend/internal-packages/e2e/tests/e2e/commandPalette.test.ts
+++ b/frontend/internal-packages/e2e/tests/e2e/commandPalette.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page, isMobile }) => {
+  if (isMobile) {
+    test.skip()
+  }
+
+  await page.goto('/')
+})
+
+test('go to table in ERD by CommandPalette', async ({ page }) => {
+  // Open dialog
+  await page.keyboard.press('Control+k')
+  const commandPaletteDialog = await page.getByRole('dialog', {
+    name: 'Command Palette',
+  })
+  await expect(commandPaletteDialog).toBeVisible()
+
+  // Select "user_roles" option
+  await page.keyboard.type('user_roles')
+  await page.keyboard.press('Enter')
+
+  // Go to ERD
+  await expect(page).toHaveURL(/.*active=user_roles/)
+})

--- a/frontend/internal-packages/e2e/tests/e2e/commandPalette.test.ts
+++ b/frontend/internal-packages/e2e/tests/e2e/commandPalette.test.ts
@@ -20,6 +20,7 @@ test('go to table in ERD by CommandPalette', async ({ page }) => {
   await page.keyboard.type('user_roles')
   await page.keyboard.press('Enter')
 
-  // Go to ERD
+  // Close dialog and go to ERD
+  await expect(commandPaletteDialog).not.toBeVisible()
   await expect(page).toHaveURL(/.*active=user_roles/)
 })


### PR DESCRIPTION
## Issue

~- resolve:~
related to https://github.com/liam-hq/liam/issues/507

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

To make sure the `CommandPalette` dialog is implemented in the application, this PR implements the E2E test. As a first step, I added a very simple case, open dialog -> select an option -> go to the table.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- check the scenario

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

N/A (only adding a test)

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 69f04f753607ef7cd87e44c9c43bfc8fe0582ef3

- Add E2E test for CommandPalette component functionality
- Test keyboard shortcut (Ctrl+K) to open dialog
- Verify table navigation through command palette search
- Include mobile device skip logic


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commandPalette.test.ts</strong><dd><code>Create CommandPalette E2E test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/e2e/tests/e2e/commandPalette.test.ts

<li>Create new E2E test file for CommandPalette component<br> <li> Add test for opening dialog with Ctrl+K keyboard shortcut<br> <li> Test table search and navigation functionality<br> <li> Include mobile device skip logic in beforeEach hook


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2163/files#diff-494af6c7cce8af811d2ce638485edc86904b2de72bf06f7aa09f823638d1f791">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>