### PR TITLE
feat: support Rails inline index syntax in schema.rb parser

### DIFF
--- a/.changeset/rails-inline-index-support.md
+++ b/.changeset/rails-inline-index-support.md
@@ -1,0 +1,10 @@
+---
+"@liam-hq/db-structure": minor
+---
+
+✨ Add support for Rails inline index syntax in schema.rb parser
+
+- Support inline index declarations on columns: `t.string "name", index: true`
+- Handle unique inline indexes: `t.text "mention", index: { unique: true }`
+- Parse custom index names: `t.string "slug", index: { name: "custom_name" }`
+- Support index types: `t.string "email", index: { using: "gin" }`

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -183,11 +183,31 @@ function processCallNode(
   }
 
   // Process column nodes
-  const column = extractColumnDetails(node)
-  if (column.name) {
-    columns.push(column)
-    // TODO: Rails syntax like `t.text "mention", index: { unique: true }` should be supported
-    // to create unique indexes. Currently, only `t.index` method calls create indexes.
+  const result = extractColumnDetails(node)
+  if (result.column.name) {
+    columns.push(result.column)
+
+    // Handle inline index creation
+    if (result.index) {
+      const index = result.index
+      // Generate default index name if not provided
+      if (!index.name) {
+        const prefix = index.unique ? 'unique_' : 'index_'
+        index.name = `${prefix}${result.column.name}`
+      }
+
+      indexes.push(index)
+
+      // Add unique constraint if index is unique
+      if (index.unique && result.column.name) {
+        const uniqueConstraint: UniqueConstraint = {
+          type: 'UNIQUE',
+          name: `UNIQUE_${result.column.name}`,
+          columnName: result.column.name,
+        }
+        constraints.push(uniqueConstraint)
+      }
+    }
   }
 }
 
@@ -229,22 +249,31 @@ function extractTableDetails(
   return [columns, indexes, constraints, errors]
 }
 
-function extractColumnDetails(node: CallNode): Column {
+function extractColumnDetails(node: CallNode): {
+  column: Column
+  index: Index | null
+} {
   const column = aColumn({
     name: '',
     type: convertColumnType(node.name),
   })
+  let index: Index | null = null
 
   const argNodes = node.arguments_?.compactChildNodes() || []
   for (const argNode of argNodes) {
     if (argNode instanceof StringNode) {
       column.name = argNode.unescaped.value
     } else if (argNode instanceof KeywordHashNode) {
-      extractColumnOptions(argNode, column)
+      index = extractColumnOptions(argNode, column)
     }
   }
 
-  return column
+  // Set index column name if index was created
+  if (index && column.name) {
+    index.columns = [column.name]
+  }
+
+  return { column, index }
 }
 
 function extractIndexDetails(node: CallNode): Index {
@@ -272,7 +301,12 @@ function extractIndexDetails(node: CallNode): Index {
   return index
 }
 
-function extractColumnOptions(hashNode: KeywordHashNode, column: Column): void {
+function extractColumnOptions(
+  hashNode: KeywordHashNode,
+  column: Column,
+): Index | null {
+  let index: Index | null = null
+
   for (const argElement of hashNode.elements) {
     if (!(argElement instanceof AssocNode)) continue
     // @ts-expect-error: unescaped is defined as string but it is actually object
@@ -302,8 +336,70 @@ function extractColumnOptions(hashNode: KeywordHashNode, column: Column): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         column.comment = value.unescaped.value
         break
+      case 'index':
+        // Handle inline index syntax
+        index = extractInlineIndexOptions(value, column.name)
+        break
     }
   }
+
+  return index
+}
+
+/**
+ * Extract inline index options from column definition
+ */
+function extractInlineIndexOptions(
+  value: Node,
+  columnName: string,
+): Index | null {
+  const index = anIndex({
+    name: '',
+    unique: false,
+    columns: [columnName],
+    type: '',
+  })
+
+  if (value instanceof TrueNode) {
+    // Simple index: index: true
+    return index
+  }
+
+  if (value instanceof KeywordHashNode) {
+    // Hash options: index: { unique: true, name: "custom_name" }
+    for (const argElement of value.elements) {
+      if (!(argElement instanceof AssocNode)) continue
+      // @ts-expect-error: unescaped is defined as string but it is actually object
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const key = argElement.key.unescaped.value
+      const optionValue = argElement.value
+
+      switch (key) {
+        case 'unique':
+          index.unique = optionValue instanceof TrueNode
+          break
+        case 'name':
+          if (
+            optionValue instanceof StringNode ||
+            optionValue instanceof SymbolNode
+          ) {
+            index.name = optionValue.unescaped.value
+          }
+          break
+        case 'using':
+          if (
+            optionValue instanceof StringNode ||
+            optionValue instanceof SymbolNode
+          ) {
+            index.type = optionValue.unescaped.value
+          }
+          break
+      }
+    }
+    return index
+  }
+
+  return null
 }
 
 function extractIndexOptions(hashNode: KeywordHashNode, index: Index): void {

--- a/frontend/packages/db-structure/src/parser/schemarb/parser.ts
+++ b/frontend/packages/db-structure/src/parser/schemarb/parser.ts
@@ -3,6 +3,7 @@ import {
   AssocNode,
   CallNode,
   FalseNode,
+  HashNode,
   IntegerNode,
   KeywordHashNode,
   LocalVariableReadNode,
@@ -365,7 +366,7 @@ function extractInlineIndexOptions(
     return index
   }
 
-  if (value instanceof KeywordHashNode) {
+  if (value instanceof KeywordHashNode || value instanceof HashNode) {
     // Hash options: index: { unique: true, name: "custom_name" }
     for (const argElement of value.elements) {
       if (!(argElement instanceof AssocNode)) continue


### PR DESCRIPTION
Support Rails inline index syntax in schema.rb parser

Resolves #2233

## Summary
This PR adds support for Rails inline index syntax in column definitions, allowing indexes to be created directly within column definitions instead of requiring separate `t.index` calls.

## Changes
- Add support for inline index syntax: `t.string "name", index: true`
- Support unique indexes: `t.text "mention", index: { unique: true }`
- Support custom index names: `t.string "slug", index: { name: "custom_name" }`
- Support index types: `t.string "email", index: { using: "gin" }`
- Add comprehensive test coverage for all inline index scenarios
- Maintain full compatibility with existing `t.index` method syntax

## Technical Details
- Extended `extractColumnDetails()` to return both column and index information
- Added `extractInlineIndexOptions()` to parse different index formats
- Modified `processCallNode()` to handle inline index creation and unique constraints

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing Rails inline index syntax in schema files, including unique indexes, custom index names, and index types directly on column definitions.

* **Tests**
  * Expanded test coverage to verify correct parsing and handling of various inline index scenarios, ensuring robust support for these new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->