### PR TITLE
💄 style(command palette): make ESC button be prettier

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css
@@ -79,6 +79,10 @@
   color: var(--overlay-60);
 }
 
+.escButton {
+  min-width: auto;
+}
+
 .main {
   display: flex;
   padding: var(--spacing-2);

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
@@ -71,7 +71,11 @@ export const CommandPalette: FC = () => {
           />
         </div>
         <DialogClose asChild>
-          <Button size="xs" variant="outline-secondary">
+          <Button
+            size="xs"
+            variant="outline-secondary"
+            className={styles.escButton}
+          >
             ESC
           </Button>
         </DialogClose>


### PR DESCRIPTION
ref: https://github.com/liam-hq/liam/pull/2278#pullrequestreview-2969604056

## Issue

- resolve: https://github.com/liam-hq/liam/pull/2278#pullrequestreview-2969604056

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

In https://github.com/liam-hq/liam/pull/2278, we use `Button` component from `@liam-hq/ui` package for the ESC button. However, the button was a little bit too wide since it has `min-width` property.
This PR removes the property to make the button be prettier.

|before|after|
|-|-|
|![Screenshot 0007-07-08 at 8 10 36](https://github.com/user-attachments/assets/1872b85d-b97e-4cda-92f4-8ed518103e5a)|![Screenshot 0007-07-08 at 8 10 40](https://github.com/user-attachments/assets/d5fc70c3-a2c8-4740-a4e6-b94aabfb3ddc)|

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- if style change is acceptable.

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

1. visit https://liam-app-git-style-command-palette-esc-button-prettier-liambx.vercel.app/
2. press ⌘K to open the dialog
3. check the ESC button style

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at c27b4fc10f517b32d723c58044b7dd8a5497a143

- Override min-width property for ESC button styling
- Add custom CSS class to make button more compact
- Improve visual appearance of command palette ESC button


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.module.css</strong><dd><code>Add custom CSS for ESC button styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.module.css

<li>Add <code>.escButton</code> CSS class with <code>min-width: auto</code> property<br> <li> Override default button min-width to make ESC button more compact


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2412/files#diff-1b2c933681f2482ea26b144a844c87e82437516eb31e6b5c5c24c78286c49279">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Apply custom CSS class to ESC button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx

<li>Add <code>className={styles.escButton}</code> to Button component<br> <li> Apply custom styling to ESC button in DialogClose


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2412/files#diff-94c7028698d83655392638264848d9a70ea1e476877bee9806d9e5d7b61e1780">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of the "Esc" button in the Command Palette for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->