### PR TITLE
🔧 Add permission denial for schema.sql file editing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [],
     "deny": [
-      "Bash(git commit --no-verify:*)"
+      "Bash(git commit --no-verify:*)",
+      "Edit(frontend/internal-packages/db/schema/schema.sql)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,6 @@ pnpm --filter @liam-hq/cli build
 For database migration and type generation workflows, see [`docs/migrationOpsContext.md`](docs/migrationOpsContext.md).
 
 ### Schema Changes
-- Schema files (schema.sql) must never be edited directly
 - Always use the following migration workflow:
   1. `pnpm -F db supabase:migration:new <MIGRATION_NAME>`
   2. Write DDL in the generated migration file


### PR DESCRIPTION
## Issue

- resolve: N/A (Infrastructure/tooling improvement)

## Why is this change needed?
<\!-- Please explain briefly why this change is necessary -->

This change adds a permission denial rule to prevent accidental modifications to the database schema file through Claude Code. The schema.sql file contains critical database structure definitions that should be protected from unintended edits.

## What would you like reviewers to focus on?
<\!-- What specific aspects are you requesting review for? -->

- Review the permission configuration in `.claude/settings.json`
- Confirm that the denied path is correct for the database schema file
- Ensure this change aligns with our development workflow and security practices

## Testing Verification
<\!-- Please describe how you verified these changes in your local environment using text/images/video -->

Verified that the Edit tool is properly denied access to the schema.sql file by attempting to edit it and confirming the permission denial works as expected.

## What was done
<\!-- This section will be filled by PR-Agent when the Pull Request is opened -->

### 🤖 Generated by PR Agent at 7ef91f0bda010bc7769638741641b01e6b7b16fe

- Add permission denial for `schema.sql` file editing in Claude settings
- Remove explicit schema editing restriction from documentation
- Enforce database schema protection at tool permission level


## Detailed Changes
<\!-- This section will be filled by PR-Agent when the Pull Request is opened -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Add schema.sql edit permission denial</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/settings.json

<li>Add Edit permission denial for <br><code>frontend/internal-packages/db/schema/schema.sql</code><br> <li> Prevent accidental schema modifications through Claude Code


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2476/files#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Remove explicit schema editing restriction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<li>Remove explicit mention of schema.sql editing restriction<br> <li> Rely on tool-level permission enforcement instead


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2476/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
<\!-- Any additional information for reviewers -->

This is a defensive measure to prevent accidental schema modifications. The database schema file should only be modified through proper migration processes, not through direct editing via Claude Code.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permissions to explicitly disallow direct edits to a specific SQL schema file.
* **Documentation**
  * Removed the statement prohibiting direct edits to schema files from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->