### PR TITLE
fix: resolve ghalint policy violations in renovate-review workflow

### DIFF
--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -13,15 +13,17 @@ jobs:
       pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Need full history for accurate diff analysis
+          persist-credentials: false
 
       - name: Auto review Renovate PR
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@9dd49689e4f1e4dc231c5694c3753c1e1157b4d7 # beta
         with:
           direct_prompt: |
             Review this Renovate PR for dependency updates. Analyze regression risks by examining:


### PR DESCRIPTION
## Issue

- resolve: #2220

## Why is this change needed?

The renovate-review workflow was violating several ghalint security policies that enforce best practices for GitHub Actions workflows.

## What would you like reviewers to focus on?

Please verify that the workflow still functions correctly with these security improvements:
- Timeout setting is appropriate (30 minutes)
- Pinned action versions are correct
- The workflow continues to auto-review Renovate PRs as expected

## Testing Verification

Ran `ghalint run` locally - all violations are now resolved.

## What was done

### Fixed ghalint policy violations:
1. **Added timeout-minutes** - Set 30-minute timeout for the renovate-review job (policy: job_timeout_minutes_is_required)
2. **Pinned action versions** - Updated actions to use full commit SHAs instead of tags:
   - `actions/checkout@v4` → `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
   - `anthropics/claude-code-action@beta` → `anthropics/claude-code-action@9dd49689e4f1e4dc231c5694c3753c1e1157b4d7` (beta)
3. **Disabled credential persistence** - Added `persist-credentials: false` to checkout step (policy: checkout_persist_credentials_should_be_false)

These changes improve workflow security by:
- Preventing runaway jobs with explicit timeouts
- Ensuring reproducible builds with pinned SHA references
- Reducing attack surface by not persisting Git credentials

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability by setting a timeout and pinning actions to specific versions in the Renovate review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->