### PR TITLE
feat: implement DDL execution retry mechanism

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/constants.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/constants.ts
@@ -24,3 +24,15 @@ export const WORKFLOW_NODE_PROGRESS = {
   reviewDeliverables: 90,
   finalizeArtifacts: 100,
 } as const
+
+/**
+ * Retry configuration for workflow operations
+ */
+export const WORKFLOW_RETRY_CONFIG = {
+  /**
+   * Maximum number of retries for DDL execution failures
+   * When DDL execution fails, the workflow will retry up to this many times
+   * by going back to the designSchema node with the error information
+   */
+  MAX_DDL_EXECUTION_RETRIES: 1,
+} as const

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { WorkflowState } from '../types'
+import { designSchemaNode } from './designSchemaNode'
+
+describe('designSchemaNode retry behavior', () => {
+  it('should include DDL failure reason in user message when retrying', async () => {
+    const mockAgent = {
+      generate: vi.fn().mockResolvedValue({
+        schema: { tables: {} },
+      }),
+    }
+
+    vi.mock('../../../langchain/agents', () => ({
+      QASchemaGenerateAgent: vi.fn(() => mockAgent),
+    }))
+
+    const state: WorkflowState = {
+      userInput: 'Create a users table',
+      formattedHistory: '',
+      schemaData: { tables: {} },
+      buildingSchemaId: 'test-id',
+      latestVersionNumber: 1,
+      repositories: {
+        schema: {
+          updateTimelineItem: vi.fn(),
+          getSchema: vi.fn(),
+          getDesignSession: vi.fn(),
+          createVersion: vi.fn(),
+          createTimelineItem: vi.fn(),
+          createArtifact: vi.fn(),
+          updateArtifact: vi.fn(),
+          getArtifact: vi.fn(),
+        },
+      },
+      designSessionId: 'session-id',
+      userId: 'user-id',
+      logger: {
+        log: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      retryCount: { ddlExecutionRetry: 1 },
+      shouldRetryWithDesignSchema: true,
+      ddlExecutionFailureReason: 'Foreign key constraint error',
+    }
+
+    await designSchemaNode(state)
+
+    const generateCall = mockAgent.generate.mock.calls[0]?.[0] as
+      | { user_message: string }
+      | undefined
+    expect(generateCall?.user_message).toContain('Create a users table')
+    expect(generateCall?.user_message).toContain('Foreign key constraint error')
+  })
+})

--- a/frontend/internal-packages/agent/src/chat/workflow/shared/langGraphUtils.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/shared/langGraphUtils.ts
@@ -53,6 +53,11 @@ export const createAnnotations = () => {
 
     ddlStatements: Annotation<string | undefined>,
 
+    // DDL execution retry mechanism
+    shouldRetryWithDesignSchema: Annotation<boolean | undefined>,
+    ddlExecutionFailed: Annotation<boolean | undefined>,
+    ddlExecutionFailureReason: Annotation<string | undefined>,
+
     // Repository dependencies for data access
     repositories: Annotation<Repositories>,
 

--- a/frontend/internal-packages/agent/src/chat/workflow/types.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/types.ts
@@ -23,6 +23,11 @@ export type WorkflowState = {
 
   ddlStatements?: string | undefined
 
+  // DDL execution retry mechanism
+  shouldRetryWithDesignSchema?: boolean | undefined
+  ddlExecutionFailed?: boolean | undefined
+  ddlExecutionFailureReason?: string | undefined
+
   // Schema update fields
   buildingSchemaId: string
   latestVersionNumber: number

--- a/frontend/internal-packages/agent/src/deepModeling.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.ts
@@ -118,6 +118,17 @@ const createGraph = () => {
       return state.error ? 'finalizeArtifacts' : 'executeDDL'
     })
 
+    // Conditional edge for executeDDL - retry with designSchema if DDL execution fails
+    .addConditionalEdges('executeDDL', (state) => {
+      if (state.shouldRetryWithDesignSchema) {
+        return 'designSchema'
+      }
+      if (state.ddlExecutionFailed) {
+        return 'finalizeArtifacts'
+      }
+      return 'generateUsecase'
+    })
+
     // Conditional edges for validation results
     .addConditionalEdges('validateSchema', (state) => {
       // success → reviewDeliverables


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
When DDL execution fails, we want to give the schema design agent one chance to fix the issue based on the error message. This improves the success rate of schema generation.

(One rerun is a tentative decision.We will adjust it as we do dogfooding.)

## What would you like reviewers to focus on?
- The retry logic implementation in `executeDdlNode.ts`
- The error message handling in `designSchemaNode.ts`
- The workflow routing logic in `deepModeling.ts`

## Testing Verification
Added a minimal unit test to verify that DDL error messages are properly included in the retry prompt.

## What was done
- Add retry logic to executeDdlNode that sets shouldRetryWithDesignSchema flag on first failure  
- Update designSchemaNode to include DDL error messages in prompt when retrying
- Add conditional edge in deepModeling workflow to route back to designSchema on DDL failure
- Add retry count tracking to prevent infinite loops (max 1 retry)

### 🤖 Generated by PR Agent at 5564d3714ee5408dc1213445d7615205cb4087fc

- Add DDL execution retry mechanism with schema redesign
- Implement workflow routing for failed DDL executions
- Add retry count tracking and configuration constants
- Include error messages in retry prompts


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>constants.ts</strong><dd><code>Add DDL retry configuration constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-915c8b53cfd0de26280714bee13d0aa18dd8651da3e012b9827a4f4efca8455d">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>designSchemaNode.retry.test.ts</strong><dd><code>Add unit test for DDL retry behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-3f435fec49225fd6f26e197751dbf332dfb006a8fea61b7ef8c5b2ff2b7b8bca">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>designSchemaNode.ts</strong><dd><code>Include DDL error messages in retry prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-d8640276ef7b26dba3c7427f094425f942a7bbec1e218ff0afce8fb09d165044">+21/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>executeDdlNode.ts</strong><dd><code>Implement DDL execution retry logic with failure tracking</code></dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-bb46ee6aeb1b4f9dcaf0008d471806b727e4d46bb5f8d3c8dac8e2cfb7bcb06e">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>langGraphUtils.ts</strong><dd><code>Add DDL retry state annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-b51f33c7be3439bcc1c05d550336ad4bee18bf6a1a3a9eb4d8a01b93ab6ec5c3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add DDL retry mechanism type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-109e0c9f6ce9b81d77af86dd13f8e125ae9544fe68fa8d8757d471b139378dcb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deepModeling.ts</strong><dd><code>Add conditional workflow routing for DDL failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/liam-hq/liam/pull/2425/files#diff-3f4a426800ae7acea1ccc0f60c6e52ab11658b1d80d765812b648c6998a07ec9">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

## Additional Notes
This PR supersedes #2409 and targets the main branch directly.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic retry for schema design when database execution fails, improving workflow resilience.
  * Users will see improved handling of DDL execution failures, with the system attempting to fix and retry once before marking as failed.

* **Bug Fixes**
  * Enhanced error tracking and messaging during schema design and execution retries for clearer feedback on failure reasons.

* **Tests**
  * Added new tests to verify retry behavior when schema execution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->