### PR TITLE
🔧 feat: Add support for multiple PostgreSQL schemas in Drizzle parser with proper FK resolution

### DIFF
--- a/.changeset/cruel-cats-decide.md
+++ b/.changeset/cruel-cats-decide.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/db-structure": patch
+---
+
+✨ Add support for multiple PostgreSQL schemas in Drizzle parser with proper FK resolution

--- a/frontend/packages/db-structure/src/parser/drizzle/astUtils.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/astUtils.ts
@@ -116,6 +116,17 @@ export const isPgTableCall = (callExpr: CallExpression): boolean => {
 }
 
 /**
+ * Check if a call expression is a schema.table() call
+ */
+export const isSchemaTableCall = (callExpr: CallExpression): boolean => {
+  return (
+    isMemberExpression(callExpr.callee) &&
+    isIdentifier(callExpr.callee.property) &&
+    callExpr.callee.property.value === 'table'
+  )
+}
+
+/**
  * Extract string value from a string literal
  */
 export const getStringValue = (node: Expression): string | null => {

--- a/frontend/packages/db-structure/src/parser/drizzle/converter.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/converter.ts
@@ -186,20 +186,7 @@ const fixForeignKeyTargetColumnNames = (
   for (const table of Object.values(tables)) {
     for (const constraint of Object.values(table.constraints)) {
       if (constraint.type === 'FOREIGN KEY') {
-        // The targetTableName should already be resolved to the actual table name
-        // Now we need to get the actual target table to resolve column names
-        const targetTable = tables[constraint.targetTableName]
-        if (targetTable) {
-          // Find the actual column name in the target table
-          for (const [_, column] of Object.entries(targetTable.columns)) {
-            if (column.name === constraint.targetColumnName) {
-              // Column name is already correct
-              break
-            }
-          }
-        }
-
-        // Also check in drizzleTables for column mapping
+        // Check in drizzleTables for column mapping
         const drizzleTargetTable = drizzleTables[constraint.targetTableName]
         if (drizzleTargetTable) {
           // Find column definition by JS property name and get actual DB column name

--- a/frontend/packages/db-structure/src/parser/drizzle/converter.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/converter.ts
@@ -23,6 +23,7 @@ import type { DrizzleEnumDefinition, DrizzleTableDefinition } from './types.js'
 const convertToTable = (
   tableDef: DrizzleTableDefinition,
   enums: Record<string, DrizzleEnumDefinition> = {},
+  variableToTableMapping: Record<string, string> = {},
 ): Table => {
   const columns: Columns = {}
   const constraints: Constraints = {}
@@ -98,12 +99,17 @@ const convertToTable = (
 
     // Add foreign key constraint
     if (columnDef.references) {
+      // Resolve variable name to actual table name
+      const targetTableName =
+        variableToTableMapping[columnDef.references.table] ||
+        columnDef.references.table
+
       const constraintName = `${tableDef.name}_${columnDef.name}_${columnDef.references.table}_${columnDef.references.column}_fk`
       const constraint: ForeignKeyConstraint = {
         type: 'FOREIGN KEY',
         name: constraintName,
         columnName: columnDef.name, // Use actual column name, not JS property name
-        targetTableName: columnDef.references.table,
+        targetTableName: targetTableName,
         targetColumnName: columnDef.references.column,
         updateConstraint: columnDef.references.onUpdate
           ? convertReferenceOption(columnDef.references.onUpdate)
@@ -180,6 +186,20 @@ const fixForeignKeyTargetColumnNames = (
   for (const table of Object.values(tables)) {
     for (const constraint of Object.values(table.constraints)) {
       if (constraint.type === 'FOREIGN KEY') {
+        // The targetTableName should already be resolved to the actual table name
+        // Now we need to get the actual target table to resolve column names
+        const targetTable = tables[constraint.targetTableName]
+        if (targetTable) {
+          // Find the actual column name in the target table
+          for (const [_, column] of Object.entries(targetTable.columns)) {
+            if (column.name === constraint.targetColumnName) {
+              // Column name is already correct
+              break
+            }
+          }
+        }
+
+        // Also check in drizzleTables for column mapping
         const drizzleTargetTable = drizzleTables[constraint.targetTableName]
         if (drizzleTargetTable) {
           // Find column definition by JS property name and get actual DB column name
@@ -200,6 +220,7 @@ const fixForeignKeyTargetColumnNames = (
 export const convertDrizzleTablesToInternal = (
   drizzleTables: Record<string, DrizzleTableDefinition>,
   enums: Record<string, DrizzleEnumDefinition>,
+  variableToTableMapping: Record<string, string> = {},
 ): { tables: Record<string, Table>; errors: Error[] } => {
   const tables: Record<string, Table> = {}
   const errors: Error[] = []
@@ -207,7 +228,11 @@ export const convertDrizzleTablesToInternal = (
   // Convert Drizzle tables to internal format
   for (const [tableName, tableDef] of Object.entries(drizzleTables)) {
     try {
-      tables[tableName] = convertToTable(tableDef, enums)
+      tables[tableName] = convertToTable(
+        tableDef,
+        enums,
+        variableToTableMapping,
+      )
     } catch (error) {
       errors.push(
         new Error(

--- a/frontend/packages/db-structure/src/parser/drizzle/index.test.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/index.test.ts
@@ -733,5 +733,148 @@ describe(_processor, () => {
         expect(foreignKeyConstraint.targetTableName).toBe('users')
       }
     })
+
+    it('multiple PostgreSQL schemas', async () => {
+      const { value } = await _processor(`
+        import { pgTable, serial, varchar, integer, timestamp, uuid, boolean, text } from 'drizzle-orm/pg-core';
+        import { pgSchema } from 'drizzle-orm/pg-core';
+
+        // Define multiple schemas
+        export const authSchema = pgSchema('auth');
+        export const publicSchema = pgSchema('public');
+        export const analyticsSchema = pgSchema('analytics');
+        export const adminSchema = pgSchema('admin');
+
+        // Auth schema tables
+        export const authUsers = authSchema.table('users', {
+          id: serial('id').primaryKey(),
+          email: varchar('email', { length: 255 }).notNull().unique(),
+          passwordHash: text('password_hash').notNull(),
+          isActive: boolean('is_active').default(true).notNull(),
+          createdAt: timestamp('created_at').defaultNow().notNull(),
+        });
+
+        export const authSessions = authSchema.table('sessions', {
+          id: serial('id').primaryKey(),
+          userId: integer('user_id').references(() => authUsers.id).notNull(),
+          token: text('token').notNull().unique(),
+          expiresAt: timestamp('expires_at').notNull(),
+          createdAt: timestamp('created_at').defaultNow().notNull(),
+        });
+
+        // Public schema tables
+        export const publicEvents = publicSchema.table('events', {
+          id: serial('id').primaryKey(),
+          title: varchar('title', { length: 255 }).notNull(),
+          description: text('description'),
+          startDate: timestamp('start_date').notNull(),
+          endDate: timestamp('end_date'),
+          createdAt: timestamp('created_at').defaultNow().notNull(),
+        });
+
+        export const publicCategories = publicSchema.table('categories', {
+          id: serial('id').primaryKey(),
+          name: varchar('name', { length: 100 }).notNull().unique(),
+          description: text('description'),
+          createdAt: timestamp('created_at').defaultNow().notNull(),
+        });
+
+        // Analytics schema tables
+        export const analyticsPageViews = analyticsSchema.table('page_views', {
+          id: serial('id').primaryKey(),
+          userId: integer('user_id').references(() => authUsers.id),
+          page: varchar('page', { length: 500 }).notNull(),
+          timestamp: timestamp('timestamp').defaultNow().notNull(),
+          sessionId: uuid('session_id').notNull(),
+        });
+
+        export const analyticsUserEvents = analyticsSchema.table('user_events', {
+          id: serial('id').primaryKey(),
+          userId: integer('user_id').references(() => authUsers.id),
+          eventType: varchar('event_type', { length: 100 }).notNull(),
+          eventData: text('event_data'),
+          timestamp: timestamp('timestamp').defaultNow().notNull(),
+        });
+
+        // Admin schema tables
+        export const adminAuditLogs = adminSchema.table('audit_logs', {
+          id: serial('id').primaryKey(),
+          userId: integer('user_id').references(() => authUsers.id).notNull(),
+          action: varchar('action', { length: 100 }).notNull(),
+          tableName: varchar('table_name', { length: 100 }),
+          recordId: integer('record_id'),
+          oldValues: text('old_values'),
+          newValues: text('new_values'),
+          timestamp: timestamp('timestamp').defaultNow().notNull(),
+        });
+
+        export const adminSettings = adminSchema.table('settings', {
+          id: serial('id').primaryKey(),
+          key: varchar('key', { length: 100 }).notNull().unique(),
+          value: text('value').notNull(),
+          description: text('description'),
+          updatedAt: timestamp('updated_at').defaultNow().notNull(),
+        });
+      `)
+
+      // Check that all tables from different schemas are parsed
+      expect(value.tables).toHaveProperty('users')
+      expect(value.tables).toHaveProperty('sessions')
+      expect(value.tables).toHaveProperty('events')
+      expect(value.tables).toHaveProperty('categories')
+      expect(value.tables).toHaveProperty('page_views')
+      expect(value.tables).toHaveProperty('user_events')
+      expect(value.tables).toHaveProperty('audit_logs')
+      expect(value.tables).toHaveProperty('settings')
+
+      // Check that we have the expected number of tables
+      expect(Object.keys(value.tables)).toHaveLength(8)
+
+      // Verify foreign key constraints across schemas work
+      // Check that foreign keys now correctly reference table names, not variable names
+      const sessionsFK =
+        value.tables['sessions']?.constraints[
+          'sessions_user_id_authUsers_id_fk'
+        ]
+      expect(sessionsFK).toBeDefined()
+      if (sessionsFK && sessionsFK.type === 'FOREIGN KEY') {
+        expect(sessionsFK.targetTableName).toBe('users') // Should be 'users', not 'authUsers'
+      }
+
+      const pageViewsFK =
+        value.tables['page_views']?.constraints[
+          'page_views_user_id_authUsers_id_fk'
+        ]
+      expect(pageViewsFK).toBeDefined()
+      if (pageViewsFK && pageViewsFK.type === 'FOREIGN KEY') {
+        expect(pageViewsFK.targetTableName).toBe('users') // Should be 'users', not 'authUsers'
+      }
+
+      const userEventsFK =
+        value.tables['user_events']?.constraints[
+          'user_events_user_id_authUsers_id_fk'
+        ]
+      expect(userEventsFK).toBeDefined()
+      if (userEventsFK && userEventsFK.type === 'FOREIGN KEY') {
+        expect(userEventsFK.targetTableName).toBe('users') // Should be 'users', not 'authUsers'
+      }
+
+      const auditLogsFK =
+        value.tables['audit_logs']?.constraints[
+          'audit_logs_user_id_authUsers_id_fk'
+        ]
+      expect(auditLogsFK).toBeDefined()
+      if (auditLogsFK && auditLogsFK.type === 'FOREIGN KEY') {
+        expect(auditLogsFK.targetTableName).toBe('users') // Should be 'users', not 'authUsers'
+      }
+
+      // Verify table structures
+      expect(value.tables['users']?.columns).toHaveProperty('email')
+      expect(value.tables['users']?.columns).toHaveProperty('passwordHash')
+      expect(value.tables['events']?.columns).toHaveProperty('title')
+      expect(value.tables['page_views']?.columns).toHaveProperty('sessionId')
+      expect(value.tables['user_events']?.columns).toHaveProperty('eventType')
+      expect(value.tables['audit_logs']?.columns).toHaveProperty('action')
+    })
   })
 })

--- a/frontend/packages/db-structure/src/parser/drizzle/mainParser.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/mainParser.ts
@@ -5,10 +5,14 @@
 import type { Module, VariableDeclarator } from '@swc/core'
 import { parseSync } from '@swc/core'
 import type { Processor, ProcessResult } from '../types.js'
-import { isPgTableCall } from './astUtils.js'
+import { isPgTableCall, isSchemaTableCall } from './astUtils.js'
 import { convertDrizzleTablesToInternal } from './converter.js'
 import { parsePgEnumCall } from './enumParser.js'
-import { parsePgTableCall, parsePgTableWithComment } from './tableParser.js'
+import {
+  parsePgTableCall,
+  parsePgTableWithComment,
+  parseSchemaTableCall,
+} from './tableParser.js'
 import type { DrizzleEnumDefinition, DrizzleTableDefinition } from './types.js'
 
 /**
@@ -19,6 +23,7 @@ const parseDrizzleSchema = (
 ): {
   tables: Record<string, DrizzleTableDefinition>
   enums: Record<string, DrizzleEnumDefinition>
+  variableToTableMapping: Record<string, string>
 } => {
   // Parse TypeScript code into AST
   const ast = parseSync(sourceCode, {
@@ -28,11 +33,12 @@ const parseDrizzleSchema = (
 
   const tables: Record<string, DrizzleTableDefinition> = {}
   const enums: Record<string, DrizzleEnumDefinition> = {}
+  const variableToTableMapping: Record<string, string> = {}
 
   // Traverse the AST to find pgTable calls
-  visitModule(ast, tables, enums)
+  visitModule(ast, tables, enums, variableToTableMapping)
 
-  return { tables, enums }
+  return { tables, enums, variableToTableMapping }
 }
 
 /**
@@ -42,18 +48,29 @@ const visitModule = (
   module: Module,
   tables: Record<string, DrizzleTableDefinition>,
   enums: Record<string, DrizzleEnumDefinition>,
+  variableToTableMapping: Record<string, string>,
 ) => {
   for (const item of module.body) {
     if (item.type === 'VariableDeclaration') {
       for (const declarator of item.declarations) {
-        visitVariableDeclarator(declarator, tables, enums)
+        visitVariableDeclarator(
+          declarator,
+          tables,
+          enums,
+          variableToTableMapping,
+        )
       }
     } else if (
       item.type === 'ExportDeclaration' &&
       item.declaration?.type === 'VariableDeclaration'
     ) {
       for (const declarator of item.declaration.declarations) {
-        visitVariableDeclarator(declarator, tables, enums)
+        visitVariableDeclarator(
+          declarator,
+          tables,
+          enums,
+          variableToTableMapping,
+        )
       }
     }
   }
@@ -66,6 +83,7 @@ const visitVariableDeclarator = (
   declarator: VariableDeclarator,
   tables: Record<string, DrizzleTableDefinition>,
   enums: Record<string, DrizzleEnumDefinition>,
+  variableToTableMapping: Record<string, string>,
 ) => {
   if (!declarator.init || declarator.init.type !== 'CallExpression') return
 
@@ -73,8 +91,17 @@ const visitVariableDeclarator = (
 
   if (isPgTableCall(callExpr)) {
     const table = parsePgTableCall(callExpr)
-    if (table) {
+    if (table && declarator.id.type === 'Identifier') {
       tables[table.name] = table
+      // Map variable name to table name
+      variableToTableMapping[declarator.id.value] = table.name
+    }
+  } else if (isSchemaTableCall(callExpr)) {
+    const table = parseSchemaTableCall(callExpr)
+    if (table && declarator.id.type === 'Identifier') {
+      tables[table.name] = table
+      // Map variable name to table name
+      variableToTableMapping[declarator.id.value] = table.name
     }
   } else if (
     declarator.init.type === 'CallExpression' &&
@@ -84,8 +111,10 @@ const visitVariableDeclarator = (
   ) {
     // Handle table comments: pgTable(...).comment(...)
     const table = parsePgTableWithComment(declarator.init)
-    if (table) {
+    if (table && declarator.id.type === 'Identifier') {
       tables[table.name] = table
+      // Map variable name to table name
+      variableToTableMapping[declarator.id.value] = table.name
     }
   } else if (
     callExpr.callee.type === 'Identifier' &&
@@ -105,10 +134,15 @@ const parseDrizzleSchemaString = (
   schemaString: string,
 ): Promise<ProcessResult> => {
   try {
-    const { tables: drizzleTables, enums } = parseDrizzleSchema(schemaString)
+    const {
+      tables: drizzleTables,
+      enums,
+      variableToTableMapping,
+    } = parseDrizzleSchema(schemaString)
     const { tables, errors } = convertDrizzleTablesToInternal(
       drizzleTables,
       enums,
+      variableToTableMapping,
     )
 
     return Promise.resolve({

--- a/frontend/packages/db-structure/src/parser/drizzle/tableParser.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/tableParser.ts
@@ -139,18 +139,11 @@ export const parsePgTableCall = (
 export const parseSchemaTableCall = (
   callExpr: CallExpression,
 ): DrizzleTableDefinition | null => {
-  if (!isSchemaTableCall(callExpr)) return null
-
-  if (callExpr.arguments.length < 2) return null
-
-  const tableNameArg = callExpr.arguments[0]
-  const columnsArg = callExpr.arguments[1]
-
-  if (!tableNameArg || !columnsArg) return null
+  if (!isSchemaTableCall(callExpr) || callExpr.arguments.length < 2) return null
 
   // Extract expression from SWC argument structure
-  const tableNameExpr = getArgumentExpression(tableNameArg)
-  const columnsExpr = getArgumentExpression(columnsArg)
+  const tableNameExpr = getArgumentExpression(callExpr.arguments[0])
+  const columnsExpr = getArgumentExpression(callExpr.arguments[1])
 
   const tableName = tableNameExpr ? getStringValue(tableNameExpr) : null
   if (!tableName || !columnsExpr || !isObjectExpression(columnsExpr))

--- a/frontend/packages/db-structure/src/parser/drizzle/tableParser.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/tableParser.ts
@@ -162,6 +162,12 @@ export const parseSchemaTableCall = (
     indexes: {},
   }
 
+  // TODO: Handle table name conflicts across different schemas
+  // Currently, if multiple schemas have tables with the same name (e.g., auth.users and public.users),
+  // the later one will overwrite the earlier one since we only use the table name without schema prefix.
+  // This is a limitation shared by other parsers and should be addressed consistently across the codebase.
+  // ref: https://github.com/liam-hq/liam/discussions/2391
+
   // Parse columns from the object expression
   for (const prop of columnsExpr.properties) {
     if (prop.type === 'KeyValueProperty') {


### PR DESCRIPTION
## Issue

- ref: https://github.com/liam-hq/liam/issues/1293

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

  Previously, the Drizzle parser couldn't handle schemas with multiple PostgreSQL schemas (e.g., `auth`, `public`, `analytics`). Additionally, foreign key constraints were using variable names (e.g., `authUsers`) instead of actual table names (e.g., `users`), which prevented ERD edges from being displayed correctly.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

  Tested with a complex schema containing multiple PostgreSQL schemas from https://github.com/FunamaYukina/drizzle-sample-schema/blob/main/drizzle/postgresql/advanced/schema.ts

  Before:
https://liam-erd-web.vercel.app/erd/p/github.com/FunamaYukina/drizzle-sample-schema/blob/main/drizzle/postgresql/advanced/schema.ts

![ss 3554](https://github.com/user-attachments/assets/bb5af19e-16a0-4b28-bf48-a3aa87617635)


  - Schema parsing resulted in empty tables
  - Foreign keys referenced variable names (e.g., `targetTableName: "authUsers"`)

  After:
https://liam-app-git-feat-drizzle-multi-schema-fk-resolution-liambx.vercel.app/erd/p/github.com/FunamaYukina/drizzle-sample-schema/blob/main/drizzle/postgresql/advanced/schema.ts

![ss 3555](https://github.com/user-attachments/assets/ada11707-cb06-48c5-bee3-131455734806)


  - All tables from different schemas are parsed correctly
  - Foreign keys reference actual table names (e.g., `targetTableName: "users"`)
  - ERD correctly displays relationship edges

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

  - Added support for parsing multiple PostgreSQL schemas using `pgSchema()` in Drizzle ORM
  - Fixed foreign key constraint resolution to use actual table names instead of variable names
  - Implemented variable-to-table-name mapping for proper cross-schema references

### 🤖 Generated by PR Agent at 0f66c30713dde21e54aaaa269c851eb32e63eab6

- Add support for multiple PostgreSQL schemas in Drizzle parser
- Fix foreign key resolution to use table names instead of variable names
- Implement schema.table() parsing for multi-schema support
- Add comprehensive tests for multi-schema scenarios


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>astUtils.ts</strong><dd><code>Add schema table call detection utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/drizzle/astUtils.ts

<li>Add <code>isSchemaTableCall()</code> function to detect schema.table() calls<br> <li> Enable parsing of schema-prefixed table definitions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2444/files#diff-e887a8f793c6486e9cb2b8ff43e529716e2b557fe2f18c65d36ebc2270c6b986">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>converter.ts</strong><dd><code>Enhance FK resolution with variable-to-table mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/drizzle/converter.ts

<li>Add <code>variableToTableMapping</code> parameter to resolve FK references<br> <li> Fix foreign key constraints to use actual table names<br> <li> Update FK resolution logic to map variable names to table names


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2444/files#diff-c9189e9060360d418d8e978745ac29392560d5e2193aa4e60304df8ef8120dcd">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mainParser.ts</strong><dd><code>Integrate multi-schema parsing into main parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/drizzle/mainParser.ts

<li>Add <code>variableToTableMapping</code> tracking throughout parsing pipeline<br> <li> Integrate schema table call parsing with existing pgTable parsing<br> <li> Update AST traversal to handle schema-prefixed table definitions


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2444/files#diff-45436a6b460d2fbcaa78961077f69eef99e85e6f5127a49a4e2714341e82fa16">+43/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tableParser.ts</strong><dd><code>Add schema table parsing functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/drizzle/tableParser.ts

<li>Add <code>parseSchemaTableCall()</code> function for schema.table() parsing<br> <li> Include TODO comment about table name conflicts across schemas<br> <li> Implement column and index parsing for schema tables


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2444/files#diff-4bbc8f86dcf0240ba81496ccc6507a584c526b3c056d6cbb57bca434863a0fde">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add comprehensive multi-schema test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/db-structure/src/parser/drizzle/index.test.ts

<li>Add test for multiple PostgreSQL schemas parsing<br> <li> Add test for FK resolution across different schemas<br> <li> Add test for column name mapping (JS property vs DB column)


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2444/files#diff-5d8edffd67066314c45524886038479c6c0e6d763aed6980cb74765a355fce79">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cruel-cats-decide.md</strong><dd><code>Add changeset for new feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/cruel-cats-decide.md

- Add changeset entry for multi-schema PostgreSQL support


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2444/files#diff-4f478940aef4829384af7b97ebff67901b01f87660c64369785c7ce50bda9c3b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling multiple PostgreSQL schemas, including correct resolution of foreign key relationships across schemas.
  * Enhanced the parser to recognize and process schema-qualified table definitions.
  
* **Bug Fixes**
  * Foreign key constraints now correctly reference the actual target table and column names, even when variable names differ from database names.

* **Tests**
  * Added test cases for multi-schema parsing and foreign key resolution with differing property and column names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->