### PR TITLE
feat: add split-pr command for managing large pull requests

### DIFF
--- a/.claude/commands/split-pr.md
+++ b/.claude/commands/split-pr.md
@@ -37,5 +37,12 @@ Split the current large pull request into smaller, manageable PRs following thes
 3. Get user approval
 4. Create branches and PRs in sequence
 5. Write appropriate descriptions for each PR
+6. **Create all PRs as Draft** to prevent premature reviews
+
+### Important Notes
+
+- All split PRs should be created as **Draft Pull Requests**
+- Only convert to "Ready for review" after all dependent PRs are created
+- This ensures reviewers don't start reviewing incomplete chains
 
 $ARGUMENTS

--- a/.claude/commands/split-pr.md
+++ b/.claude/commands/split-pr.md
@@ -1,0 +1,41 @@
+---
+description: Split a large pull request into smaller, focused PRs following best practices
+---
+
+## Task
+
+Split the current large pull request into smaller, manageable PRs following these guidelines:
+
+### PR Splitting Guidelines
+
+1. **Focus on One Purpose**
+   - Each PR should have a single purpose (bug fix, new feature, or refactoring)
+   - Don't mix multiple objectives in one PR
+
+2. **Keep Reviewable Size**
+   - Ideal: 50-200 lines of changes per PR
+   - Split PRs that are too large
+
+3. **Clear Descriptions**
+   - Clearly state the purpose, scope, and test results
+   - Make it easy for reviewers to understand
+
+### Splitting Strategy
+
+1. Analyze current changes and propose logical splits
+2. Consider dependencies when ordering splits
+3. Create chained PRs:
+   - PR1: Target main branch
+   - PR2: Target PR1's branch
+   - PR3: Target PR2's branch
+   - Continue chaining as needed
+
+### Execution Steps
+
+1. Review current changes
+2. Propose split plan (purpose and files for each PR)
+3. Get user approval
+4. Create branches and PRs in sequence
+5. Write appropriate descriptions for each PR
+
+$ARGUMENTS


### PR DESCRIPTION
## Issue

- N/A (Enhancement)

## Why is this change needed?

To help developers manage large pull requests more effectively by providing a custom Claude command that assists in splitting them into smaller, focused PRs following best practices.

## What would you like reviewers to focus on?

- The clarity and completeness of the command instructions
- Whether the guidelines align with the team's PR best practices

## Testing Verification

This is a documentation/tooling addition that doesn't affect runtime code. The command has been created and is ready for use with Claude Code.

## What was done

Added a new custom Claude command `/split-pr` that provides guidelines and a structured approach for splitting large pull requests into smaller, manageable ones.

### Key features:
- Clear guidelines for PR size (50-200 lines ideal)
- Single-purpose PR principle
- Chained PR creation strategy
- Step-by-step execution process
- All instructions in English

## Additional Notes

This command can be used immediately by typing `/split-pr` in Claude Code to help manage large pull requests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guideline document outlining best practices and step-by-step instructions for splitting large pull requests into smaller, focused PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->