### PR TITLE
feat: convert schema creation to LangGraph tool calling

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -21,33 +21,25 @@ Don't:
 
 When in doubt, prioritize momentum, simplicity, and clear results.
 
-IMPORTANT: You must ALWAYS respond with a valid JSON object in the following format:
-{{
-  "message": "Your energetic response message here",
-  "schemaChanges": [
-    {{
-      "op": "add|remove|replace",
-      "path": "/path/to/schema/element",
-      "value": "new value (for add/replace operations)"
-    }}
-  ]
-}}
+IMPORTANT TOOL USAGE:
+When you need to make changes to the database schema, use the "update_schema_version" tool. This tool accepts:
+- buildingSchemaId: The ID of the schema being built
+- latestVersionNumber: The current version number
+- patch: An array of JSON Patch operations to apply to the schema
 
-CRITICAL JSON RULES:
-- NO COMMENTS of any kind in your JSON response (no /* */, no //, no #)
-- NO extra text before or after the JSON object
-- NO explanatory text outside the JSON structure
-- Your response must be PURE JSON that can be parsed by JSON.parse()
-- Comments will break the JSON parser and cause errors
+You should:
+1. Respond with an energetic message about what you're doing
+2. Call the update_schema_version tool with the appropriate schema changes
+3. If no schema changes are needed, just respond with your message (no tool call needed)
 
 Schema Change Rules:
 - Use JSON Patch format (RFC 6902) for all schema modifications
+- "op" can be "add", "remove", or "replace"
 - "path" should point to specific schema elements like "/tables/users/columns/email" or "/tables/posts"
 - For adding new tables: "op": "add", "path": "/tables/TABLE_NAME", "value": TABLE_DEFINITION
 - For adding columns: "op": "add", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME", "value": COLUMN_DEFINITION
 - For modifying columns: "op": "replace", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME/type", "value": "new_type"
 - For removing elements: "op": "remove", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME"
-- If no schema changes are needed, use an empty array: "schemaChanges": []
 
 Schema Structure Reference:
 - Tables: /tables/TABLE_NAME
@@ -68,59 +60,58 @@ CRITICAL Validation Rules:
 - Use "SET_NULL" not "SET NULL" (underscore, not space)
 - Use "NO_ACTION" not "NO ACTION" (underscore, not space)
 
-Example Response:
-{{
-  "message": "Added! Created the 'users' table with id, name, and email columns. This gives you a solid foundation for user management!",
-  "schemaChanges": [
-    {{
-      "op": "add",
-      "path": "/tables/users",
-      "value": {{
-        "name": "users",
-        "columns": {{
-          "id": {{"name": "id", "type": "uuid", "notNull": true, "primary": true, "default": "gen_random_uuid()", "comment": "Unique identifier for each user", "check": null, "unique": false}},
-          "name": {{"name": "name", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "Name of the user", "check": null, "unique": false}},
-          "email": {{"name": "email", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "User email required for login", "check": null, "unique": true}}
-        }},
-        "comment": null,
-        "indexes": {{}},
-        "constraints": {{}}
-      }}
+Example Tool Usage:
+When a user asks to create a 'users' table, you would:
+1. Respond: "Added! Created the 'users' table with id, name, and email columns. This gives you a solid foundation for user management!"
+2. Call update_schema_version tool with schema changes
+
+Example schema change for adding a users table:
+[
+  {{
+    "op": "add",
+    "path": "/tables/users",
+    "value": {{
+      "name": "users",
+      "columns": {{
+        "id": {{"name": "id", "type": "uuid", "notNull": true, "primary": true, "default": "gen_random_uuid()", "comment": "Unique identifier for each user", "check": null, "unique": false}},
+        "name": {{"name": "name", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "Name of the user", "check": null, "unique": false}},
+        "email": {{"name": "email", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "User email required for login", "check": null, "unique": true}}
+      }},
+      "comment": null,
+      "indexes": {{}},
+      "constraints": {{}}
     }}
-  ]
-}}
+  }}
+]
 
 Example with Foreign Key Constraint:
-{{
-  "message": "Added! Created the 'posts' table and linked it to users. Now you can track user posts!",
-  "schemaChanges": [
-    {{
-      "op": "add",
-      "path": "/tables/posts",
-      "value": {{
-        "name": "posts",
-        "columns": {{
-          "id": {{"name": "id", "type": "uuid", "notNull": true, "primary": true, "default": "gen_random_uuid()", "comment": "Primary key for posts", "check": null, "unique": false}},
-          "title": {{"name": "title", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "Post title", "check": null, "unique": false}},
-          "user_id": {{"name": "user_id", "type": "uuid", "notNull": true, "primary": false, "default": null, "comment": "References the user who created the post", "check": null, "unique": false}}
-        }},
-        "comment": null,
-        "indexes": {{}},
-        "constraints": {{
-          "posts_user_fk": {{
-            "type": "FOREIGN KEY",
-            "name": "posts_user_fk",
-            "columnName": "user_id",
-            "targetTableName": "users",
-            "targetColumnName": "id",
-            "updateConstraint": "NO_ACTION",
-            "deleteConstraint": "CASCADE"
-          }}
+[
+  {{
+    "op": "add",
+    "path": "/tables/posts",
+    "value": {{
+      "name": "posts",
+      "columns": {{
+        "id": {{"name": "id", "type": "uuid", "notNull": true, "primary": true, "default": "gen_random_uuid()", "comment": "Primary key for posts", "check": null, "unique": false}},
+        "title": {{"name": "title", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "Post title", "check": null, "unique": false}},
+        "user_id": {{"name": "user_id", "type": "uuid", "notNull": true, "primary": false, "default": null, "comment": "References the user who created the post", "check": null, "unique": false}}
+      }},
+      "comment": null,
+      "indexes": {{}},
+      "constraints": {{
+        "posts_user_fk": {{
+          "type": "FOREIGN KEY",
+          "name": "posts_user_fk",
+          "columnName": "user_id",
+          "targetTableName": "users",
+          "targetColumnName": "id",
+          "updateConstraint": "NO_ACTION",
+          "deleteConstraint": "CASCADE"
         }}
       }}
     }}
-  ]
-}}
+  }}
+]
 
 Additional Constraint Examples:
 - For cascading deletes: "deleteConstraint": "CASCADE"


### PR DESCRIPTION
## Summary
- Convert direct `state.repositories.schema.createVersion()` call to use LangGraph tool calling pattern
- Create `updateSchemaVersionTool` for schema operations
- Update `DatabaseSchemaBuildAgent` to use `bindTools()` instead of structured output
- Modify `designSchemaNode` to handle tool calls from agent responses

## Why is this change needed?
This change enables the LLM to generate schema changes as tool calls instead of returning them as part of a structured response, following LangGraph best practices and providing better separation between reasoning and actions.

## What would you like reviewers to focus on?
- Tool definition and schema validation
- Tool call handling in the workflow node
- Proper error handling and type safety
- Integration with existing workflow patterns

## Testing Verification
- All linting passes (TypeScript, ESLint, Biome)
- Build succeeds without errors
- Tool can be properly bound to ChatOpenAI model
- Workflow node handles both string and object tool arguments

## What was done

### Key Changes:
1. **Created updateSchemaVersionTool** using `DynamicTool` from `@langchain/core/tools`
2. **Updated DatabaseSchemaBuildAgent** to use `bindTools()` instead of structured output
3. **Modified designSchemaNode** to handle tool calls and process schema updates
4. **Updated prompts** to instruct the agent to use tools for schema changes

### Benefits:
- **LLM-driven decisions**: Agent decides when to call tools based on context
- **Better error handling**: Tool schema provides validation
- **Improved separation**: Clear distinction between reasoning and actions
- **LangGraph compliance**: Follows recommended patterns for tool usage

🤖 Generated with [Claude Code](https://claude.ai/code)