### PR TITLE
fix: resolve hydration error in UserMessage timestamp formatting

### DIFF
--- a/frontend/apps/app/components/Chat/UserMessage/UserMessage.tsx
+++ b/frontend/apps/app/components/Chat/UserMessage/UserMessage.tsx
@@ -22,11 +22,12 @@ export const UserMessage: FC<UserMessageProps> = ({
   timestamp,
   userName,
 }) => {
-  // Format timestamp if it exists
+  // Format timestamp if it exists - use explicit locale for consistency
   const formattedTime = timestamp
-    ? timestamp.toLocaleTimeString([], {
+    ? timestamp.toLocaleTimeString('en-US', {
         hour: '2-digit',
         minute: '2-digit',
+        hour12: false,
       })
     : null
 


### PR DESCRIPTION
## Issue

- resolve: #2200

## Why is this change needed?

The UserMessage component was causing a hydration mismatch error due to inconsistent timestamp formatting between server and client rendering. The `toLocaleTimeString()` method without an explicit locale can produce different formats (e.g., "12:47" vs "12:47 PM") depending on the system's locale settings.

## What would you like reviewers to focus on?

- The timestamp formatting fix ensures consistent rendering by using an explicit locale ('en-US') and 24-hour format
- This prevents hydration errors while maintaining the desired time display format

## Testing Verification

- Lint checks passed successfully
- The hydration error should no longer occur when viewing design sessions with timestamps

## What was done

- Modified the timestamp formatting in UserMessage component to use explicit locale and 24-hour format
- Changed from `toLocaleTimeString([], {...})` to `toLocaleTimeString('en-US', {...})` with `hour12: false`

## Detailed Changes

- `frontend/apps/app/components/Chat/UserMessage/UserMessage.tsx`: Updated timestamp formatting to prevent hydration mismatches

## Additional Notes

The test failures in CI are unrelated to this change and are due to missing environment variables in the test environment.

🤖 Generated with [Claude Code](https://claude.ai/code)