### PR TITLE
🔧 Update E2E tests workflow to trigger on repository dispatch for Vercel deployment success

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -20,13 +20,13 @@ jobs:
         working-directory: "frontend/internal-packages/e2e"
     env:
       CI: true
-      URL: ${{ github.event.deployment_status.target_url }}
-      ENVIRONMENT: ${{ github.event.deployment.environment }}
+      URL: ${{ github.event.client_payload.deployment_status.target_url }}
+      ENVIRONMENT: ${{ github.event.client_payload.deployment.environment }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.deployment.sha }}
+          ref: ${{ github.event.client_payload.deployment.sha }}
           persist-credentials: false
 
       - name: Check deployment conditions
@@ -35,12 +35,11 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           event_name      = "${{ github.event_name }}"
-          event_state     = "${{ github.event.deployment_status.state }}"
-          environment_val = "${{ github.event.deployment.environment }}"
-          target_url      = "${{ github.event.deployment_status.target_url }}"
+          environment_val = "${{ github.event.client_payload.deployment.environment }}"
+          target_url      = "${{ github.event.client_payload.deployment_status.target_url }}"
 
           result =
-            if event_name == "deployment_status" && event_state == "success"
+            if event_name == "repository_dispatch"
               # Production deployment
               if (environment_val.include?("Production") && target_url.include?("liam-app-git-main"))
                 "should_run=true"


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


- Changed the event trigger from `deployment_status` to `repository_dispatch` with type `vercel.deployment.success` to improve the workflow's responsiveness to deployment events.(and to avoid workflow loops)

📘 
https://vercel.com/guides/how-can-i-run-end-to-end-tests-after-my-vercel-preview-deployment
https://vercel.com/docs/git/vercel-for-github#repository-dispatch-events

⚠️ 
**Repository dispatch events can only be tested after merging to the main branch.**
As a result, E2E test execution cannot be confirmed on the current branch.

![ss 3551](https://github.com/user-attachments/assets/0679cf5a-72f1-4612-9eb3-3f10da3e23ab)



We need to turn off the `deployment_status` setting in vercel, but we would like to do this after the merge of this pull request, because the E2E GitHub Action for the other pull request will not work!

![ss 3549](https://github.com/user-attachments/assets/8f251e41-0ecb-43b6-9db6-e0ed21987ae4)


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

Verified in my private repository.
- https://github.com/FunamaYukina/vercel-loop-test/pull/4

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at cbe08c1612f3590fd080c3ba67ee73b4c84ee051

- Changed E2E workflow trigger from `deployment_status` to `repository_dispatch`
- Updated event data references to use `client_payload` structure
- Improved workflow responsiveness and prevents deployment loops
- Targets `vercel.deployment.success` dispatch events specifically


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_tests.yml</strong><dd><code>Migrate workflow trigger to repository dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e_tests.yml

<li>Changed trigger from <code>deployment_status</code> to <code>repository_dispatch</code> with <br><code>vercel.deployment.success</code> type<br> <li> Updated all event data references to use <code>client_payload</code> structure<br> <li> Modified deployment condition check to use <code>repository_dispatch</code> event <br>name<br> <li> Removed <code>event_state</code> check since it's no longer needed


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2443/files#diff-37aed4ad4a8c3a4220c5e3c2eee33093073b8d64f480cc742b63764c859b6c72">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to trigger end-to-end tests on successful deployments using a new event type for improved integration with deployment notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->