### PR TITLE
feat: add custom instructions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,8 @@ jobs:
         uses: anthropics/claude-code-action@91c510a769db0f9b79df0efbdded0c29c033f846 # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          custom_instructions: |
+            You have also been granted tools for editing files and running pnpm commands (fmt, install, lint, test) for testing your changes: pnpm fmt, pnpm install, pnpm lint, pnpm test.
           allowed_tools: |
             Bash(pnpm fmt:*),
             Bash(pnpm install),


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
This change adds custom instructions to the Claude workflow to inform Claude about the available pnpm commands for testing changes. This follows the pattern from the upstream claude-code-action repository example at https://github.com/anthropics/claude-code-action/blob/23fae74fdb7f3bb4fdd3ef029a08b1db410a4240/.github/workflows/claude.yml#L38 but adapts it for pnpm instead of bun.

## What would you like reviewers to focus on?
- The custom instructions section in the Claude workflow
- Whether the pnpm commands listed match the allowed tools

## Testing Verification
- Updated the `.github/workflows/claude.yml` file to include custom instructions
- Verified the syntax is correct and follows the example from the upstream repository

## Additional Notes
The custom instructions are intended to guide Claude to use commands like `npx biome check` and other linting/formatting tools when making changes to the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow configuration to include a new input for providing custom instructions to the AI assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->