### PR TITLE
feat: add DML generation prompts with tests

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/dmlGenerationAgent/prompts.test.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/dmlGenerationAgent/prompts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DML_GENERATION_SYSTEM_PROMPT,
+  DML_GENERATION_USER_PROMPT,
+} from './prompts'
+
+describe('DML Generation Prompts', () => {
+  describe('System Prompt', () => {
+    it('should be a non-empty string', () => {
+      expect(DML_GENERATION_SYSTEM_PROMPT).toBeDefined()
+      expect(typeof DML_GENERATION_SYSTEM_PROMPT).toBe('string')
+      expect(DML_GENERATION_SYSTEM_PROMPT.length).toBeGreaterThan(0)
+    })
+
+    it('should contain key instructions for DML generation', () => {
+      expect(DML_GENERATION_SYSTEM_PROMPT).toContain('INSERT')
+      expect(DML_GENERATION_SYSTEM_PROMPT).toContain('schema')
+      expect(DML_GENERATION_SYSTEM_PROMPT).toContain('use cases')
+    })
+
+    it('should include formatting guidelines', () => {
+      expect(DML_GENERATION_SYSTEM_PROMPT).toContain('format')
+      expect(DML_GENERATION_SYSTEM_PROMPT).toContain('comments')
+    })
+  })
+
+  describe('User Prompt', () => {
+    it('should be a non-empty string', () => {
+      expect(DML_GENERATION_USER_PROMPT).toBeDefined()
+      expect(typeof DML_GENERATION_USER_PROMPT).toBe('string')
+      expect(DML_GENERATION_USER_PROMPT.length).toBeGreaterThan(0)
+    })
+
+    it('should contain placeholders for schema and use cases', () => {
+      expect(DML_GENERATION_USER_PROMPT).toContain('{schemaSQL}')
+      expect(DML_GENERATION_USER_PROMPT).toContain('{formattedUseCases}')
+    })
+
+    it('should have proper structure with sections', () => {
+      expect(DML_GENERATION_USER_PROMPT).toContain('Schema:')
+      expect(DML_GENERATION_USER_PROMPT).toContain('Use Cases:')
+    })
+  })
+})

--- a/frontend/internal-packages/agent/src/langchain/agents/dmlGenerationAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/dmlGenerationAgent/prompts.ts
@@ -1,0 +1,24 @@
+export const DML_GENERATION_SYSTEM_PROMPT = `You are a database expert specializing in generating Data Manipulation Language (DML) statements.
+Your task is to create appropriate INSERT statements based on the provided database schema and use cases.
+
+Guidelines:
+1. Generate realistic sample data that aligns with the use cases
+2. Ensure foreign key constraints are respected
+3. Use meaningful test data that demonstrates the functionality
+4. Include comments to explain the purpose of each INSERT statement
+5. Group related inserts together logically
+
+Output format:
+- SQL INSERT statements with appropriate comments
+- Each statement should be on its own line
+- Include explanatory comments above each group of related inserts`
+
+export const DML_GENERATION_USER_PROMPT = `Based on the following database schema and use cases, generate appropriate DML (INSERT) statements:
+
+Schema:
+{schemaSQL}
+
+Use Cases:
+{formattedUseCases}
+
+Please generate INSERT statements that provide sample data to support these use cases.`


### PR DESCRIPTION
## Summary
- Add system and user prompts for DML generation
- Include comprehensive tests to verify prompt structure and content
- Part 2/13 of implementing DML generation functionality
- Depends on: #2467

## Test plan
- [x] Run unit tests: `pnpm test src/langchain/agents/dmlGenerationAgent/prompts.test.ts`
- [x] Verify linting passes: `pnpm lint`
- [x] Check that prompts contain required placeholders and instructions

🤖 Generated with [Claude Code](https://claude.ai/code)