### PR TITLE
refactor: change workflow error field from string to Error class

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
@@ -64,11 +64,12 @@ export async function analyzeRequirementsNode(
 
   if (analysisResult.isErr()) {
     const errorMessage = analysisResult.error
-    state.logger.error(`[${NODE_NAME}] Failed: ${errorMessage}`)
+    const error = new Error(`[${NODE_NAME}] Failed: ${errorMessage}`)
+    state.logger.error(error.message)
 
     return {
       ...state,
-      error: errorMessage,
+      error,
       retryCount: {
         ...state.retryCount,
         [NODE_NAME]: retryCount + 1,

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.integration.test.ts
@@ -222,7 +222,8 @@ describe('designSchemaNode -> executeDdlNode integration', () => {
     const result = await designSchemaNode(initialState)
 
     // Verify error handling
-    expect(result.error).toBe(
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe(
       'Invalid schema after applying changes: validation failed',
     )
     expect(result.schemaData).toEqual(initialSchema) // Should remain unchanged
@@ -277,7 +278,8 @@ describe('designSchemaNode -> executeDdlNode integration', () => {
     const result = await designSchemaNode(initialState)
 
     // Verify error handling
-    expect(result.error).toBe('Database connection failed')
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe('Database connection failed')
     expect(result.schemaData).toEqual(initialSchema) // Should remain unchanged
     expect(mockLogger.error).toHaveBeenCalledWith(
       'Schema update failed:',

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -29,13 +29,15 @@ const applySchemaChanges = async (
   })
 
   if (!result.success) {
+    const errorMessage = result.error || 'Failed to update schema'
+    const error = new Error(errorMessage)
     state.logger.error('Schema update failed:', {
-      error: result.error || 'Failed to update schema',
+      error: errorMessage,
     })
     return {
       ...state,
       generatedAnswer: message,
-      error: result.error || 'Failed to update schema',
+      error,
     }
   }
 

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/finalizeArtifactsNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/finalizeArtifactsNode.ts
@@ -53,10 +53,10 @@ async function saveTimelineItem(
  */
 async function generateFinalResponse(state: WorkflowState): Promise<{
   finalResponse: string
-  errorToReturn: string | undefined
+  errorToReturn: Error | undefined
 }> {
   if (state.error) {
-    const finalResponse = `Sorry, an error occurred during processing: ${state.error}`
+    const finalResponse = `Sorry, an error occurred during processing: ${state.error.message}`
     await saveTimelineItem(state, finalResponse, 'error')
     return { finalResponse, errorToReturn: state.error }
   }
@@ -70,7 +70,10 @@ async function generateFinalResponse(state: WorkflowState): Promise<{
   const finalResponse =
     'Sorry, we could not generate an answer. Please try again.'
   await saveTimelineItem(state, finalResponse, 'error')
-  return { finalResponse, errorToReturn: 'No generated answer available' }
+  return {
+    finalResponse,
+    errorToReturn: new Error('No generated answer available'),
+  }
 }
 
 /**

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
@@ -78,10 +78,11 @@ export async function generateUsecaseNode(
   if (!state.analyzedRequirements) {
     const errorMessage =
       'No analyzed requirements found. Cannot generate use cases.'
-    state.logger.error(`[${NODE_NAME}] ${errorMessage}`)
+    const error = new Error(`[${NODE_NAME}] ${errorMessage}`)
+    state.logger.error(error.message)
     return {
       ...state,
-      error: errorMessage,
+      error,
     }
   }
 
@@ -107,11 +108,12 @@ export async function generateUsecaseNode(
 
   if (usecaseResult.isErr()) {
     const errorMessage = usecaseResult.error
-    state.logger.error(`[${NODE_NAME}] Failed: ${errorMessage}`)
+    const error = new Error(`[${NODE_NAME}] Failed: ${errorMessage}`)
+    state.logger.error(error.message)
 
     return {
       ...state,
-      error: errorMessage,
+      error,
       retryCount: {
         ...state.retryCount,
         [NODE_NAME]: retryCount + 1,

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/saveUserMessageNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/saveUserMessageNode.ts
@@ -24,9 +24,10 @@ export async function saveUserMessageNode(
       error: saveResult.error,
     })
     // Set error state to trigger transition to finalizeArtifacts
+    const error = new Error(`Failed to save message: ${saveResult.error}`)
     return {
       ...state,
-      error: `Failed to save message: ${saveResult.error}`,
+      error,
     }
   }
 

--- a/frontend/internal-packages/agent/src/chat/workflow/shared/langGraphUtils.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/shared/langGraphUtils.ts
@@ -48,7 +48,7 @@ export const createAnnotations = () => {
     organizationId: Annotation<string | undefined>,
     userId: Annotation<string>,
     designSessionId: Annotation<string>,
-    error: Annotation<string | undefined>,
+    error: Annotation<Error | undefined>,
     retryCount: Annotation<Record<string, number>>,
 
     ddlStatements: Annotation<string | undefined>,

--- a/frontend/internal-packages/agent/src/chat/workflow/types.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/types.ts
@@ -18,7 +18,7 @@ export type WorkflowState = {
   formattedHistory: string
   schemaData: Schema
   projectId?: string | undefined
-  error?: string | undefined
+  error?: Error | undefined
   retryCount: Record<string, number>
 
   ddlStatements?: string | undefined

--- a/frontend/internal-packages/agent/src/deepModeling.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.ts
@@ -182,7 +182,7 @@ export const deepModeling = async (
     })
 
     if (result.error) {
-      return err(new Error(result.error))
+      return err(result.error)
     }
 
     return ok({
@@ -195,9 +195,9 @@ export const deepModeling = async (
       error instanceof Error
         ? error.message
         : WORKFLOW_ERROR_MESSAGES.EXECUTION_FAILED
-    const errorState = { ...workflowState, error: errorMessage }
+    const errorState = { ...workflowState, error: new Error(errorMessage) }
     const finalizedResult = await finalizeArtifactsNode(errorState)
 
-    return err(new Error(finalizedResult.error || errorMessage))
+    return err(finalizedResult.error || new Error(errorMessage))
   }
 }


### PR DESCRIPTION
~https://github.com/liam-hq/liam/pull/2416 will be merged as soon as it is merged.~


## Summary

- Changed WorkflowState.error type from `string` to `Error` for better debugging information
- Updated all workflow nodes to create Error objects with descriptive messages including node names
- Modified error handling in finalizeArtifactsNode to access error.message property
- Updated LangGraph annotations to support Error type instead of string
- Fixed integration tests to expect Error objects

## Why is this change needed?

The previous string-based error handling made it difficult to debug workflow issues because:
- No stack traces were available
- Couldn't identify which specific node generated the error
- Lost contextual information about error origins

## What would you like reviewers to focus on?

- Error object creation patterns in each workflow node
- Type safety improvements in the LangGraph integration
- Test coverage for the new Error-based error handling

## Testing Verification

- All existing tests pass with updated Error object expectations
- Linting and type checking pass successfully
- Integration tests verify proper Error object handling in workflow nodes

🤖 Generated with [Claude Code](https://claude.ai/code)