### PR TITLE
Address PR #2263 review feedback

### DIFF
--- a/frontend/internal-packages/schema-bench/src/cli/evaluate-schema.ts
+++ b/frontend/internal-packages/schema-bench/src/cli/evaluate-schema.ts
@@ -1,31 +1,10 @@
 import * as path from 'node:path'
-
+import { formatError } from '../shared/formatError.ts'
 import { evaluateSchema } from '../workspace/evaluation/evaluation.ts'
-import type { EvaluationConfig, WorkspaceError } from '../workspace/types'
+import type { EvaluationConfig } from '../workspace/types'
 
 // Right now, the script processes process.argv directly and lives in this package since it's still rough and only meant for internal (Liam team) use.
 // In the future, once things are more stable, we'd like to move this feature to the CLI package and rely on something like commander for argument parsing.
-
-const formatError = (error: WorkspaceError): string => {
-  switch (error.type) {
-    case 'DIRECTORY_NOT_FOUND':
-      return `Directory not found: ${error.path}`
-    case 'FILE_READ_ERROR':
-      return `Failed to read file at ${error.path}: ${error.cause}`
-    case 'FILE_WRITE_ERROR':
-      return `Failed to write file at ${error.path}: ${error.cause}`
-    case 'JSON_PARSE_ERROR':
-      return `Failed to parse JSON at ${error.path}: ${error.cause}`
-    case 'SCHEMA_NOT_FOUND':
-      return `${error.schemaType} schema not found for case: ${error.caseId}`
-    case 'VALIDATION_ERROR':
-      return `Validation error: ${error.message}`
-    case 'EVALUATION_ERROR':
-      return `Evaluation failed for case ${error.caseId}: ${error.cause}`
-    default:
-      return 'Unknown error occurred'
-  }
-}
 
 const runEvaluateSchema = async (): Promise<void> => {
   const initCwd = process.env['INIT_CWD'] || process.cwd()

--- a/frontend/internal-packages/schema-bench/src/cli/setup-workspace.ts
+++ b/frontend/internal-packages/schema-bench/src/cli/setup-workspace.ts
@@ -1,34 +1,14 @@
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { formatError } from '../shared/formatError.ts'
 import { setupWorkspace } from '../workspace/setup/setup.ts'
-import type { WorkspaceConfig, WorkspaceError } from '../workspace/types'
+import type { WorkspaceConfig } from '../workspace/types'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 // Right now, the script processes process.argv directly and lives in this package since it's still rough and only meant for internal (Liam team) use.
 // In the future, once things are more stable, we'd like to move this feature to the CLI package and rely on something like commander for argument parsing.
-
-const formatError = (error: WorkspaceError): string => {
-  switch (error.type) {
-    case 'DIRECTORY_NOT_FOUND':
-      return `Directory not found: ${error.path}`
-    case 'FILE_READ_ERROR':
-      return `Failed to read file at ${error.path}: ${error.cause}`
-    case 'FILE_WRITE_ERROR':
-      return `Failed to write file at ${error.path}: ${error.cause}`
-    case 'JSON_PARSE_ERROR':
-      return `Failed to parse JSON at ${error.path}: ${error.cause}`
-    case 'SCHEMA_NOT_FOUND':
-      return `${error.schemaType} schema not found for case: ${error.caseId}`
-    case 'VALIDATION_ERROR':
-      return `Validation error: ${error.message}`
-    case 'EVALUATION_ERROR':
-      return `Evaluation failed for case ${error.caseId}: ${error.cause}`
-    default:
-      return 'Unknown error occurred'
-  }
-}
 
 const runSetupWorkspace = async (): Promise<void> => {
   const initCwd = process.env['INIT_CWD'] || process.cwd()

--- a/frontend/internal-packages/schema-bench/src/shared/formatError.ts
+++ b/frontend/internal-packages/schema-bench/src/shared/formatError.ts
@@ -1,0 +1,22 @@
+import type { WorkspaceError } from '../workspace/types'
+
+export const formatError = (error: WorkspaceError): string => {
+  switch (error.type) {
+    case 'DIRECTORY_NOT_FOUND':
+      return `Directory not found: ${error.path}`
+    case 'FILE_READ_ERROR':
+      return `Failed to read file at ${error.path}: ${error.cause}`
+    case 'FILE_WRITE_ERROR':
+      return `Failed to write file at ${error.path}: ${error.cause}`
+    case 'JSON_PARSE_ERROR':
+      return `Failed to parse JSON at ${error.path}: ${error.cause}`
+    case 'SCHEMA_NOT_FOUND':
+      return `${error.schemaType} schema not found for case: ${error.caseId}`
+    case 'VALIDATION_ERROR':
+      return `Validation error: ${error.message}`
+    case 'EVALUATION_ERROR':
+      return `Evaluation failed for case ${error.caseId}: ${error.cause}`
+    default:
+      return 'Unknown error occurred'
+  }
+}


### PR DESCRIPTION
## Summary
This PR addresses the review feedback from PR #2263 by implementing three key improvements:
- Extract duplicated `formatError` function to maintain DRY principle
- Improve error handling patterns in file loading functions
- Better handle partial failures in ResultAsync.combine

ref comment: https://github.com/liam-hq/liam/pull/2263#discussion_r2179655309 , https://github.com/liam-hq/liam/pull/2263#discussion_r2179669355

## Related
- Addresses review feedback from #2263

## Test plan
[x] All existing tests pass
[x] TypeScript type checking passes
[x] Manual verification of error handling improvements

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved error messages for schema and workspace operations, providing clearer feedback for various error scenarios.

* **Refactor**
  * Enhanced error handling for file and schema operations, allowing the application to process partial successes and provide more detailed warnings instead of failing completely on individual errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->