### PR TITLE
feat(agent): update OpenAI model from o3 to o4-mini

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
@@ -21,7 +21,7 @@ export class DatabaseSchemaBuildAgent
 
   constructor() {
     const baseModel = new ChatOpenAI({
-      model: 'o3',
+      model: 'o4-mini',
       callbacks: [createLangfuseHandler()],
     })
 

--- a/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
@@ -20,7 +20,7 @@ export class PMAnalysisAgent
 
   constructor() {
     const baseModel = new ChatOpenAI({
-      model: 'o3',
+      model: 'o4-mini',
       callbacks: [createLangfuseHandler()],
     })
 

--- a/frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts
@@ -32,7 +32,7 @@ export class QAGenerateUsecaseAgent
 
   constructor() {
     const baseModel = new ChatOpenAI({
-      model: 'o3',
+      model: 'o4-mini',
       callbacks: [createLangfuseHandler()],
     })
 


### PR DESCRIPTION
## Issue

- resolve: Update OpenAI model configuration for improved response time and cost efficiency

## Why is this change needed?
The current o3 model has response times exceeding 1 minute, which is impractical for real-time agent interactions. The o4-mini model provides 1/10 the cost and response time while maintaining comparable performance, making it a better choice for current operations.

## What would you like reviewers to focus on?
- Verify that all agent classes are consistently updated to use o4-mini
- Confirm that the model change maintains expected functionality
- Review the performance improvements from faster response times

## Testing Verification
- All linters passed successfully during commit
- No functional changes to agent behavior, only model configuration update
- Changes affect three agent classes: DatabaseSchemaBuildAgent, PMAnalysisAgent, and QAGenerateUsecaseAgent

## What was done

### 🤖 Generated by PR Agent at 369335757ae5e4152b9bfe6ea34153f335c16751

- Update OpenAI model from `o3` to `o4-mini` across all agent classes
- Improve response time and cost efficiency by 10x
- Maintain consistent model configuration across three agent types


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Update model configuration to o4-mini</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts

- Change OpenAI model from `o3` to `o4-mini` in constructor


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2433/files#diff-31f2c91208c3ca40dd1deb90d323eb52ba6f5ab3d5e271b76072b50045eda8a9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Update model configuration to o4-mini</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts

- Change OpenAI model from `o3` to `o4-mini` in constructor


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2433/files#diff-e9a2a83d9369c9a7d00f9099cd6730f8b686e969d1c63d57ff79ae2ef8af0cf1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Update model configuration to o4-mini</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts

- Change OpenAI model from `o3` to `o4-mini` in constructor


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2433/files#diff-91948fb8b8f57c9e903c0993357fc5fed804de7cac23b5343957600d4570113b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This is a temporary solution to address response time issues. Future optimization may involve selecting different models based on specific agent tasks and requirements.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the underlying language model used by various agents to a newer version for improved performance. No changes to user-facing logic or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->