### PR TITLE
Fixed incorrect workflow file

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
         (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
       )
     runs-on: ubuntu-latest
-    timeout-minutes: "60"
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -41,5 +41,4 @@ jobs:
         uses: anthropics/claude-code-action@8c08381496931f68f7918d3788c75ec258f2698b # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          timeout_minutes: "60"
           allowed_tools: "Bash(pnpm fmt:*),Bash(pnpm install),Bash(pnpm lint:*),Bash(pnpm test:*)"


### PR DESCRIPTION
## Issue

- resolve: Workflow file syntax error introduced in #2208

## Why is this change needed?
PR #2208 introduced incorrect syntax in the claude.yml workflow file that would prevent it from running properly:
- `timeout-minutes` was set as a string ("60") instead of a number (60)
- There was a duplicate `timeout_minutes` parameter in the claude-code-action configuration

## What would you like reviewers to focus on?
Please verify that the workflow file syntax is now correct and the timeout values are properly configured.

## Testing Verification
- Checked the workflow file syntax
- Confirmed that `timeout-minutes` should be a number according to GitHub Actions documentation
- Removed duplicate timeout configuration from the action parameters

## What was done
Fixed the claude.yml workflow file by:
1. Changed `timeout-minutes: "60"` to `timeout-minutes: 60` (removed quotes to make it a number)
2. Removed the duplicate `timeout_minutes: "60"` parameter from the claude-code-action

## Detailed Changes
- `.github/workflows/claude.yml`: Fixed timeout configuration syntax

## Additional Notes
This fixes the syntax errors that were introduced in PR #2208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve reliability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->