### PR TITLE
feat: enable Biome useDateNow rule

### DIFF
--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -57,8 +57,6 @@
         "noUselessEscapeInRegex": "off",
         // TODO: Re-enable noUselessUndefinedInitialization after fixing undefined initialization issues
         "noUselessUndefinedInitialization": "off",
-        // TODO: Re-enable useDateNow after replacing new Date().getTime() with Date.now()
-        "useDateNow": "off",
         // TODO: Re-enable noUselessFragments after removing unnecessary fragments
         "noUselessFragments": "off"
       },

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -57,6 +57,7 @@
         "noUselessEscapeInRegex": "off",
         // TODO: Re-enable noUselessUndefinedInitialization after fixing undefined initialization issues
         "noUselessUndefinedInitialization": "off",
+        "useDateNow": "error",
         // TODO: Re-enable noUselessFragments after removing unnecessary fragments
         "noUselessFragments": "off"
       },

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/ERDContent.tsx
@@ -128,7 +128,7 @@ export const ERDContentInner: FC<Props> = ({
 
   const handleDragStopNode: OnNodeDrag<Node> = useCallback(
     (_event, _node, nodes) => {
-      const operationId = `id_${new Date().getTime()}`
+      const operationId = `id_${Date.now()}`
       for (const node of nodes) {
         const tableId = node.id
         repositionTableLogEvent({


### PR DESCRIPTION
Enable the Biome linting rule `useDateNow` from the complexity category.

## Changes
- Replace `new Date().getTime()` with `Date.now()` in ERDContent.tsx
- Remove useDateNow rule from disabled list in biome.jsonc

Resolves: #2326

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp generation for node reposition events to use a more concise and reliable method.

* **Chores**
  * Updated code quality rules to enforce consistent use of timestamp methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->