### PR TITLE
Fix E2E workflow payload structure for repository_dispatch events 

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -20,13 +20,13 @@ jobs:
         working-directory: "frontend/internal-packages/e2e"
     env:
       CI: true
-      URL: ${{ github.event.client_payload.deployment_status.target_url }}
-      ENVIRONMENT: ${{ github.event.client_payload.deployment.environment }}
+      URL: ${{ github.event.client_payload.url }}
+      ENVIRONMENT: ${{ github.event.client_payload.environment }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.client_payload.deployment.sha }}
+          ref: ${{ github.event.client_payload.sha }}
           persist-credentials: false
 
       - name: Check deployment conditions
@@ -35,8 +35,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           event_name      = "${{ github.event_name }}"
-          environment_val = "${{ github.event.client_payload.deployment.environment }}"
-          target_url      = "${{ github.event.client_payload.deployment_status.target_url }}"
+          environment_val = "${{ github.event.client_payload.environment }}"
+          target_url      = "${{ github.event.client_payload.url }}"
 
           result =
             if event_name == "repository_dispatch"


### PR DESCRIPTION

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

  We encountered an issue after switching the E2E workflow trigger from `deployment_status` to `repository_dispatch`. The target URL and environment variables were coming through as empty, causing the workflow to skip execution due to unmatched conditions.

  The problem was that the payload structure is different between these two event types:
  - `deployment_status`: Uses `github.event.deployment_status.target_url` and
  `github.event.deployment.environment`
  - `repository_dispatch`: Uses `github.event.client_payload.url` and
  `github.event.client_payload.environment`

![ss 3553](https://github.com/user-attachments/assets/b13a7cd8-9e6c-4972-b633-5869521aa491)


  I've updated the workflow to use the correct payload structure for `repository_dispatch`
  events so that the URL and environment are properly captured.


## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
