### PR TITLE
feat(e2e): add Vercel feature flag override support for Playwright tests

### DIFF
--- a/.claude/commands/test-playwright.md
+++ b/.claude/commands/test-playwright.md
@@ -1,0 +1,47 @@
+---
+allowed-tools: mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_press_key, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_wait_for, Bash, Read
+description: Test application functionality using Playwright MCP based on PR number or test description
+---
+
+## Test Target
+You need to test: $ARGUMENTS
+
+## Instructions
+
+1. **Analyze the test target**
+   - If $ARGUMENTS is a number (e.g., "2237"), treat it as a PR number and run `gh pr view $ARGUMENTS` to understand what was fixed
+   - If $ARGUMENTS is descriptive text, use it as the test scenario description
+
+2. **Set up the test environment**
+   - Navigate to http://localhost:3001 using Playwright MCP
+   - If authentication is required, use these credentials:
+     - Email: test@example.com
+     - Password: liampassword1234
+   - Reference: @frontend/internal-packages/e2e/tests/e2e/login-and-design-session.test.ts
+
+3. **Execute the test**
+   - Based on the test target, perform the necessary actions
+   - Use `mcp__playwright__browser_snapshot` to understand page state before interactions
+   - Take screenshots at important moments for documentation
+
+4. **Verify results**
+   - Confirm the expected behavior is working
+   - Document any issues found
+   - Provide a clear summary of the test results
+
+## Example Test Flows
+
+### For PR verification
+- Check what the PR fixed
+- Reproduce the scenario that was previously broken
+- Verify the fix is working
+
+### For feature testing
+- Navigate to the relevant page
+- Perform user actions
+- Verify expected outcomes
+
+## Important Notes
+- Always wait for async operations to complete
+- Take screenshots to document the test process
+- Report both successes and failures clearly

--- a/.claude/commands/test-playwright.md
+++ b/.claude/commands/test-playwright.md
@@ -11,9 +11,11 @@ You need to test: $ARGUMENTS
 1. **Analyze the test target**
    - If $ARGUMENTS is a number (e.g., "2237"), treat it as a PR number and run `gh pr view $ARGUMENTS` to understand what was fixed
    - If $ARGUMENTS is descriptive text, use it as the test scenario description
+   - If $ARGUMENTS mentions analyzing git changes, read the diff file if provided
 
 2. **Set up the test environment**
-   - Navigate to http://localhost:3001 using Playwright MCP
+   - IMPORTANT: Always navigate to http://localhost:3001 (not Vercel or other deployments)
+   - Verify the application is running by checking the page loads successfully
    - If authentication is required, use these credentials:
      - Email: test@example.com
      - Password: liampassword1234
@@ -23,11 +25,13 @@ You need to test: $ARGUMENTS
    - Based on the test target, perform the necessary actions
    - Use `mcp__playwright__browser_snapshot` to understand page state before interactions
    - Take screenshots at important moments for documentation
+   - Focus on testing functionality, not just navigation
 
 4. **Verify results**
    - Confirm the expected behavior is working
    - Document any issues found
    - Provide a clear summary of the test results
+   - Include specific error messages if tests fail
 
 ## Example Test Flows
 

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -1,0 +1,64 @@
+name: Playwright Test Verification
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - master
+
+jobs:
+  playwright-verification:
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0  # Need full history for accurate diff analysis
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: ./.github/actions/pnpm-setup
+
+      - name: Start Supabase
+        run: pnpm --filter @liam-hq/db supabase:start
+
+      - name: Setup environment
+        run: |
+          cp .env.template .env
+          chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh
+          ./scripts/extract-supabase-anon-key.sh
+          ./scripts/extract-supabase-service-key.sh
+
+      - name: Start Trigger.dev
+        run: |
+          pnpm --filter @liam-hq/jobs trigger:dev &
+          sleep 10  # Wait for Trigger.dev to start
+
+      - name: Start application
+        run: |
+          pnpm dev --filter @liam-hq/app &
+          sleep 30  # Wait for application to start
+          curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:3001 || exit 1
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+          echo "Changed files:"
+          git diff --name-only HEAD~1 HEAD || git diff --name-only $(git rev-list --max-parents=0 HEAD) HEAD
+          
+          # Store the diff for Claude to analyze
+          git diff HEAD~1 HEAD > /tmp/git-diff.txt || git diff $(git rev-list --max-parents=0 HEAD) HEAD > /tmp/git-diff.txt
+
+      - name: Run Playwright test verification
+        uses: anthropics/claude-code-action@91c510a769db0f9b79df0efbdded0c29c033f846 # beta
+        with:
+          direct_prompt: |
+            /test-playwright analyze git changes and test affected features based on the diff in /tmp/git-diff.txt
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "mcp__playwright__browser_navigate,mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_type,mcp__playwright__browser_press_key,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_console_messages,mcp__playwright__browser_network_requests,Bash,Read,Grep,Glob"

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/pnpm-setup
 
-      - name: Install Playwright system dependencies
-        run: pnpm --filter @liam-hq/e2e exec playwright install-deps
-
       - name: Start Supabase
         run: pnpm --filter @liam-hq/db supabase:start
 

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -11,9 +11,6 @@ jobs:
       pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.48.2-noble
-      options: --user 1001
     timeout-minutes: 30
 
     steps:
@@ -25,6 +22,23 @@ jobs:
 
       - name: Setup pnpm
         uses: ./.github/actions/pnpm-setup
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', '**/playwright.config.ts') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @liam-hq/e2e exec playwright install --with-deps
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @liam-hq/e2e exec playwright install-deps
 
       - name: Start Supabase
         run: pnpm --filter @liam-hq/db supabase:start

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -22,29 +22,29 @@ jobs:
           fetch-depth: 0  # Need full history for accurate diff analysis
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: ./.github/actions/pnpm-setup
+      # - name: Setup pnpm
+      #   uses: ./.github/actions/pnpm-setup
 
-      - name: Start Supabase
-        run: pnpm --filter @liam-hq/db supabase:start
+      # - name: Start Supabase
+      #   run: pnpm --filter @liam-hq/db supabase:start
 
-      - name: Setup environment
-        run: |
-          cp .env.template .env
-          chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh
-          ./scripts/extract-supabase-anon-key.sh
-          ./scripts/extract-supabase-service-key.sh
+      # - name: Setup environment
+      #   run: |
+      #     cp .env.template .env
+      #     chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh
+      #     ./scripts/extract-supabase-anon-key.sh
+      #     ./scripts/extract-supabase-service-key.sh
 
-      - name: Start Trigger.dev
-        run: |
-          pnpm --filter @liam-hq/jobs trigger:dev &
-          sleep 10  # Wait for Trigger.dev to start
+      # - name: Start Trigger.dev
+      #   run: |
+      #     pnpm --filter @liam-hq/jobs trigger:dev &
+      #     sleep 10  # Wait for Trigger.dev to start
 
-      - name: Start application
-        run: |
-          pnpm dev --filter @liam-hq/app &
-          sleep 30  # Wait for application to start
-          curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:3001 || exit 1
+      # - name: Start application
+      #   run: |
+      #     pnpm dev --filter @liam-hq/app &
+      #     sleep 30  # Wait for application to start
+      #     curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:3001 || exit 1
 
       - name: Get changed files
         id: changed-files
@@ -61,4 +61,5 @@ jobs:
           direct_prompt: |
             /test-playwright analyze git changes and test affected features based on the diff in /tmp/git-diff.txt
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "mcp__playwright__browser_navigate,mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_type,mcp__playwright__browser_press_key,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_console_messages,mcp__playwright__browser_network_requests,Bash,Read,Grep,Glob"

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -11,6 +11,9 @@ jobs:
       pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.48.2-noble
+      options: --user 1001
     timeout-minutes: 30
 
     steps:
@@ -20,29 +23,48 @@ jobs:
           fetch-depth: 0  # Need full history for accurate diff analysis
           persist-credentials: false
 
-      # - name: Setup pnpm
-      #   uses: ./.github/actions/pnpm-setup
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
-      # - name: Start Supabase
-      #   run: pnpm --filter @liam-hq/db supabase:start
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
 
-      # - name: Setup environment
-      #   run: |
-      #     cp .env.template .env
-      #     chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh
-      #     ./scripts/extract-supabase-anon-key.sh
-      #     ./scripts/extract-supabase-service-key.sh
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      # - name: Start Trigger.dev
-      #   run: |
-      #     pnpm --filter @liam-hq/jobs trigger:dev &
-      #     sleep 10  # Wait for Trigger.dev to start
+      - name: Install Playwright dependencies
+        run: pnpm --filter @liam-hq/e2e exec playwright install-deps
 
-      # - name: Start application
-      #   run: |
-      #     pnpm dev --filter @liam-hq/app &
-      #     sleep 30  # Wait for application to start
-      #     curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:3001 || exit 1
+      - name: Start Supabase
+        run: pnpm --filter @liam-hq/db supabase:start
+
+      - name: Setup environment
+        run: |
+          cp .env.template .env
+          chmod +x ./scripts/extract-supabase-anon-key.sh ./scripts/extract-supabase-service-key.sh
+          ./scripts/extract-supabase-anon-key.sh
+          ./scripts/extract-supabase-service-key.sh
+          # Set FLAGS_SECRET from GitHub Secrets if available
+          if [ -n "${{ secrets.FLAGS_SECRET }}" ]; then
+            echo "FLAGS_SECRET=${{ secrets.FLAGS_SECRET }}" >> .env
+          fi
+
+      - name: Start Trigger.dev
+        run: |
+          pnpm --filter @liam-hq/jobs trigger:dev &
+          sleep 10  # Wait for Trigger.dev to start
+
+      - name: Start application
+        run: |
+          pnpm dev --filter @liam-hq/app &
+          # Wait for application to be ready
+          timeout 60 bash -c 'until curl -s http://localhost:3001 > /dev/null 2>&1; do echo "Waiting for app..."; sleep 2; done'
+          echo "Application is ready!"
 
       - name: Get changed files
         id: changed-files
@@ -55,9 +77,20 @@ jobs:
 
       - name: Run Playwright test verification
         uses: anthropics/claude-code-action@91c510a769db0f9b79df0efbdded0c29c033f846 # beta
+        env:
+          FLAGS_SECRET: ${{ secrets.FLAGS_SECRET }}
         with:
           direct_prompt: |
             /test-playwright analyze git changes and test affected features based on the diff in /tmp/git-diff.txt
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "mcp__playwright__browser_navigate,mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_type,mcp__playwright__browser_press_key,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_wait_for,mcp__playwright__browser_close,mcp__playwright__browser_console_messages,mcp__playwright__browser_network_requests,Bash,Read,Grep,Glob"
+          mcp_config: |
+            {
+              "mcpServers": {
+                "playwright": {
+                  "command": "npx",
+                  "args": ["@playwright/mcp@latest", "--headless"]
+                }
+              }
+            }

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -1,10 +1,8 @@
 name: Playwright Test Verification
 
 on:
-  push:
-    branches-ignore:
-      - main
-      - master
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   playwright-verification:

--- a/.github/workflows/playwright-test-verification.yml
+++ b/.github/workflows/playwright-test-verification.yml
@@ -23,21 +23,10 @@ jobs:
           fetch-depth: 0  # Need full history for accurate diff analysis
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
+      - name: Setup pnpm
+        uses: ./.github/actions/pnpm-setup
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-          run_install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright dependencies
+      - name: Install Playwright system dependencies
         run: pnpm --filter @liam-hq/e2e exec playwright install-deps
 
       - name: Start Supabase

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "/Users/mh4gf/.asdf/shims/npx",
+      "args": ["-y", "@playwright/mcp@latest", "--config", "/Users/mh4gf/ghq/github.com/liam-hq/liam-worktree/poc-monkey-agent/frontend/internal-packages/e2e/playwright-mcp.config.json"]
+    }
+  }
+}

--- a/frontend/internal-packages/e2e/.env.template
+++ b/frontend/internal-packages/e2e/.env.template
@@ -1,0 +1,1 @@
+FLAGS_SECRET="test-flags-secret"

--- a/frontend/internal-packages/e2e/.gitignore
+++ b/frontend/internal-packages/e2e/.gitignore
@@ -9,3 +9,4 @@
 !/tests/vrt/vrt.test.ts-snapshots/top-1-Mobile-Safari-linux.png
 
 storageState.json
+.env

--- a/frontend/internal-packages/e2e/package.json
+++ b/frontend/internal-packages/e2e/package.json
@@ -2,11 +2,15 @@
   "name": "@liam-hq/e2e",
   "private": true,
   "version": "0.0.0",
+  "dependencies": {
+    "flags": "4.0.1"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
     "@liam-hq/configs": "workspace:*",
     "@playwright/test": "1.52.0",
     "@types/node": "22.15.30",
+    "dotenv": "16.5.0",
     "eslint": "9.28.0",
     "typescript": "5.8.3"
   },
@@ -17,6 +21,8 @@
     "lint": "concurrently \"pnpm:lint:*\"",
     "lint:biome": "biome check .",
     "lint:eslint": "eslint .",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:app": "playwright test --config=playwright.app.config.ts",
+    "test:e2e:vercel": "playwright test --config=playwright.vercel.config.ts"
   }
 }

--- a/frontend/internal-packages/e2e/playwright-mcp.config.json
+++ b/frontend/internal-packages/e2e/playwright-mcp.config.json
@@ -1,0 +1,6 @@
+{
+  "baseURL": "https://liam-erd-web.vercel.app",
+  "browser": "chromium",
+  "headless": false,
+  "viewport-size": "1280,720"
+}

--- a/frontend/internal-packages/e2e/playwright.app.config.ts
+++ b/frontend/internal-packages/e2e/playwright.app.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 5 : 0,
+  workers: process.env.CI ? 1 : '50%',
+  timeout: 30 * 1000, // 30 seconds for app tests
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3001',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        isMobile: false,
+        permissions: ['clipboard-read', 'clipboard-write'],
+      },
+    },
+  ],
+})

--- a/frontend/internal-packages/e2e/playwright.vercel.config.ts
+++ b/frontend/internal-packages/e2e/playwright.vercel.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+
+// Load environment variables from .env file
+dotenv.config()
+
+export default defineConfig({
+  testDir: 'tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 5 : 2,
+  workers: process.env.CI ? 1 : '50%',
+  timeout: 30 * 1000, // 30 seconds for app tests
+  reporter: 'list',
+  use: {
+    baseURL: 'https://liam-erd-web.vercel.app',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        isMobile: false,
+        permissions: ['clipboard-read', 'clipboard-write'],
+      },
+    },
+  ],
+})

--- a/frontend/internal-packages/e2e/tests/e2e/login-and-design-session.test.ts
+++ b/frontend/internal-packages/e2e/tests/e2e/login-and-design-session.test.ts
@@ -1,0 +1,80 @@
+import { test as base, expect } from '@playwright/test'
+import { setFlagOverrides } from '../../utils/flags'
+
+// Create a custom test that doesn't use global setup
+const test = base.extend({
+  // Override the default storage state
+  storageState: async ({}, use) => {
+    await use({ cookies: [], origins: [] })
+  },
+})
+
+test.describe('Login and Design Session', () => {
+  // Enable the migration flag for all tests in this describe block
+  setFlagOverrides(test, {
+    migration: true,
+  })
+
+  test('should login with email/password and create a design session', async ({
+    page,
+  }) => {
+    // Navigate to login page
+    await page.goto('/app/login')
+
+    // Verify we're on the login page
+    await expect(page).toHaveTitle(/Liam ERD/)
+    await expect(
+      page.getByRole('heading', { name: 'Sign in to Liam Migration' }),
+    ).toBeVisible()
+
+    // Fill in login credentials
+    await page.getByRole('textbox', { name: 'Email' }).fill('test@example.com')
+    await page
+      .getByRole('textbox', { name: 'Password' })
+      .fill('liampassword1234')
+
+    // Click sign in button
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
+
+    // Wait for navigation to design sessions page
+    await page.waitForURL('**/app/design_sessions/new')
+
+    // Verify we're on the design sessions page
+    await expect(
+      page.getByRole('heading', {
+        name: 'What can I help you Database Design?',
+      }),
+    ).toBeVisible()
+
+    // Create a new design session with a message
+    const testMessage = 'E2E test: Verify design session creation'
+    await page
+      .getByRole('textbox', { name: 'Initial message for database design' })
+      .fill(testMessage)
+
+    // Send the message
+    await page.getByRole('button').filter({ hasText: 'Stop' }).click()
+
+    // Wait for navigation to the design session page
+    await page.waitForURL(/\/app\/design_sessions\/[a-f0-9-]+$/)
+
+    // Extract the session ID from the URL
+    const url = page.url()
+    const sessionIdMatch = url.match(/\/app\/design_sessions\/([a-f0-9-]+)$/)
+    expect(sessionIdMatch).toBeTruthy()
+    const sessionId = sessionIdMatch?.[1]
+
+    // Verify we're on the design session page with the correct ID
+    expect(url).toContain(`/app/design_sessions/${sessionId}`)
+
+    // Verify the chat interface is visible
+    await expect(
+      page.getByRole('combobox', { name: 'Build or ask anything, @ to' }),
+    ).toBeVisible()
+
+    // Wait for AI processing to start
+    await expect(page.getByText('Processing AI Message')).toBeVisible({
+      timeout: 10000,
+    })
+  })
+})

--- a/frontend/internal-packages/e2e/tsconfig.json
+++ b/frontend/internal-packages/e2e/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "@liam-hq/configs/tsconfig/base.json",
-  "include": ["tests/**/*", "playwright.config.ts", "global-setup.ts"]
+  "include": [
+    "tests/**/*",
+    "utils/**/*",
+    "playwright.config.ts",
+    "playwright.*.config.ts",
+    "global-setup.ts",
+    "default_test_url.ts"
+  ]
 }

--- a/frontend/internal-packages/e2e/utils/flags.ts
+++ b/frontend/internal-packages/e2e/utils/flags.ts
@@ -1,0 +1,32 @@
+import type { BrowserContext, TestInfo, TestType } from '@playwright/test'
+import { encryptOverrides } from 'flags'
+
+/**
+ * Sets Vercel feature flag overrides for Playwright tests
+ * @param test - Playwright test object
+ * @param overrides - Object containing flag names and their values
+ */
+export function setFlagOverrides<TestArgs extends object>(
+  test: TestType<TestArgs, object>,
+  overrides: Record<string, boolean>,
+) {
+  test.beforeEach(async ({ context }) => {
+    // Encrypt the flag overrides using Vercel's encryptOverrides function
+    const encryptedOverrides = await encryptOverrides(overrides)
+
+    // Get the base URL from the context
+    const baseUrl = test.info().project.use?.baseURL || 'http://localhost:5173'
+    const url = new URL(baseUrl)
+
+    // Set the encrypted overrides as a cookie
+    await context.addCookies([
+      {
+        name: 'vercel-flag-overrides',
+        value: encryptedOverrides,
+        domain: url.hostname,
+        path: '/',
+      },
+    ])
+  })
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,16 +105,16 @@ importers:
         version: 15.3.3(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@sentry/nextjs':
         specifier: '9'
-        version: 9.30.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9(esbuild@0.25.5))
+        version: 9.30.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9)
       '@trigger.dev/sdk':
         specifier: 4.0.0-v4-beta.21
-        version: 4.0.0-v4-beta.21(ai@4.3.16(react@19.1.0)(zod@3.23.8))(zod@3.23.8)
+        version: 4.0.0-v4-beta.21(ai@4.3.16(react@19.1.0)(zod@3.25.67))(zod@3.25.67)
       '@types/react-syntax-highlighter':
         specifier: 15.5.13
         version: 15.5.13
       '@vercel/otel':
         specifier: 1.12.0
-        version: 1.12.0(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+        version: 1.12.0(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       cheerio:
         specifier: 1.0.0
         version: 1.0.0
@@ -135,7 +135,7 @@ importers:
         version: 4.0.1(@opentelemetry/api@1.9.0)(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       langfuse-vercel:
         specifier: 3.37.4
-        version: 3.37.4(ai@4.3.16(react@19.1.0)(zod@3.23.8))
+        version: 3.37.4(ai@4.3.16(react@19.1.0)(zod@3.25.67))
       lucide-react:
         specifier: 0.511.0
         version: 0.511.0(react@19.1.0)
@@ -326,7 +326,7 @@ importers:
         version: 3.1.1
       langfuse-langchain:
         specifier: 3.37.4
-        version: 3.37.4(langchain@0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0(debug@4.4.1))(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2))
+        version: 3.37.4(langchain@0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2))
       valibot:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.8.3)
@@ -400,6 +400,10 @@ importers:
         version: 5.8.3
 
   frontend/internal-packages/e2e:
+    dependencies:
+      flags:
+        specifier: 4.0.1
+        version: 4.0.1(@opentelemetry/api@1.9.0)(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.0.0
@@ -413,6 +417,9 @@ importers:
       '@types/node':
         specifier: 22.15.30
         version: 22.15.30
+      dotenv:
+        specifier: 16.5.0
+        version: 16.5.0
       eslint:
         specifier: 9.28.0
         version: 9.28.0(jiti@2.4.2)
@@ -610,7 +617,7 @@ importers:
         version: 8.6.14(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))
       '@storybook/nextjs':
         specifier: 8.6.14
-        version: 8.6.14(next@15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9)
+        version: 8.6.14(esbuild@0.25.5)(next@15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))
       '@storybook/react':
         specifier: 8.6.14
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
@@ -11321,6 +11328,14 @@ snapshots:
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.23.8
+    optional: true
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.67
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -11335,6 +11350,17 @@ snapshots:
       throttleit: 2.1.0
     optionalDependencies:
       zod: 3.23.8
+    optional: true
+
+  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
+      react: 19.1.0
+      swr: 2.3.3(react@19.1.0)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.67
 
   '@ai-sdk/ui-utils@1.2.11(zod@3.23.8)':
     dependencies:
@@ -11342,6 +11368,14 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.23.8)
       zod: 3.23.8
       zod-to-json-schema: 3.24.5(zod@3.23.8)
+    optional: true
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -13063,7 +13097,7 @@ snapshots:
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.4.0
       js-yaml: 4.1.0
-      langchain: 0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0(debug@4.4.1))(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2)
+      langchain: 0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2)
       langsmith: 0.3.33(openai@4.104.0(ws@8.18.2)(zod@3.24.4))
       openai: 4.104.0(ws@8.18.2)(zod@3.24.4)
       uuid: 10.0.0
@@ -13280,7 +13314,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       express: 5.1.0(supports-color@10.0.0)
-      express-rate-limit: 7.5.1(express@5.1.0)
+      express-rate-limit: 7.5.1(express@5.1.0(supports-color@10.0.0))
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.24.4
@@ -13956,7 +13990,7 @@ snapshots:
     dependencies:
       playwright: 1.52.0
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.99.9)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.16(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.43.0
@@ -13966,7 +14000,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.2
       source-map: 0.7.4
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.26.1
@@ -14893,33 +14927,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/nextjs@9.30.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9(esbuild@0.25.5))':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.34.0
-      '@rollup/plugin-commonjs': 28.0.1(rollup@4.35.0)
-      '@sentry-internal/browser-utils': 9.30.0
-      '@sentry/core': 9.30.0
-      '@sentry/node': 9.30.0
-      '@sentry/opentelemetry': 9.30.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)
-      '@sentry/react': 9.30.0(react@19.1.0)
-      '@sentry/vercel-edge': 9.30.0
-      '@sentry/webpack-plugin': 3.5.0(webpack@5.99.9(esbuild@0.25.5))
-      chalk: 3.0.0
-      next: 15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      resolve: 1.22.8
-      rollup: 4.35.0
-      stacktrace-parser: 0.1.11
-    transitivePeerDependencies:
-      - '@opentelemetry/context-async-hooks'
-      - '@opentelemetry/core'
-      - '@opentelemetry/instrumentation'
-      - '@opentelemetry/sdk-trace-base'
-      - encoding
-      - react
-      - supports-color
-      - webpack
-
   '@sentry/nextjs@9.30.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15056,16 +15063,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@sentry/core': 9.30.0
-
-  '@sentry/webpack-plugin@3.5.0(webpack@5.99.9(esbuild@0.25.5))':
-    dependencies:
-      '@sentry/bundler-plugin-core': 3.5.0
-      unplugin: 1.0.1
-      uuid: 9.0.1
-      webpack: 5.99.9(esbuild@0.25.5)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@sentry/webpack-plugin@3.5.0(webpack@5.99.9)':
     dependencies:
@@ -15236,7 +15233,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/builder-webpack5@8.6.14(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)':
+  '@storybook/builder-webpack5@8.6.14(esbuild@0.25.5)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)':
     dependencies:
       '@storybook/core-webpack': 8.6.14(storybook@8.6.14(prettier@3.6.0))
       '@types/semver': 7.7.0
@@ -15244,23 +15241,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.99.9)
+      css-loader: 6.11.0(webpack@5.99.9(esbuild@0.25.5))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.8.3)(webpack@5.99.9)
-      html-webpack-plugin: 5.6.3(webpack@5.99.9)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5))
+      html-webpack-plugin: 5.6.3(webpack@5.99.9(esbuild@0.25.5))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.7.2
       storybook: 8.6.14(prettier@3.6.0)
-      style-loader: 3.3.4(webpack@5.99.9)
-      terser-webpack-plugin: 5.3.14(webpack@5.99.9)
+      style-loader: 3.3.4(webpack@5.99.9(esbuild@0.25.5))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.5)(webpack@5.99.9(esbuild@0.25.5))
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.99.9
-      webpack-dev-middleware: 6.1.3(webpack@5.99.9)
+      webpack: 5.99.9(esbuild@0.25.5)
+      webpack-dev-middleware: 6.1.3(webpack@5.99.9(esbuild@0.25.5))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -15324,7 +15321,7 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@3.6.0)
 
-  '@storybook/nextjs@8.6.14(next@15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9)':
+  '@storybook/nextjs@8.6.14(esbuild@0.25.5)(next@15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.27.4)
@@ -15339,30 +15336,30 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.27.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.27.4)
       '@babel/runtime': 7.27.6
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.99.9)
-      '@storybook/builder-webpack5': 8.6.14(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
-      '@storybook/preset-react-webpack': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.16(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.99.9(esbuild@0.25.5))
+      '@storybook/builder-webpack5': 8.6.14(esbuild@0.25.5)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
+      '@storybook/preset-react-webpack': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(esbuild@0.25.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
       '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
       '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.6.0))
       '@types/semver': 7.7.0
-      babel-loader: 9.2.1(@babel/core@7.27.4)(webpack@5.99.9)
-      css-loader: 6.11.0(webpack@5.99.9)
+      babel-loader: 9.2.1(@babel/core@7.27.4)(webpack@5.99.9(esbuild@0.25.5))
+      css-loader: 6.11.0(webpack@5.99.9(esbuild@0.25.5))
       find-up: 5.0.0
       image-size: 1.2.1
       loader-utils: 3.3.1
       next: 15.3.3(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.99.9)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.99.9(esbuild@0.25.5))
       pnp-webpack-plugin: 1.7.0(typescript@5.8.3)
       postcss: 8.5.5
-      postcss-loader: 8.1.1(postcss@8.5.5)(typescript@5.8.3)(webpack@5.99.9)
+      postcss-loader: 8.1.1(postcss@8.5.5)(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 14.2.1(webpack@5.99.9)
+      sass-loader: 14.2.1(webpack@5.99.9(esbuild@0.25.5))
       semver: 7.7.2
       storybook: 8.6.14(prettier@3.6.0)
-      style-loader: 3.3.4(webpack@5.99.9)
+      style-loader: 3.3.4(webpack@5.99.9(esbuild@0.25.5))
       styled-jsx: 5.1.7(@babel/core@7.27.4)(react@19.1.0)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -15370,7 +15367,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.5
       typescript: 5.8.3
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -15389,11 +15386,11 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)':
+  '@storybook/preset-react-webpack@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(esbuild@0.25.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)':
     dependencies:
       '@storybook/core-webpack': 8.6.14(storybook@8.6.14(prettier@3.6.0))
       '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.0)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.0))(typescript@5.8.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.99.9)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5))
       '@types/semver': 7.7.0
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -15404,7 +15401,7 @@ snapshots:
       semver: 7.7.2
       storybook: 8.6.14(prettier@3.6.0)
       tsconfig-paths: 4.2.0
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -15419,7 +15416,7 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@3.6.0)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.99.9)':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       debug: 4.4.1(supports-color@10.0.0)
       endent: 2.1.0
@@ -15429,7 +15426,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
       tslib: 2.8.1
       typescript: 5.8.3
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -15718,6 +15715,29 @@ snapshots:
       zod: 3.23.8
     optionalDependencies:
       ai: 4.3.16(react@19.1.0)(zod@3.23.8)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@trigger.dev/sdk@4.0.0-v4-beta.21(ai@4.3.16(react@19.1.0)(zod@3.25.67))(zod@3.25.67)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.52.1
+      '@opentelemetry/semantic-conventions': 1.25.1
+      '@trigger.dev/core': 4.0.0-v4-beta.21(supports-color@10.0.0)
+      chalk: 5.4.1
+      cronstrue: 2.61.0
+      debug: 4.4.1(supports-color@10.0.0)
+      evt: 2.5.9
+      slug: 6.1.0
+      ulid: 2.4.0
+      uncrypto: 0.1.3
+      uuid: 9.0.1
+      ws: 8.18.2
+      zod: 3.25.67
+    optionalDependencies:
+      ai: 4.3.16(react@19.1.0)(zod@3.25.67)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16186,10 +16206,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/otel@1.12.0(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))':
+  '@vercel/otel@1.12.0(@opentelemetry/api@1.9.0)(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
@@ -16494,6 +16513,19 @@ snapshots:
       zod: 3.23.8
     optionalDependencies:
       react: 19.1.0
+    optional: true
+
+  ai@4.3.16(react@19.1.0)(zod@3.25.67):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
+      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.25.67)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.67
+    optionalDependencies:
+      react: 19.1.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -16642,12 +16674,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.99.9):
+  babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       '@babel/core': 7.27.4
       find-cache-dir: 4.0.0
       schema-utils: 4.3.2
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   babel-plugin-polyfill-corejs2@0.4.13(@babel/core@7.27.4):
     dependencies:
@@ -17302,7 +17334,7 @@ snapshots:
       randombytes: 2.1.0
       randomfill: 1.0.4
 
-  css-loader@6.11.0(webpack@5.99.9):
+  css-loader@6.11.0(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.5)
       postcss: 8.5.5
@@ -17313,7 +17345,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   css-select@4.3.0:
     dependencies:
@@ -17955,7 +17987,7 @@ snapshots:
 
   expr-eval@2.0.2: {}
 
-  express-rate-limit@7.5.1(express@5.1.0):
+  express-rate-limit@7.5.1(express@5.1.0(supports-color@10.0.0)):
     dependencies:
       express: 5.1.0(supports-color@10.0.0)
 
@@ -18165,7 +18197,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.99.9):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -18180,7 +18212,7 @@ snapshots:
       semver: 7.7.2
       tapable: 2.2.2
       typescript: 5.8.3
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   form-data-encoder@1.7.2: {}
 
@@ -18757,7 +18789,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.99.9):
+  html-webpack-plugin@5.6.3(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -18765,7 +18797,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.2
     optionalDependencies:
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -18861,7 +18893,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.10.0(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.10.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -19308,7 +19340,7 @@ snapshots:
       zod: 3.24.4
       zod-validation-error: 3.5.2(zod@3.24.4)
 
-  langchain@0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0(debug@4.4.1))(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2):
+  langchain@0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2):
     dependencies:
       '@langchain/core': 0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4))
       '@langchain/openai': 0.5.12(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(ws@8.18.2)
@@ -19335,15 +19367,15 @@ snapshots:
     dependencies:
       mustache: 4.2.0
 
-  langfuse-langchain@3.37.4(langchain@0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0(debug@4.4.1))(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2)):
+  langfuse-langchain@3.37.4(langchain@0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2)):
     dependencies:
-      langchain: 0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0(debug@4.4.1))(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2)
+      langchain: 0.3.29(@langchain/core@0.3.57(openai@4.104.0(ws@8.18.2)(zod@3.24.4)))(axios@1.10.0)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.104.0(ws@8.18.2)(zod@3.24.4))(ws@8.18.2)
       langfuse: 3.37.4
       langfuse-core: 3.37.4
 
-  langfuse-vercel@3.37.4(ai@4.3.16(react@19.1.0)(zod@3.23.8)):
+  langfuse-vercel@3.37.4(ai@4.3.16(react@19.1.0)(zod@3.25.67)):
     dependencies:
-      ai: 4.3.16(react@19.1.0)(zod@3.23.8)
+      ai: 4.3.16(react@19.1.0)(zod@3.25.67)
       langfuse: 3.37.4
       langfuse-core: 3.37.4
 
@@ -20254,7 +20286,7 @@ snapshots:
       mkdirp: 0.5.6
       resolve: 1.22.10
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.99.9):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -20281,7 +20313,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   node-releases@2.0.19: {}
 
@@ -20879,14 +20911,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.1.1(postcss@8.5.5)(typescript@5.8.3)(webpack@5.99.9):
+  postcss-loader@8.1.1(postcss@8.5.5)(typescript@5.8.3)(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
       postcss: 8.5.5
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     transitivePeerDependencies:
       - typescript
 
@@ -21498,7 +21530,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.10.0(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.10.0):
     dependencies:
       axios: 1.10.0(debug@4.4.1)
 
@@ -21621,11 +21653,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@14.2.1(webpack@5.99.9):
+  sass-loader@14.2.1(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   scheduler@0.26.0: {}
 
@@ -22077,9 +22109,9 @@ snapshots:
       prettier: 3.6.0
       tinycolor2: 1.6.0
 
-  style-loader@3.3.4(webpack@5.99.9):
+  style-loader@3.3.4(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   style-mod@4.1.2: {}
 
@@ -22937,7 +22969,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@6.1.3(webpack@5.99.9):
+  webpack-dev-middleware@6.1.3(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -22945,7 +22977,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.2
     optionalDependencies:
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -23165,10 +23197,15 @@ snapshots:
   zod-to-json-schema@3.24.5(zod@3.23.8):
     dependencies:
       zod: 3.23.8
+    optional: true
 
   zod-to-json-schema@3.24.5(zod@3.24.4):
     dependencies:
       zod: 3.24.4
+
+  zod-to-json-schema@3.24.5(zod@3.25.67):
+    dependencies:
+      zod: 3.25.67
 
   zod-validation-error@1.5.0(zod@3.23.8):
     dependencies:


### PR DESCRIPTION
## Summary
- Add helper function to set Vercel feature flag overrides via encrypted cookies in Playwright tests
- Create login and design session E2E test that works with migration flag enabled
- Add separate Playwright configs for app and Vercel deployments

## Test plan
- [x] Run E2E tests locally
- [x] Run E2E tests against Vercel deployment
- [x] Verify feature flag overrides work correctly
- [x] Ensure all lint and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)