### PR TITLE
style: enable noDescendingSpecificity rule and fix CSS selector ordering

### DIFF
--- a/frontend/apps/app/components/Chat/ProcessIndicator/ProcessIndicator.module.css
+++ b/frontend/apps/app/components/Chat/ProcessIndicator/ProcessIndicator.module.css
@@ -16,15 +16,15 @@
   overflow: hidden;
 }
 
-.collapsed .header {
-  margin-bottom: 0;
-}
-
 .header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--spacing-3);
+}
+
+.collapsed .header {
+  margin-bottom: 0;
 }
 
 .iconContainer {

--- a/frontend/apps/app/components/SchemaLink/SchemaLink.module.css
+++ b/frontend/apps/app/components/SchemaLink/SchemaLink.module.css
@@ -11,10 +11,6 @@
   border: none;
 }
 
-.schemaLink:hover .schemaName {
-  color: var(--global-foreground, #ffffff);
-}
-
 .schemaName {
   font-family: var(--main-font, Inter);
   font-size: var(--font-size-3, 0.75rem);
@@ -23,6 +19,10 @@
   line-height: 1.6em;
   transition: color var(--default-hover-animation-duration, 0.2s)
     var(--default-timing-function, ease);
+}
+
+.schemaLink:hover .schemaName {
+  color: var(--global-foreground, #ffffff);
 }
 
 .iconContainer {

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -74,8 +74,7 @@
         "noInferrableTypes": "error",
         "noUselessElse": "error",
         "noCommonJs": "error",
-        // TODO: Re-enable noDescendingSpecificity after fixing CSS specificity issues
-        "noDescendingSpecificity": "off"
+        "noDescendingSpecificity": "error"
       }
     },
     "includes": ["**"]

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/AppBar.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/AppBar.module.css
@@ -77,14 +77,6 @@
   outline: 1px solid var(--primary-color);
 }
 
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon {
-    color: var(--global-foreground);
-  }
-}
-
 .icon {
   width: 1rem;
   height: 1rem;
@@ -92,4 +84,12 @@
   stroke-width: 1.5px;
   transition: color var(--default-hover-animation-duration)
     var(--default-timing-function);
+}
+
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon {
+    color: var(--global-foreground);
+  }
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/GithubButton/GithubButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/GithubButton/GithubButton.module.css
@@ -13,14 +13,6 @@
   outline: 1px solid var(--primary-color);
 }
 
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon {
-    color: var(--global-foreground);
-  }
-}
-
 .icon {
   width: 1rem;
   height: 1rem;
@@ -28,4 +20,12 @@
   stroke-width: 1.5px;
   transition: color var(--default-hover-animation-duration)
     var(--default-timing-function);
+}
+
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon {
+    color: var(--global-foreground);
+  }
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/HelpButton/HelpButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/HelpButton/HelpButton.module.css
@@ -13,20 +13,20 @@
   outline: 1px solid var(--primary-color);
 }
 
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon {
-    color: var(--global-foreground);
-  }
-}
-
 .icon {
   width: 1rem;
   height: 1rem;
   color: var(--overlay-70);
   transition: color var(--default-hover-animation-duration)
     var(--default-timing-function);
+}
+
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon {
+    color: var(--global-foreground);
+  }
 }
 
 .menuContent {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/MenuButton/MenuButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/MenuButton/MenuButton.module.css
@@ -5,9 +5,6 @@
   padding: var(--spacing-1);
   margin: 0 var(--spacing-2);
   border-radius: var(--border-radius-base);
-  &:hover .icon {
-    color: var(--global-foreground);
-  }
 }
 
 .wrapper:focus-visible {
@@ -20,4 +17,8 @@
   color: var(--link-default);
   transition: color var(--default-hover-animation-duration)
     var(--default-timing-function);
+}
+
+.wrapper:hover .icon {
+  color: var(--global-foreground);
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/ReleaseNoteButton/ReleaseNoteButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/ReleaseNoteButton/ReleaseNoteButton.module.css
@@ -13,18 +13,18 @@
   outline: 1px solid var(--primary-color);
 }
 
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon {
-    color: var(--global-foreground);
-  }
-}
-
 .icon {
   width: 1rem;
   height: 1rem;
   color: var(--overlay-70);
   transition: color var(--default-hover-animation-duration)
     var(--default-timing-function);
+}
+
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon {
+    color: var(--global-foreground);
+  }
 }

--- a/frontend/packages/ui/src/components/IconButton/IconButton.module.css
+++ b/frontend/packages/ui/src/components/IconButton/IconButton.module.css
@@ -13,14 +13,6 @@
   outline: 1px solid var(--primary-color);
 }
 
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon > svg {
-    color: var(--global-foreground);
-  }
-}
-
 .iconWrapper.hoverBackground:hover {
   background-color: var(--overlay-10);
 }
@@ -45,4 +37,12 @@
 .icon.md > svg {
   width: 1rem;
   height: 1rem;
+}
+
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon > svg {
+    color: var(--global-foreground);
+  }
 }

--- a/frontend/packages/ui/src/components/IconButton/IconButton.module.css
+++ b/frontend/packages/ui/src/components/IconButton/IconButton.module.css
@@ -9,14 +9,6 @@
     var(--default-timing-function);
 }
 
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon > svg {
-    color: var(--global-foreground);
-  }
-}
-
 .iconWrapper.hoverBackground:hover {
   background-color: var(--overlay-10);
 }
@@ -31,6 +23,12 @@
   justify-content: center;
 }
 
+.icon > svg {
+  color: var(--overlay-70);
+  transition: color var(--default-hover-animation-duration)
+    var(--default-timing-function);
+}
+
 .icon.sm > svg {
   width: 0.75rem;
   height: 0.75rem;
@@ -41,8 +39,10 @@
   height: 1rem;
 }
 
-.icon > svg {
-  color: var(--overlay-70);
-  transition: color var(--default-hover-animation-duration)
-    var(--default-timing-function);
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon > svg {
+    color: var(--global-foreground);
+  }
 }

--- a/frontend/packages/ui/src/components/IconButton/IconButton.module.css
+++ b/frontend/packages/ui/src/components/IconButton/IconButton.module.css
@@ -9,12 +9,20 @@
     var(--default-timing-function);
 }
 
-.iconWrapper.hoverBackground:hover {
-  background-color: var(--overlay-10);
-}
-
 .iconWrapper:focus-visible {
   outline: 1px solid var(--primary-color);
+}
+
+.iconWrapper:hover {
+  background-color: var(--pane-background-active);
+
+  .icon > svg {
+    color: var(--global-foreground);
+  }
+}
+
+.iconWrapper.hoverBackground:hover {
+  background-color: var(--overlay-10);
 }
 
 .icon {
@@ -37,12 +45,4 @@
 .icon.md > svg {
   width: 1rem;
   height: 1rem;
-}
-
-.iconWrapper:hover {
-  background-color: var(--pane-background-active);
-
-  .icon > svg {
-    color: var(--global-foreground);
-  }
 }


### PR DESCRIPTION
Resolves #2328

This PR enables the Biome `noDescendingSpecificity` rule and fixes all CSS selector ordering violations across the codebase.

## Changes
- Enable `noDescendingSpecificity` Biome rule in style category
- Reorder CSS selectors to prevent descending specificity violations
- Fix violations in @liam-hq/ui IconButton component
- Fix violations in @liam-hq/erd-core AppBar components
- Fix violations in @liam-hq/app components
- Ensure hover states and more specific selectors come after base selectors

Generated with [Claude Code](https://claude.ai/code)