### PR TITLE
chore: add Claude Code settings with git commit permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": [
+      "Bash(git commit --no-verify:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Issue

- resolve: Add Claude Code settings to configure permissions

## Why is this change needed?
This change adds Claude Code settings to control git commit permissions, specifically preventing the use of `git commit --no-verify` commands to maintain code quality standards.

## What would you like reviewers to focus on?
Please review the permissions configuration in `.claude/settings.json` and ensure it aligns with our development workflow requirements.

## Testing Verification
- Verified the settings.json file is properly formatted
- Confirmed the deny rule prevents `git commit --no-verify` commands
- Tested that normal git commits still work as expected

## Additional Notes
This settings file will help maintain code quality by ensuring all commits go through proper validation hooks.

🤖 Generated with [Claude Code](https://claude.ai/code)