### PR TITLE
docs: add PR template reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,12 @@ For database migration and type generation workflows, see [`docs/migrationOpsCon
 - Generate CSS type definitions with `pnpm gen:css`
 - Watch mode available with `pnpm dev:css`
 
+## Pull Requests
+When creating pull requests, refer to @.github/pull_request_template.md for the required information and format.
+
 ## Important Files
 - `frontend/apps/docs/content/docs/contributing/repository-architecture.mdx` - Detailed package structure
 - `.cursorrules` - Contains detailed coding standards and guidelines
 - `turbo.json` - Build system configuration
 - `biome.jsonc` - Linting and formatting configuration
+- `.github/pull_request_template.md` - Pull request template


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
To ensure that Claude Code references the PR template when creating pull requests, improving consistency in PR creation.

## What would you like reviewers to focus on?
- Clarity of the new Pull Requests section
- Placement within the document structure

## Testing Verification
This is a documentation change, no functional testing required.

## What was done

Added guidance to CLAUDE.md for referencing the PR template:
- Created new "Pull Requests" section
- Added instruction to refer to `.github/pull_request_template.md`
- Included PR template in the Important Files list

## Additional Notes
This change helps ensure consistent PR creation when using Claude Code.

🤖 Generated with [Claude Code](https://claude.ai/code)