### PR TITLE
✨ feat(command palette): allow ESC button to close the dialog

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
@@ -71,16 +71,6 @@
   color: var(--overlay-60);
 }
 
-.escapeSign {
-  border: 1px solid #434536;
-  border-radius: var(--border-radius-smbase);
-  font-size: 10px;
-  width: 34px;
-  height: 21px;
-  text-align: center;
-  line-height: 21px;
-}
-
 .main {
   display: flex;
   padding: var(--spacing-2);

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx
@@ -105,6 +105,19 @@ describe('dialog opening interactions', () => {
   })
 })
 
+describe('dialog closing interaction', () => {
+  it('closes dialog by clicking ESC button', async () => {
+    const {
+      user,
+      elements: { dialog },
+    } = await prepareCommandPalette()
+
+    await user.click(within(dialog).getByRole('button', { name: 'ESC' }))
+
+    expect(dialog).not.toBeInTheDocument()
+  })
+})
+
 describe('options and combobox interactions', () => {
   it('renders options with table name', async () => {
     const {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
@@ -1,7 +1,11 @@
 'use client'
 
-import { Search, Table2 } from '@liam-hq/ui'
-import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
+import { Button, Search, Table2 } from '@liam-hq/ui'
+import {
+  DialogClose,
+  DialogDescription,
+  DialogTitle,
+} from '@radix-ui/react-dialog'
 import { Command } from 'cmdk'
 import { type FC, useCallback, useEffect, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
@@ -61,7 +65,11 @@ export const CommandPalette: FC = () => {
           <Search className={styles.searchIcon} />
           <Command.Input placeholder="Search" />
         </div>
-        <span className={styles.escapeSign}>ESC</span>
+        <DialogClose asChild>
+          <Button size="xs" variant="outline-secondary">
+            ESC
+          </Button>
+        </DialogClose>
       </div>
       <div className={styles.main}>
         <Command.List>


### PR DESCRIPTION
## Issue

~- resolve:~
related to https://github.com/liam-hq/liam/issues/507

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

Allow `ESC` button to close the dialog for mouse users.
The dialog was previously closable by clicking outside of it, and this change allows it to be closed by clicking a button as well.

https://github.com/user-attachments/assets/682d3ebe-03d6-4c4f-aae2-37ad4b552581

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- The `Button` component is used properly

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

- For the logic, I added test
- For the application:
  1. visit https://liam-n6yrnsi34-liambx.vercel.app/
  2. press ⌘K to open the dialog
  3. click "ESC" button right top, then the dialog closes

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at a7dc3f1fa5a9a56b0d9d4e1f3dc04d2bf6b16ca7

- Replace static ESC text with clickable button
- Add dialog close functionality via ESC button
- Remove unused CSS styles for escape sign
- Add test coverage for ESC button interaction


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Add clickable ESC button with close functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx

<li>Import <code>Button</code> and <code>DialogClose</code> components from UI library<br> <li> Replace static ESC span with clickable <code>Button</code> wrapped in <code>DialogClose</code><br> <li> Add proper dialog close functionality for mouse users


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2278/files#diff-94c7028698d83655392638264848d9a70ea1e476877bee9806d9e5d7b61e1780">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.module.css</strong><dd><code>Remove unused ESC sign styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css

<li>Remove <code>.escapeSign</code> CSS class definition<br> <li> Clean up unused styling for static ESC text


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2278/files#diff-1b2c933681f2482ea26b144a844c87e82437516eb31e6b5c5c24c78286c49279">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.test.tsx</strong><dd><code>Add ESC button close functionality tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.test.tsx

<li>Add new test suite for dialog closing interactions<br> <li> Test ESC button click functionality to close dialog<br> <li> Verify dialog removal from DOM after button click


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2278/files#diff-f53994cdb096610f6aa2e5a3c90d29817dd97b7d67ec42a0c513abc0cf2f5ed0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "ESC" indicator in the command palette dialog is now an interactive button that closes the dialog when clicked.

* **Bug Fixes**
  * Improved accessibility and user interaction by making the "ESC" element actionable.

* **Tests**
  * Added a test to verify that clicking the "ESC" button closes the command palette dialog.

* **Style**
  * Removed unused styling related to the previous "ESC" indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->