### PR TITLE
♻️ Refactor: Update prompt variable types

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
@@ -2,7 +2,6 @@ import type * as v from 'valibot'
 import { PMAnalysisAgent } from '../../../langchain/agents'
 import type { requirementsAnalysisSchema } from '../../../langchain/agents/pmAnalysisAgent/agent'
 import type { BasePromptVariables } from '../../../langchain/utils/types'
-import { convertSchemaToText } from '../../../utils/convertSchemaToText'
 import type { WorkflowState } from '../types'
 
 const NODE_NAME = 'analyzeRequirementsNode'
@@ -37,10 +36,8 @@ export async function analyzeRequirementsNode(
   state.logger.log(`[${NODE_NAME}] Started`)
 
   const pmAnalysisAgent = new PMAnalysisAgent()
-  const schemaText = convertSchemaToText(state.schemaData)
 
   const promptVariables: BasePromptVariables = {
-    schema_text: schemaText,
     chat_history: state.formattedHistory,
     user_message: state.userInput,
   }

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -1,6 +1,6 @@
 import { DatabaseSchemaBuildAgent } from '../../../langchain/agents'
 import type { BuildAgentResponse } from '../../../langchain/agents/databaseSchemaBuildAgent/agent'
-import type { BasePromptVariables } from '../../../langchain/utils/types'
+import type { SchemaAwareChatVariables } from '../../../langchain/utils/types'
 import { convertSchemaToText } from '../../../utils/convertSchemaToText'
 import type { WorkflowState } from '../types'
 
@@ -97,7 +97,7 @@ export async function designSchemaNode(
   const { agent, schemaText } = await prepareSchemaDesign(state)
 
   // Create prompt variables directly
-  const promptVariables: BasePromptVariables = {
+  const promptVariables: SchemaAwareChatVariables = {
     schema_text: schemaText,
     chat_history: state.formattedHistory,
     user_message: state.userInput,

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/generateDDLNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/generateDDLNode.ts
@@ -1,5 +1,5 @@
 import { QADDLGenerationAgent } from '../../../langchain/agents'
-import type { BasePromptVariables } from '../../../langchain/utils/types'
+import type { SchemaAwareChatVariables } from '../../../langchain/utils/types'
 import { convertSchemaToText } from '../../../utils/convertSchemaToText'
 import type { WorkflowState } from '../types'
 
@@ -40,7 +40,7 @@ export async function generateDDLNode(
 
     const { agent, schemaText } = await prepareDDLGeneration(state)
 
-    const promptVariables: BasePromptVariables = {
+    const promptVariables: SchemaAwareChatVariables = {
       schema_text: schemaText,
       chat_history: state.formattedHistory,
       user_message:

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
@@ -1,7 +1,6 @@
 import { QAGenerateUsecaseAgent } from '../../../langchain/agents'
 import type { Usecase } from '../../../langchain/agents/qaGenerateUsecaseAgent/agent'
 import type { BasePromptVariables } from '../../../langchain/utils/types'
-import { convertSchemaToText } from '../../../utils/convertSchemaToText'
 import type { WorkflowState } from '../types'
 
 const NODE_NAME = 'generateUsecaseNode'
@@ -74,7 +73,6 @@ export async function generateUsecaseNode(
   }
 
   const qaAgent = new QAGenerateUsecaseAgent()
-  const schemaText = convertSchemaToText(state.schemaData)
 
   // Create a user message that includes the analyzed requirements
   const requirementsText = formatAnalyzedRequirements(
@@ -83,7 +81,6 @@ export async function generateUsecaseNode(
   )
 
   const promptVariables: BasePromptVariables = {
-    schema_text: schemaText,
     chat_history: state.formattedHistory,
     user_message: requirementsText,
   }

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
@@ -3,7 +3,7 @@ import { operationsSchema } from '@liam-hq/db-structure'
 import { toJsonSchema } from '@valibot/to-json-schema'
 import * as v from 'valibot'
 import { createLangfuseHandler } from '../../utils/telemetry'
-import type { BasePromptVariables, ChatAgent } from '../../utils/types'
+import type { ChatAgent, SchemaAwareChatVariables } from '../../utils/types'
 import { buildAgentPrompt } from './prompts'
 
 // Define the response schema
@@ -14,7 +14,9 @@ const buildAgentResponseSchema = v.object({
 
 export type BuildAgentResponse = v.InferOutput<typeof buildAgentResponseSchema>
 
-export class DatabaseSchemaBuildAgent implements ChatAgent<BuildAgentResponse> {
+export class DatabaseSchemaBuildAgent
+  implements ChatAgent<SchemaAwareChatVariables, BuildAgentResponse>
+{
   private model: ReturnType<ChatOpenAI['withStructuredOutput']>
 
   constructor() {
@@ -27,7 +29,9 @@ export class DatabaseSchemaBuildAgent implements ChatAgent<BuildAgentResponse> {
     this.model = baseModel.withStructuredOutput(jsonSchema)
   }
 
-  async generate(variables: BasePromptVariables): Promise<BuildAgentResponse> {
+  async generate(
+    variables: SchemaAwareChatVariables,
+  ): Promise<BuildAgentResponse> {
     const formattedPrompt = await buildAgentPrompt.format(variables)
     const rawResponse = await this.model.invoke(formattedPrompt)
 

--- a/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
@@ -13,7 +13,9 @@ export const requirementsAnalysisSchema = v.object({
 
 type AnalysisResponse = v.InferOutput<typeof requirementsAnalysisSchema>
 
-export class PMAnalysisAgent implements ChatAgent<AnalysisResponse> {
+export class PMAnalysisAgent
+  implements ChatAgent<BasePromptVariables, AnalysisResponse>
+{
   private analysisModel: ReturnType<ChatOpenAI['withStructuredOutput']>
 
   constructor() {

--- a/frontend/internal-packages/agent/src/langchain/agents/qaDDLGenerationAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/qaDDLGenerationAgent/agent.ts
@@ -1,6 +1,6 @@
 import { ChatOpenAI } from '@langchain/openai'
 import { createLangfuseHandler } from '../../utils/telemetry'
-import type { BasePromptVariables, ChatAgent } from '../../utils/types'
+import type { ChatAgent, SchemaAwareChatVariables } from '../../utils/types'
 import { qaDDLGenerationPrompt } from './prompts'
 
 /**
@@ -9,7 +9,9 @@ import { qaDDLGenerationPrompt } from './prompts'
  * TODO: This LLM-based DDL generation is a temporary solution.
  * In the future, DDL will be generated mechanically without LLM.
  */
-export class QADDLGenerationAgent implements ChatAgent {
+export class QADDLGenerationAgent
+  implements ChatAgent<SchemaAwareChatVariables, string>
+{
   private model: ChatOpenAI
 
   constructor() {
@@ -19,7 +21,7 @@ export class QADDLGenerationAgent implements ChatAgent {
     })
   }
 
-  async generate(variables: BasePromptVariables): Promise<string> {
+  async generate(variables: SchemaAwareChatVariables): Promise<string> {
     const formattedPrompt = await qaDDLGenerationPrompt.format(variables)
     const response = await this.model.invoke(formattedPrompt)
     return response.content as string

--- a/frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts
@@ -26,7 +26,7 @@ type GenerateUsecasesResponse = v.InferOutput<
 >
 
 export class QAGenerateUsecaseAgent
-  implements ChatAgent<GenerateUsecasesResponse>
+  implements ChatAgent<BasePromptVariables, GenerateUsecasesResponse>
 {
   private model: ReturnType<ChatOpenAI['withStructuredOutput']>
 

--- a/frontend/internal-packages/agent/src/langchain/utils/types.ts
+++ b/frontend/internal-packages/agent/src/langchain/utils/types.ts
@@ -1,9 +1,15 @@
 export interface BasePromptVariables {
-  schema_text: string
   chat_history: string
   user_message: string
 }
 
-export interface ChatAgent<T = string> {
-  generate(variables: BasePromptVariables): Promise<T>
+export interface SchemaAwareChatVariables extends BasePromptVariables {
+  schema_text: string
+}
+
+export interface ChatAgent<
+  TVariables = BasePromptVariables,
+  TResponse = string,
+> {
+  generate(variables: TVariables): Promise<TResponse>
 }


### PR DESCRIPTION

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

 Refactored prompt variables to be more specific for each agent's needs, eliminating unused variable warnings and improving type safety.

- Introduced two distinct prompt variable interfaces:
  - `BasePromptVariables`: Contains only `chat_history` and `user_message` for basic chat agents
  - `SchemaAwareChatVariables`: Extends `BasePromptVariables` with `schema_text` for schema-aware agents

- Made `ChatAgent` interface generic to support different variable types:
  - `ChatAgent<TVariables, TResponse>` allows each agent to specify its required variables

- Updated agents to use appropriate variable types:
  - `QAGenerateUsecaseAgent` and `PMAnalysisAgent` use `BasePromptVariables` (no schema needed)
  - `DatabaseSchemaBuildAgent` and `QADDLGenerationAgent` use `SchemaAwareChatVariables`

- Updated all workflow nodes to use the correct variable types

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
