### PR TITLE
Improve serve command example

### DIFF
--- a/.changeset/puny-falcons-cough.md
+++ b/.changeset/puny-falcons-cough.md
@@ -1,0 +1,11 @@
+---
+"@liam-hq/cli": patch
+---
+
+Improve static file serving experience with better cache control
+
+- Add cache-disabling flag (`-c-1`) to all `http-server` command examples to prevent browsers from caching ERD files
+- Recommend `npx serve` as the primary static file server over `http-server` for better user experience
+- Auto-generate `serve.json` configuration file in build output that sets `Cache-Control: no-cache` headers for HTML and JSON files when using the `serve` package
+
+These changes ensure users always see the latest ERD visualization after regeneration without manual cache clearing.

--- a/frontend/apps/docs/content/docs/cli/ci-cd.mdx
+++ b/frontend/apps/docs/content/docs/cli/ci-cd.mdx
@@ -79,6 +79,7 @@ When you run `npx @liam-hq/cli erd build` or `liam erd build`, a `./dist` direct
     <File name="favicon.ico" />
     <File name="index.html" />
     <File name="schema.json" />
+    <File name="serve.json" />
   </Folder>
 </Files>
 

--- a/frontend/apps/docs/content/docs/cli/index.mdx
+++ b/frontend/apps/docs/content/docs/cli/index.mdx
@@ -29,7 +29,7 @@ This command processes your schema file and generates interactive ERD visualizat
 Once the ERD is generated, you can view it by serving the files using a local HTTP server:
 
 ```npm
-npx http-server dist  # or your custom output directory
+npx http-server -c-1 dist  # or your custom output directory
 ```
 
 The server will start and provide you with a local URL (typically http://localhost:8080) where you can view your ERD in a web browser.
@@ -62,7 +62,7 @@ The command generates a simple web application using [Vite](https://vite.dev/), 
 To view the generated ERD, serve the output directory using any HTTP server:
 
 ```npm
-npx http-server dist  # or your custom output directory
+npx http-server -c-1 dist  # or your custom output directory
 ```
 
 ## Sample Projects

--- a/frontend/apps/docs/content/docs/cli/index.mdx
+++ b/frontend/apps/docs/content/docs/cli/index.mdx
@@ -29,10 +29,10 @@ This command processes your schema file and generates interactive ERD visualizat
 Once the ERD is generated, you can view it by serving the files using a local HTTP server:
 
 ```npm
-npx http-server -c-1 dist  # or your custom output directory
+npx serve dist/  # or your custom output directory
 ```
 
-The server will start and provide you with a local URL (typically http://localhost:8080) where you can view your ERD in a web browser.
+The server will start and provide you with a local URL (typically http://localhost:3000) where you can view your ERD in a web browser.
 
 You can use any hosting service of your choice to serve the generated files.
 
@@ -62,7 +62,7 @@ The command generates a simple web application using [Vite](https://vite.dev/), 
 To view the generated ERD, serve the output directory using any HTTP server:
 
 ```npm
-npx http-server -c-1 dist  # or your custom output directory
+npx serve dist/  # or your custom output directory
 ```
 
 ## Sample Projects

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -60,7 +60,7 @@ ERD has been generated successfully in the \`${displayOutDir}/\` directory.
 Note: You cannot open this file directly using \`file://\`.
 Please serve the \`${displayOutDir}/\` directory with an HTTP server and access it via \`http://\`.
 Example:
-    ${blueBright(`$ npx http-server ${displayOutDir}/`)}
+    ${blueBright(`$ npx http-server -c-1 ${displayOutDir}/`)}
 `)
   }
   return errors

--- a/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
+++ b/frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts
@@ -60,6 +60,8 @@ ERD has been generated successfully in the \`${displayOutDir}/\` directory.
 Note: You cannot open this file directly using \`file://\`.
 Please serve the \`${displayOutDir}/\` directory with an HTTP server and access it via \`http://\`.
 Example:
+    ${blueBright(`$ npx serve ${displayOutDir}/`)}
+    ${blueBright('or')}
     ${blueBright(`$ npx http-server -c-1 ${displayOutDir}/`)}
 `)
   }

--- a/frontend/packages/cli/src/cli/initCommand/index.ts
+++ b/frontend/packages/cli/src/cli/initCommand/index.ts
@@ -264,9 +264,9 @@ const displayNextSteps = (
   console.info(
     `\n${stepNum}) Start your favorite httpd for serving dist. e.g.:`,
   )
-  console.info(yocto.blueBright('   $ npx serve dist'))
+  console.info(yocto.blueBright('   $ npx serve dist/'))
   console.info(yocto.blueBright('   or'))
-  console.info(yocto.blueBright('   $ npx http-server -c-1 dist'))
+  console.info(yocto.blueBright('   $ npx http-server -c-1 dist/'))
 }
 
 /**

--- a/frontend/packages/cli/src/cli/initCommand/index.ts
+++ b/frontend/packages/cli/src/cli/initCommand/index.ts
@@ -264,6 +264,8 @@ const displayNextSteps = (
   console.info(
     `\n${stepNum}) Start your favorite httpd for serving dist. e.g.:`,
   )
+  console.info(yocto.blueBright('   $ npx serve dist'))
+  console.info(yocto.blueBright('   or'))
   console.info(yocto.blueBright('   $ npx http-server -c-1 dist'))
 }
 

--- a/frontend/packages/cli/src/cli/initCommand/index.ts
+++ b/frontend/packages/cli/src/cli/initCommand/index.ts
@@ -264,7 +264,7 @@ const displayNextSteps = (
   console.info(
     `\n${stepNum}) Start your favorite httpd for serving dist. e.g.:`,
   )
-  console.info(yocto.blueBright('   $ npx http-server dist'))
+  console.info(yocto.blueBright('   $ npx http-server -c-1 dist'))
 }
 
 /**

--- a/frontend/packages/cli/vite.config.ts
+++ b/frontend/packages/cli/vite.config.ts
@@ -1,4 +1,5 @@
-import { rmSync } from 'node:fs'
+import { rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
@@ -21,6 +22,29 @@ export default defineConfig({
           name: 'exclude-schema-json',
           closeBundle() {
             rmSync(`${outDir}/schema.json`, { force: true })
+          },
+        },
+        {
+          // Generate serve.json for the serve package
+          name: 'generate-serve-json',
+          closeBundle() {
+            const serveConfig = {
+              headers: [
+                {
+                  source: '**/*.@(html|json)',
+                  headers: [
+                    {
+                      key: 'Cache-Control',
+                      value: 'no-cache',
+                    },
+                  ],
+                },
+              ],
+            }
+            writeFileSync(
+              join(outDir, 'serve.json'),
+              JSON.stringify(serveConfig, null, 2),
+            )
           },
         },
       ],


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/1789

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


Users were experiencing stale ERD visualizations due to browser caching.
When regenerating ERD files after schema changes, the browser would serve
cached versions instead of the updated content, requiring manual cache
clearing to see the latest changes.



## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- Whether the cache control approach (using serve.json for the serve
package) is appropriate
- If the documentation clearly explains the recommended serving method
- Whether the -c-1 flag for http-server as a fallback option is clearly
communicated

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

I verified the cache control improvements work correctly by following these
steps:

```
1. Built the CLI package
pnpm --filter @liam-hq/cli build
2. Generated ERD from a sample schema
node frontend/packages/cli/dist-cli/bin/cli.js erd build --input
https://github.com/mastodon/mastodon/blob/v4.3.2/db/schema.rb
3. Tested both static file servers
  - Using serve (recommended): npx serve dist/
  - Using http-server with cache disabled: npx http-server -c-1 dist/
4. Verified cache headers are properly set

4. For serve (port 3000):
curl -is http://localhost:3000/ | head -20
curl -is http://localhost:3000/schema.json | head -20

4. For http-server (port 8080):
curl -is http://127.0.0.1:8080/ | head -20
curl -is http://127.0.0.1:8080/schema.json | head -20

4. ✅ Confirmed that Cache-Control headers are set to either:
  - no-cache (when using serve with the auto-generated serve.json)
  - no-cache, no-store, must-revalidate (when using http-server -c-1)
```


## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 0b806147356668e8a00537b39711e3c6b47c55a4

- Fix browser caching issues for ERD files by adding cache-disabling flags
- Replace `http-server` with `serve` as recommended static file server
- Auto-generate `serve.json` config with no-cache headers for HTML/JSON files
- Update documentation to reflect new serving recommendations


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update ERD build command output messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/erdCommand/buildCommand/index.ts

<li>Replace <code>http-server</code> with <code>serve</code> as primary recommendation<br> <li> Add <code>-c-1</code> flag to <code>http-server</code> as fallback option<br> <li> Update CLI output message with both serving options


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2399/files#diff-40e5647ca5c26b5c00d835caebbd61f2952f36203890fe2b412fe24d1192ba45">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update init command serving recommendations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/src/cli/initCommand/index.ts

<li>Replace <code>http-server</code> with <code>serve</code> in init command output<br> <li> Add <code>-c-1</code> flag to <code>http-server</code> as alternative option<br> <li> Update step instructions for serving dist directory


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2399/files#diff-927569ca321915530a5c635f660996e7ea7da3e1c89046324e4cab2acb5e55c7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Add serve.json generation plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/cli/vite.config.ts

<li>Add new Vite plugin to generate <code>serve.json</code> configuration<br> <li> Set <code>Cache-Control: no-cache</code> headers for HTML and JSON files<br> <li> Import additional Node.js modules for file operations


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2399/files#diff-ba257508cca249f37d70627a761b7d9a77745f92116462812f58a23ff9f5f013">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>puny-falcons-cough.md</strong><dd><code>Add changeset for cache control improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/puny-falcons-cough.md

<li>Document patch-level changes for cache control improvements<br> <li> List all three main changes: flags, serve recommendation, and <br>auto-config<br> <li> Explain user benefit of seeing latest ERD without manual cache <br>clearing


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2399/files#diff-2792b1605f52b0acb143baa382912bbf7f58015a44a618a70d7e93f26b34a744">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-cd.mdx</strong><dd><code>Update CI/CD documentation file structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/docs/content/docs/cli/ci-cd.mdx

<li>Add <code>serve.json</code> file to the dist directory structure documentation<br> <li> Update file tree to reflect new auto-generated configuration file


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2399/files#diff-218538ff72e8a5f2d6139903ca8cb969f7e77c7d226b51f8b14720f7b7365259">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.mdx</strong><dd><code>Update CLI documentation serving examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/docs/content/docs/cli/index.mdx

<li>Replace <code>http-server</code> with <code>serve</code> in code examples<br> <li> Update default port from 8080 to 3000 in documentation<br> <li> Change serving command recommendations throughout the file


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2399/files#diff-e7c5208ef5297be5455cc6b1b141ccfb2cb3b53dc05e5c33ef4d743c1cf7dbed">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved static file serving for ERD visualization files by recommending the use of `npx serve` and providing updated instructions.
  * Automatically generates a configuration file to prevent browsers from caching HTML and JSON files, ensuring users always see the latest ERD version.

* **Documentation**
  * Updated CLI and CI/CD documentation to reflect new serving commands and the inclusion of the cache-control configuration file in output examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->