### PR TITLE
feat: Add Claude command for monitoring CI checks

### DIFF
--- a/.claude/commands/monitor-ci.md
+++ b/.claude/commands/monitor-ci.md
@@ -1,0 +1,56 @@
+# Monitor CI Checks
+
+Monitors pull request CI checks until they are resolved (pass or fail).
+
+## Usage
+
+When asked to monitor CI checks, Claude will:
+
+1. Run `gh pr checks --watch` to continuously monitor the status
+2. Wait until all checks are completed
+3. Report the final status of all checks
+4. If checks fail, analyze the failure logs and suggest fixes
+
+## Command
+
+```bash
+# Monitor PR checks in watch mode
+gh pr checks --watch
+
+# Alternative: Check status once
+gh pr checks
+
+# View specific check details if needed
+gh pr checks --verbose
+```
+
+## Workflow
+
+1. **Start Monitoring**: Run `gh pr checks --watch` immediately after PR creation or when requested
+2. **Track Progress**: The command will show real-time updates of all CI checks
+3. **Completion**: Wait until all checks show as either ✓ (passed) or X (failed)
+4. **Action on Failure**: 
+   - If any checks fail, use `gh pr checks --verbose` to get detailed logs
+   - Analyze the failure and suggest or implement fixes
+   - After fixes, push changes and monitor again
+
+## Example Output
+
+```
+Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
+
+NAME                    STATUS      CONCLUSION
+Build                   completed   success     ✓
+Lint                    completed   success     ✓
+Test                    completed   failure     X
+Type Check              in_progress -           ◐
+
+Some checks were not successful
+```
+
+## Important Notes
+
+- The `--watch` flag refreshes every 10 seconds
+- Press Ctrl+C to stop monitoring
+- Always wait for all checks to complete before proceeding
+- If checks fail, investigate and fix issues before merging


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
This change adds a new Claude command that helps monitor CI checks on pull requests. It provides guidance for using `gh pr checks --watch` to track CI status until completion and handle both successful and failed checks.

## What would you like reviewers to focus on?
- The command documentation clarity and completeness
- Whether the workflow described is intuitive and helpful

## Testing Verification
- Created the new command file at `.claude/commands/monitor-ci.md`
- Verified the file structure follows existing Claude command patterns
- Tested that the command documentation is properly formatted

## What was done
pr_agent:summary

## Detailed Changes
pr_agent:walkthrough

## Additional Notes
This command complements the existing PR creation workflow by providing a way to monitor CI checks after PR creation.

🤖 Generated with [Claude Code](https://claude.ai/code)