### PR TITLE
💄 style(command palette): fix list item text styles

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
@@ -85,7 +85,6 @@
 }
 
 .main [cmdk-list] {
-  overflow-x: hidden;
   overflow-y: scroll;
   height: 100%;
   width: 300px;
@@ -102,6 +101,11 @@
   padding: var(--spacing-2);
   align-items: center;
   line-height: 24px;
+}
+
+.main [cmdk-item] .itemInner .itemText {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .main [cmdk-item] .itemInner .itemIcon {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
@@ -104,6 +104,7 @@
 }
 
 .main [cmdk-item] .itemInner .itemText {
+  font-size: var(--font-size-5);
   overflow-x: hidden;
   text-overflow: ellipsis;
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
@@ -107,6 +107,7 @@
   font-size: var(--font-size-5);
   overflow-x: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .main [cmdk-item] .itemInner .itemIcon {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
@@ -105,7 +105,7 @@ export const CommandPalette: FC = () => {
                   onDoubleClick={() => goToERD(table.name)}
                 >
                   <Table2 className={styles.itemIcon} />
-                  {table.name}
+                  <span className={styles.itemText}>{table.name}</span>
                 </div>
               </Command.Item>
             ))}


### PR DESCRIPTION
## Issue

~- resolve:~
related to https://github.com/liam-hq/liam/issues/507

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

To make the table list more clear to see, I committed some changes.

||before|after|
|-|-|-|
|fix font size|![Screenshot 0007-07-03 at 8 41 39](https://github.com/user-attachments/assets/e60341b3-7b19-41a9-b820-4458ce5da23f)|![Screenshot 0007-07-03 at 8 41 47](https://github.com/user-attachments/assets/6530a0f3-ec76-4fc9-802f-ef19144f6037)|
|set ellipsis if text is too long|![Screenshot 0007-07-03 at 8 37 51](https://github.com/user-attachments/assets/fa979eb1-ba78-4367-a2e0-b57a7827e723)|![Screenshot 0007-07-03 at 8 37 45](https://github.com/user-attachments/assets/ecc167a2-424c-4925-a6fd-17b1bf735f53)|


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- check the styles are suitable

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

1. visit https://liam-22xre5igu-liambx.vercel.app/
2. press ⌘K to open dialog
3. check the table list

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at c9d2f2d55fb3d2b0472688a51456bd1d6cf67d35

- Improve command palette table list text styling
- Add text ellipsis for long table names
- Fix font size consistency for better readability


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.module.css</strong><dd><code>Add text styling and ellipsis for list items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css

<li>Remove horizontal overflow hidden from list container<br> <li> Add new <code>.itemText</code> class with font size and ellipsis styling<br> <li> Set <code>font-size: var(--font-size-5)</code> for consistent text sizing<br> <li> Add <code>overflow-x: hidden</code> and <code>text-overflow: ellipsis</code> for long text <br>handling


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2309/files#diff-1b2c933681f2482ea26b144a844c87e82437516eb31e6b5c5c24c78286c49279">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Apply text styling class to table names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx

<li>Wrap table name text in <code><span></code> element with <code>itemText</code> class<br> <li> Apply new styling class to table name display


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2309/files#diff-94c7028698d83655392638264848d9a70ea1e476877bee9806d9e5d7b61e1780">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text styling and truncation for table names in the command palette to ensure long names are displayed more cleanly.
  * Adjusted scrolling behavior to allow only vertical scrolling within the command palette.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->