### PR TITLE
fix: remove relationships references from agent prompts

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -114,7 +114,7 @@ Example with Foreign Key Constraint:
             "targetTableName": "users",
             "targetColumnName": "id",
             "updateConstraint": "NO_ACTION",
-            "deleteConstraint": "SET_NULL"
+            "deleteConstraint": "CASCADE"
           }}
         }}
       }}

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -54,19 +54,17 @@ Schema Structure Reference:
 - Columns: /tables/TABLE_NAME/columns/COLUMN_NAME
 - Column properties: type, notNull, primary, unique, default, comment, check
 - Table properties: name, columns, comment, indexes, constraints (ALL REQUIRED)
-- Relationships: /relationships/RELATIONSHIP_NAME (at schema root level, NOT inside tables)
 
 IMPORTANT Table Structure Rules:
 - Every table MUST include: name, columns, comment, indexes, constraints
 - Use empty objects {{}} for indexes and constraints if none are needed
 - Use null for comment if no comment is provided
-- Relationships belong at schema root level (/relationships/), not inside tables
 
 CRITICAL Validation Rules:
-- Foreign key constraint actions MUST use these EXACT values: "CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "NO_ACTION"
-- Cardinality MUST be one of: "ONE_TO_ONE", "ONE_TO_MANY"
 - Column properties MUST be: name (string), type (string), notNull (boolean), primary (boolean), unique (boolean), default (string|number|boolean|null), comment (string|null), check (string|null)
 - All boolean values must be true/false, not strings
+- Constraint types: "PRIMARY KEY", "FOREIGN KEY", "UNIQUE", "CHECK"
+- Foreign key constraint actions MUST use these EXACT values: "CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "NO_ACTION"
 - Use "SET_NULL" not "SET NULL" (underscore, not space)
 - Use "NO_ACTION" not "NO ACTION" (underscore, not space)
 
@@ -92,7 +90,7 @@ Example Response:
   ]
 }}
 
-Example with Relationships:
+Example with Foreign Key Constraint:
 {{
   "message": "Added! Created the 'posts' table and linked it to users. Now you can track user posts!",
   "schemaChanges": [
@@ -108,21 +106,17 @@ Example with Relationships:
         }},
         "comment": null,
         "indexes": {{}},
-        "constraints": {{}}
-      }}
-    }},
-    {{
-      "op": "add",
-      "path": "/relationships/posts_user_fk",
-      "value": {{
-        "name": "posts_user_fk",
-        "primaryTableName": "users",
-        "primaryColumnName": "id",
-        "foreignTableName": "posts",
-        "foreignColumnName": "user_id",
-        "cardinality": "ONE_TO_MANY",
-        "updateConstraint": "NO_ACTION",
-        "deleteConstraint": "SET_NULL"
+        "constraints": {{
+          "posts_user_fk": {{
+            "type": "FOREIGN KEY",
+            "name": "posts_user_fk",
+            "columnName": "user_id",
+            "targetTableName": "users",
+            "targetColumnName": "id",
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "SET_NULL"
+          }}
+        }}
       }}
     }}
   ]


### PR DESCRIPTION
## Issue

- resolve: Follow-up to #2193

## Why is this change needed?
After removing `schema.relationships` in PR #2193, the agent prompts still contained references to relationships, causing the agent to attempt creating relationships and resulting in errors.

## What would you like reviewers to focus on?
- Verify that all references to relationships have been removed from the prompts
- Confirm that the foreign key constraint example is correctly formatted

## Testing Verification
- All tests pass (`pnpm test:turbo`)
- Type checks pass (`pnpm lint`)
- Code is properly formatted (`pnpm fmt`)

## What was done
- Removed all references to relationships from the database schema build agent prompts
- Removed cardinality validation rules (ONE_TO_ONE, ONE_TO_MANY)
- Updated the example to show foreign key constraints within the table's constraints object instead of as separate relationships
- Kept the foreign key constraint action values (CASCADE, RESTRICT, etc.) as they are still used within constraints

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated schema prompt instructions to clarify that foreign key constraints should be defined within the `constraints` object of each table, rather than at the schema root level.
  * Revised example to demonstrate embedding foreign key constraints directly in the table definition, with detailed fields and updated structure.
  * Enumerated supported constraint types and removed references to separate relationship objects and cardinality fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->