### PR TITLE
Enable Biome rule: noDuplicateProperties (suspicious)

### DIFF
--- a/frontend/apps/app/app/(app)/app/(root)/settings/components/SettingsHeader/SettingsHeader.module.css
+++ b/frontend/apps/app/app/(app)/app/(root)/settings/components/SettingsHeader/SettingsHeader.module.css
@@ -23,7 +23,6 @@
   border-radius: var(--border-radius-md);
   cursor: pointer;
   transition: all 0.2s ease;
-  display: flex;
   align-items: center;
   gap: var(--spacing-1half);
 }

--- a/frontend/apps/app/components/ProjectLayout/ProjectHeader/ProjectHeader.module.css
+++ b/frontend/apps/app/components/ProjectLayout/ProjectHeader/ProjectHeader.module.css
@@ -24,7 +24,6 @@
   border-radius: var(--border-radius-md);
   cursor: pointer;
   transition: all 0.2s ease;
-  display: flex;
   align-items: center;
   gap: var(--spacing-1half);
 }

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -39,8 +39,7 @@
       },
       "suspicious": {
         "noConsole": { "level": "error", "options": { "allow": ["warn", "error", "info", "debug"] } },
-        // TODO: Re-enable noDuplicateProperties after fixing duplicate property issues
-        "noDuplicateProperties": "off",
+        "noDuplicateProperties": "error",
         "noDocumentCookie": "error"
       },
       "a11y": {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/Spinner/Spinner.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/Spinner/Spinner.module.css
@@ -25,7 +25,6 @@
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  background: #141616;
   background: linear-gradient(
     0deg,
     rgba(29, 237, 131, 0.05) 33%,

--- a/frontend/packages/ui/src/components/GridTable/GridTable.module.css
+++ b/frontend/packages/ui/src/components/GridTable/GridTable.module.css
@@ -41,7 +41,6 @@
 
 .dd {
   display: flex;
-  align-items: center;
   padding: var(--spacing-1) var(--spacing-2);
   color: var(--global-foreground);
   font-family: var(--code-font);


### PR DESCRIPTION
Fixes #2320

Enabled the Biome linting rule `noDuplicateProperties` from the suspicious category.

### Changes
- Fixed 4 violations of the `noDuplicateProperties` rule across CSS files
- Removed the rule from the disabled list in biome.jsonc
- All linting violations have been resolved

🤖 Generated with [Claude Code](https://claude.ai/code)