### PR TITLE
🐛 fix (command palette): modify href to retains the current search params

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx
@@ -14,6 +14,13 @@ import { TableNode } from '../../ERDContent/components'
 import styles from './CommandPalette.module.css'
 import { useCommandPalette } from './CommandPaletteProvider'
 
+const getTableLinkHref = (activeTableName: string) => {
+  if (typeof window === 'undefined') return
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.set('active', activeTableName)
+  return `?${searchParams.toString()}`
+}
+
 export const CommandPalette: FC = () => {
   const { open, setOpen, toggleOpen } = useCommandPalette()
 
@@ -50,7 +57,7 @@ export const CommandPalette: FC = () => {
 
       if (event.key === 'Enter') {
         if (event.metaKey || event.ctrlKey) {
-          window.open(`?active=${tableName}`)
+          window.open(getTableLinkHref(tableName))
         } else {
           goToERD(tableName)
         }
@@ -99,7 +106,7 @@ export const CommandPalette: FC = () => {
             {Object.values(schema.current.tables).map((table) => (
               <Command.Item key={table.name} value={table.name} asChild>
                 <a
-                  href={`?active=${table.name}`}
+                  href={getTableLinkHref(table.name)}
                   onClick={(event) => {
                     // Do not call preventDefault to allow the default link behavior when ⌘ key is pressed
                     if (event.ctrlKey || event.metaKey) {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/pull/2387/files#r2191222791

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

The href in the CommandPalette links don't retain the search params other than `active` in the current version. This PR will modify href to retains  the current search params.

![Screenshot 0007-07-10 at 8 23 40](https://github.com/user-attachments/assets/2872a9e0-8816-431b-8477-0d817d184f29)

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

- implementation of `getTableLinkHref` function

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

1. visit https://liam-app-git-fix-command-palette-complete-href-liambx.vercel.app/
2. modify show mode to update search params
3. press ⌘K to open the dialog
4. click option with holding ⌘ to open the link in a new tab
5. check the url

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 9575e77762ebb28401c23d0ce15cb58d0fb75162

- Fix command palette links to preserve current search parameters
- Add `getTableLinkHref` function to maintain URL state
- Update both keyboard navigation and click handlers


## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Fix command palette href generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalette.tsx

<li>Add <code>getTableLinkHref</code> helper function to preserve URL search parameters<br> <li> Update href generation in Command.Item links to use new function<br> <li> Modify keyboard Enter handler to use new href generation<br> <li> Ensure all existing search params are retained when navigating


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2455/files#diff-94c7028698d83655392638264848d9a70ea1e476877bee9806d9e5d7b61e1780">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<!-- Any additional information for reviewers -->

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how table links are generated in the command palette for more robust and consistent URL handling. No visible changes to behavior or appearance for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->