### PR TITLE
Revert "🔧 Update E2E tests workflow to trigger on repository dispatch for Vercel deployment success"

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   _e2e-tests:
+    # WARNING: Do not set 'environment' here to avoid infinite loop with Vercel deployment_status webhooks
+    # Vercel sends deployment_status events that could trigger this workflow repeatedly
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
Reverts liam-hq/liam#2443

I'm reverting the recent changes that switched our E2E workflow from `deployment_status` to `repository_dispatch` events.

After implementing the `repository_dispatch` approach ([following Vercel's documentation](https://vercel.com/docs/git/vercel-for-github#repository-dispatch-events)), I discovered a critical limitation:

- `repository_dispatch` events **only trigger workflows on the default branch (main)**
- Feature branch workflows are completely **ignored**, even if the workflow file exists on those branches
- This means E2E tests won't run for feature branch deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workflow trigger for end-to-end tests to use deployment status events, ensuring tests run only on successful deployments.
  * Added a warning to prevent configuration that could cause infinite workflow loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->