### PR TITLE
🔧 fix(workflows): Add allowed_tools to Claude PR creator workflow

### DIFF
--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -47,6 +47,11 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_app_id: ${{ secrets.LIAM_CODE_ASSISTANT_APP_ID }}
           github_app_private_key: ${{ secrets.LIAM_CODE_ASSISTANT_PRIVATE_KEY }}
+          allowed_tools: |
+            Bash(pnpm fmt:*),
+            Bash(pnpm install),
+            Bash(pnpm lint:*),
+            Bash(pnpm test:*)
           direct_prompt: |
             Please implement based on Issue #${{ github.event.issue.number }}:
 


### PR DESCRIPTION

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I noticed that Claude Code Action couldn't run lint and other commands because we hadn't  configured the appropriate allowed_tools. I discovered this while experimenting with PR  below.
- https://github.com/liam-hq/liam/pull/2484

 This has now been fixed by adding  the necessary tool permissions.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->

## Testing Verification
<!-- Please describe how you verified these changes in your local environment using text/images/video -->

## What was done
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:summary

## Detailed Changes
<!-- This section will be filled by PR-Agent when the Pull Request is opened -->

pr_agent:walkthrough

## Additional Notes
<!-- Any additional information for reviewers -->
