### PR TITLE
fix: remove unused progressMessages state from Chat component

### DIFF
--- a/frontend/apps/app/components/Chat/AgentMessage/AgentMessage.tsx
+++ b/frontend/apps/app/components/Chat/AgentMessage/AgentMessage.tsx
@@ -42,14 +42,6 @@ type AgentMessageProps = {
    * Optional children to render below the message
    */
   children?: ReactNode
-  /**
-   * Progress messages to display above the main message
-   */
-  progressMessages?: string[]
-  /**
-   * Whether to show progress messages
-   */
-  showProgress?: boolean
 }
 
 export const AgentMessage: FC<AgentMessageProps> = ({
@@ -57,8 +49,6 @@ export const AgentMessage: FC<AgentMessageProps> = ({
   message = '',
   agentName,
   children,
-  progressMessages,
-  showProgress,
 }) => {
   const isGenerating = state === 'generating'
 
@@ -69,20 +59,6 @@ export const AgentMessage: FC<AgentMessageProps> = ({
         <span className={styles.agentName}>{agentName || 'Build Agent'}</span>
       </div>
       <div className={styles.contentContainer}>
-        {/* Show progress messages if available */}
-        {showProgress && progressMessages && progressMessages.length > 0 && (
-          <div className={styles.progressContainer}>
-            {progressMessages.map((message, index) => (
-              <div
-                key={`progress-${index}-${message.slice(0, 10)}`}
-                className={styles.progressMessage}
-              >
-                {message}
-              </div>
-            ))}
-          </div>
-        )}
-
         {isGenerating &&
         (!message || (typeof message === 'string' && message.trim() === '')) ? (
           <div

--- a/frontend/apps/app/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/Chat/Chat.tsx
@@ -34,7 +34,6 @@ export const Chat: FC<Props> = ({ schemaData, designSession }) => {
     currentUserId,
   )
   const [isLoading, startTransition] = useTransition()
-  const [progressMessages, setProgressMessages] = useState<string[]>([])
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const autoStartExecuted = useRef(false)
 
@@ -78,7 +77,6 @@ export const Chat: FC<Props> = ({ schemaData, designSession }) => {
       message: content,
       timelineItems,
       designSession,
-      setProgressMessages,
       currentUserId,
     })
 
@@ -111,24 +109,9 @@ export const Chat: FC<Props> = ({ schemaData, designSession }) => {
     <div className={styles.wrapper}>
       <div className={styles.messagesContainer}>
         {/* Display all timeline items */}
-        {timelineItems.map((timelineItem, index) => {
-          // Check if this is the last AI timeline item and has progress messages
-          const isLastAITimelineItem =
-            timelineItem.role !== 'user' && index === timelineItems.length - 1
-          const shouldShowProgress =
-            progressMessages.length > 0 && isLastAITimelineItem
-
-          return (
-            <TimelineItem
-              key={timelineItem.id}
-              {...timelineItem}
-              progressMessages={
-                shouldShowProgress ? progressMessages : undefined
-              }
-              showProgress={shouldShowProgress}
-            />
-          )
-        })}
+        {timelineItems.map((timelineItem) => (
+          <TimelineItem key={timelineItem.id} {...timelineItem} />
+        ))}
         {isLoading && (
           <div className={styles.loadingIndicator}>
             <div className={styles.loadingDot} />

--- a/frontend/apps/app/components/Chat/services/aiMessageService.ts
+++ b/frontend/apps/app/components/Chat/services/aiMessageService.ts
@@ -16,7 +16,6 @@ interface SendChatMessageParams {
   message: string
   timelineItems: TimelineItemEntry[]
   designSession: DesignSession
-  setProgressMessages: (updater: (prev: string[]) => string[]) => void
   currentUserId: string
 }
 
@@ -67,16 +66,10 @@ const callChatAPI = async (
 }
 
 /**
- * Handles errors by clearing progress messages
+ * Handles errors
  */
-const handleChatError = (
-  error: unknown,
-  setProgressMessages: (updater: (prev: string[]) => string[]) => void,
-): SendChatMessageResult => {
+const handleChatError = (error: unknown): SendChatMessageResult => {
   console.error('Error in sendChatMessage:', error)
-
-  // Clear progress messages on error
-  setProgressMessages(() => [])
 
   return {
     success: false,
@@ -92,7 +85,6 @@ export const sendChatMessage = async ({
   message,
   timelineItems,
   designSession,
-  setProgressMessages,
   currentUserId,
 }: SendChatMessageParams): Promise<SendChatMessageResult> => {
   try {
@@ -115,11 +107,8 @@ export const sendChatMessage = async ({
       throw new Error(data.error || ERROR_MESSAGES.GENERAL)
     }
 
-    // Clear progress messages on success
-    setProgressMessages(() => [])
-
     return { success: true }
   } catch (error) {
-    return handleChatError(error, setProgressMessages)
+    return handleChatError(error)
   }
 }

--- a/frontend/apps/app/components/TimelineItem/TimelineItem.tsx
+++ b/frontend/apps/app/components/TimelineItem/TimelineItem.tsx
@@ -26,14 +26,6 @@ export type TimelineItemProps =
        * Optional children to render below the message content
        */
       children?: ReactNode
-      /**
-       * Progress messages to display above the main message
-       */
-      progressMessages?: string[]
-      /**
-       * Whether to show progress messages
-       */
-      showProgress?: boolean
     }
   | {
       id: string
@@ -64,8 +56,6 @@ export const TimelineItem: FC<TimelineItemProps> = (props) => {
     initial,
     isGenerating = false,
     children,
-    progressMessages,
-    showProgress,
   } = props
 
   // Only format and display timestamp if it exists
@@ -95,8 +85,6 @@ export const TimelineItem: FC<TimelineItemProps> = (props) => {
           state={isGenerating ? 'generating' : 'default'}
           message={markdownContent}
           time={formattedTime || ''}
-          progressMessages={progressMessages}
-          showProgress={showProgress}
         >
           {children}
         </AgentMessage>


### PR DESCRIPTION
Removes unused progressMessages state and related code from the Chat component system.

## Changes
- Remove progressMessages state from Chat.tsx
- Remove setProgressMessages parameter from aiMessageService.ts
- Remove progressMessages and showProgress props from TimelineItem.tsx
- Remove progress messages display UI from AgentMessage.tsx

The progressMessages feature was implemented but never actually used - messages were only cleared, never populated. This cleanup removes the unused code to maintain a clean codebase.

Fixes #2168

Generated with [Claude Code](https://claude.ai/code)