### PR TITLE
🧪 feat: add daily lint check workflow with automated issue creation

### DIFF
--- a/.github/workflows/lint-and-notify.yml
+++ b/.github/workflows/lint-and-notify.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint-and-notify.yml
+++ b/.github/workflows/lint-and-notify.yml
@@ -43,8 +43,13 @@ jobs:
       - name: Post to Issue (if warning exists)
         if: steps.lint_check.outputs.has_warning == 'true'
         run: |
+          WARNING_COUNT=$(grep -i 'warning\|warn' warnings.txt | wc -l)
+          
+          # Read template and replace WARNING_COUNT placeholder
+          ISSUE_BODY=$(sed "s/WARNING_COUNT/$WARNING_COUNT/g" .github/workflows/templates/lint-and-notify.md)
+          
           gh issue create \
             --title "Daily Lint Warning Report - $(date '+%Y-%m-%d')" \
-            --body "$(cat warnings.txt | head -n 30)\n\n@Claude Please review the following lint warnings and suggest code changes to fix them. If there are any unused variables or imports, feel free to propose their removal." \
+            --body "$ISSUE_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-and-notify.yml
+++ b/.github/workflows/lint-and-notify.yml
@@ -37,16 +37,18 @@ jobs:
       - name: Check for Warnings
         id: lint_check
         run: |
-          grep -i 'warning\|warn' lint-result.txt > warnings.txt || true
-          echo "has_warning=$(test -s warnings.txt && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Check for any warnings from various linters
+          if grep -qiE '(warning|warn|Found [0-9]+ warnings?|\[[0-9]+:[0-9]+\].*warning|error TS[0-9]+)' lint-result.txt; then
+            echo "has_warning=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_warning=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Post to Issue (if warning exists)
         if: steps.lint_check.outputs.has_warning == 'true'
         run: |
-          WARNING_COUNT=$(grep -i 'warning\|warn' warnings.txt | wc -l)
-          
-          # Read template and replace WARNING_COUNT placeholder
-          ISSUE_BODY=$(sed "s/WARNING_COUNT/$WARNING_COUNT/g" .github/workflows/templates/lint-and-notify.md)
+          # Read template (no placeholders to replace for "some warnings")
+          ISSUE_BODY=$(cat .github/workflows/templates/lint-and-notify.md)
           
           gh issue create \
             --title "Daily Lint Warning Report - $(date '+%Y-%m-%d')" \

--- a/.github/workflows/lint-and-notify.yml
+++ b/.github/workflows/lint-and-notify.yml
@@ -1,0 +1,50 @@
+name: Daily Lint Check
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # JST09:00 (UTC00:00)
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Linter with Full Output
+        run: pnpm turbo lint --output-logs=full > lint-result.txt 2>&1
+
+      - name: Check for Warnings
+        id: lint_check
+        run: |
+          grep -i 'warning\|warn' lint-result.txt > warnings.txt || true
+          echo "has_warning=$(test -s warnings.txt && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Post to Issue (if warning exists)
+        if: steps.lint_check.outputs.has_warning == 'true'
+        run: |
+          gh issue create \
+            --title "Daily Lint Warning Report - $(date '+%Y-%m-%d')" \
+            --body "$(cat warnings.txt | head -n 30)\n\n@Claude Please review the following lint warnings and suggest code changes to fix them. If there are any unused variables or imports, feel free to propose their removal." \
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-and-notify.yml
+++ b/.github/workflows/lint-and-notify.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/templates/lint-and-notify.md
+++ b/.github/workflows/templates/lint-and-notify.md
@@ -1,0 +1,11 @@
+### 🚨 WARNING_COUNT Lint Warnings Detected
+
+This workflow detected WARNING_COUNT warnings from `pnpm turbo lint --output-logs=full`.
+
+Please run the following command in this branch to view and fix the warnings:
+
+```bash
+pnpm turbo lint --output-logs=full
+```
+
+Feel free to remove unused imports, variables, or any redundant code.

--- a/.github/workflows/templates/lint-and-notify.md
+++ b/.github/workflows/templates/lint-and-notify.md
@@ -1,6 +1,6 @@
-### 🚨 WARNING_COUNT Lint Warnings Detected
+### 🚨 Lint Warnings Detected
 
-This workflow detected WARNING_COUNT warnings from `pnpm turbo lint --output-logs=full`.
+This workflow detected some warnings from `pnpm turbo lint --output-logs=full`.
 
 Please run the following command in this branch to view and fix the warnings:
 


### PR DESCRIPTION

## Issue
- resolve: Automate lint warning detection and reporting

## Why is this change needed?
This change introduces an automated daily lint check workflow to proactively identify and report lint warnings in the codebase. The workflow creates GitHub issues with lint warnings and requests Claude to suggest fixes, particularly for unused variables and imports.

## What would you like reviewers to focus on?
- The workflow configuration and security settings (permissions, timeout)
- The lint warning detection logic and issue creation format
- Whether the scheduled time (JST 09:00) is appropriate for the team

## Testing Verification
- Workflow can be manually triggered via `workflow_dispatch`
- Tested the lint command format: `pnpm turbo lint --output-logs=full`
- Verified that warnings are properly captured and filtered

## Additional Notes
**🚧 Important limitation**: It's uncertain whether Claude can respond to comments from `github-actions[bot]`. The workflow creates issues with `@Claude` mentions, but we may need to adjust the approach if Claude doesn't respond to bot-generated content.

The workflow includes:
- Daily execution at 09:00 JST
- Full lint output capture with `--output-logs=full`
- Warning detection and filtering
- Automated issue creation with detailed context
- Security best practices (minimal permissions, timeout, no credential persistence)

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
