### PR TITLE
🐛 Fix isGenerating logic to check only latest progress item

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -100,14 +100,17 @@ Please suggest a specific solution to resolve this problem.`
   const { timelineItems, addOrUpdateTimelineItem } =
     useRealtimeTimelineItems(designSession)
   const isGenerating = useMemo(() => {
-    return timelineItems.some((item) => {
-      return (
-        item.role === 'progress' &&
-        'progress' in item &&
-        typeof item.progress === 'number' &&
-        item.progress < 100
-      )
-    })
+    const progressItems = timelineItems.filter(
+      (item) => item.role === 'progress',
+    )
+    if (progressItems.length === 0) return false
+
+    const latestProgressItem = progressItems[progressItems.length - 1]
+    return (
+      'progress' in latestProgressItem &&
+      typeof latestProgressItem.progress === 'number' &&
+      latestProgressItem.progress < 100
+    )
   }, [timelineItems])
 
   // Show loading state while schema is being fetched


### PR DESCRIPTION
## Issue

- resolve: isGenerating remains true even after successful re-execution when previous progress items failed with progress < 100

## Why is this change needed?

The current isGenerating logic checks all progress items in timelineItems using `some()`, which causes a problem when:
1. An initial execution fails and stops with progress < 100 (e.g., progress: 50)
2. User re-executes and the new execution completes successfully with progress: 100
3. isGenerating still returns true because the old failed progress item (progress < 100) still exists in the timeline

The logic should only check the latest progress item to accurately reflect the current execution state, not all historical progress items.

## What would you like reviewers to focus on?

- Whether the fix correctly addresses the issue where old failed progress items affect current state
- If filtering for the latest progress item is the right approach
- The logic change from `some()` to checking only the last progress item

## Testing Verification

- Verified that isGenerating becomes false when the latest progress item reaches 100, regardless of previous failed attempts
- Confirmed that isGenerating correctly reflects the state of the most recent execution
- Tested scenarios with multiple progress items including failed and successful executions

## What was done

### 🤖 Generated by PR Agent at d2c96d6593a77f1d7e81dd343fc724430d419234

- Fix `isGenerating` logic to check only latest progress item
- Prevent old failed progress items from affecting current state
- Replace `some()` check with filtering for most recent progress


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SessionDetailPageClient.tsx</strong><dd><code>Fix isGenerating to check latest progress only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx

<li>Replace <code>some()</code> method with filtering for progress items<br> <li> Get latest progress item from filtered array<br> <li> Check progress status only on most recent item<br> <li> Add early return for empty progress items array


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2440/files#diff-69089906bb3e4cc3962e216aa760bd5e7f6d398c1a0ad19789bfb2c6264a18bc">+11/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes

This fix ensures that the generating state accurately reflects the current execution status, preventing confusion when users re-execute after failed attempts.

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of the session progress indicator by updating how ongoing progress is detected, ensuring it reflects only the most recent progress status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->