### PR TITLE
💄 style(command palette): fix font-family for cli

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
@@ -11,6 +11,7 @@
   color: var(--global-foreground);
   border: 1px solid var(--global-border);
   z-index: var(--z-index-command-palette);
+  font-family: var(--main-font);
 }
 
 [cmdk-overlay]:has(+ .content) {


### PR DESCRIPTION
## Issue

~- resolve:~
related to https://github.com/liam-hq/liam/issues/507

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

The font family of the cli application was not appropriate.

|before|after
|-|-|
|![Screenshot 0007-07-06 at 15 36 56](https://github.com/user-attachments/assets/83c405e4-b04e-4529-b546-91e76145b108)|![Screenshot 0007-07-06 at 15 36 39](https://github.com/user-attachments/assets/6e713ef9-f46d-431b-aa36-0c671a8779bd)|



## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

1. visit https://liam-erd-sample-git-style-command-palette-cli-fon-b28fcc-liambx.vercel.app/
2. press ⌘K to open the dialog
3. check the font family of the content

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 2c3f2e7a31dcf341ac52404b82f606558b8bfa31

- Fix font-family for command palette CLI interface


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.module.css</strong><dd><code>Add main font family to command palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css

<li>Added <code>font-family: var(--main-font)</code> to <code>.content[cmdk-dialog]</code> selector


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2388/files#diff-1b2c933681f2482ea26b144a844c87e82437516eb31e6b5c5c24c78286c49279">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the command palette to use the main application font for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->