### PR TITLE
fix: enable Biome rule noUselessFragments and fix violations

### DIFF
--- a/frontend/apps/app/app/layout.tsx
+++ b/frontend/apps/app/app/layout.tsx
@@ -37,14 +37,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <>
-        <GoogleTagManager
-          gtmId={GTM_ID}
-          dataLayer={{ appEnv: process.env.NEXT_PUBLIC_ENV_NAME ?? '' }}
-        />
-        <GtagScript />
-        <GTMConsent />
-      </>
+      <GoogleTagManager
+        gtmId={GTM_ID}
+        dataLayer={{ appEnv: process.env.NEXT_PUBLIC_ENV_NAME ?? '' }}
+      />
+      <GtagScript />
+      <GTMConsent />
       <body className={`${inter.className} ${montserrat.variable}`}>
         <ToastProvider>{children}</ToastProvider>
       </body>

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -59,8 +59,6 @@
         "noUselessUndefinedInitialization": "off",
         // TODO: Re-enable useDateNow after replacing new Date().getTime() with Date.now()
         "useDateNow": "off",
-        // TODO: Re-enable noUselessFragments after removing unnecessary fragments
-        "noUselessFragments": "off"
       },
       "style": {
         "noParameterAssign": "error",


### PR DESCRIPTION
## Issue

- resolve: #2327

## Why is this change needed?
This change enables the Biome linting rule `noUselessFragments` from the complexity category, which was disabled as part of issue #2244. The rule helps identify and remove unnecessary React Fragments that don't serve any purpose, improving code clarity and reducing bundle size.

## What would you like reviewers to focus on?
- The removal of the unnecessary React Fragment in `frontend/apps/app/app/layout.tsx`
- The removal of the rule from the disabled list in `frontend/internal-packages/configs/biome.jsonc`
- Verification that no other violations exist in the codebase

## Testing Verification
Verified that:
- All linting checks pass with the rule enabled
- No other violations exist across all packages
- The fragment removal doesn't break the layout functionality

## What was done
- Identified and fixed 1 violation of the `noUselessFragments` rule in `frontend/apps/app/app/layout.tsx`
- Removed the unnecessary React Fragment that was wrapping multiple components inside a `<html>` element
- Removed the rule from the disabled list in `frontend/internal-packages/configs/biome.jsonc`
- Verified no other violations exist by checking all packages systematically

## Additional Notes
This change is part of the broader effort to enable disabled Biome rules (issue #2244) and improve code quality standards across the codebase.


Generated with [Claude Code](https://claude.ai/code)