### PR TITLE
fix: remove path filters from trigger_dev_preview workflow

### DIFF
--- a/.github/workflows/trigger_dev_preview.yml
+++ b/.github/workflows/trigger_dev_preview.yml
@@ -2,14 +2,6 @@ name: trigger_dev_preview
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    paths:
-      - .github/workflows/trigger_dev_preview.yml
-      - frontend/internal-packages/jobs/**
-      - frontend/packages/db-structure/**
-      - frontend/packages/github/**
-      - frontend/internal-packages/db/**
-      - frontend/internal-packages/agent/**
-      - turbo.json
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
The trigger_dev_preview workflow currently has path filters that prevent it from running when app package changes need to be tested together with jobs. This causes deployment issues when trying to verify changes that affect both the app and background jobs.

## What would you like reviewers to focus on?
- Confirm that removing the path filters is the appropriate solution
- Verify that this won't cause unnecessary workflow runs that impact CI resources

## Testing Verification
The workflow change will be verified when this PR is created - the trigger_dev_preview workflow should run immediately.

## What was done

pr_agent:summary

## Detailed Changes

pr_agent:walkthrough

## Additional Notes
This change ensures that preview deployments happen for all PRs, allowing proper integration testing between app changes and background jobs.