### PR TITLE
🔧 Improve trigger.dev cleanup workflow robustness

### DIFF
--- a/.github/workflows/trigger_dev_preview_cleanup.yml
+++ b/.github/workflows/trigger_dev_preview_cleanup.yml
@@ -11,6 +11,9 @@ jobs:
   cleanup_stale_previews:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: trigger_dev_preview_cleanup
+      cancel-in-progress: false
     permissions:
       contents: read
       pull-requests: read
@@ -28,49 +31,45 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "Searching for closed and unmerged PRs..."
-          
-          # Get closed but unmerged PRs
-          CLOSED_BRANCHES=$(gh pr list --state closed --limit 300 --json headRefName,mergedAt | jq -r '.[] | select(.mergedAt == null) | .headRefName' | sort -u)
-          
+
+          # Get closed but unmerged latest PRs
+          CLOSED_BRANCHES=$(gh pr list --state closed --limit 200 --json headRefName,mergedAt | jq -r '.[] | select(.mergedAt == null) | .headRefName' | sort -u || true)
+
           if [ -z "$CLOSED_BRANCHES" ]; then
             echo "No closed unmerged PRs found"
             exit 0
           fi
-          
+
           echo "Found branches from closed unmerged PRs:"
           echo "$CLOSED_BRANCHES"
           echo ""
-          
-          # Process each branch
-          while IFS= read -r BRANCH; do
+
+          # Process each branch using a for loop instead of while
+          for BRANCH in $CLOSED_BRANCHES; do
             if [ -z "$BRANCH" ]; then
               continue
             fi
-            
-            echo "Checking branch: $BRANCH"
-            
-            # Check if there are any open PRs for this branch
-            OPEN_PRS=$(gh pr list --head "$BRANCH" --state open --json number | jq '. | length')
-            
-            if [ "$OPEN_PRS" -gt 0 ]; then
-              echo "  → Branch has $OPEN_PRS open PR(s), skipping"
-              continue
-            fi
-            
-            echo "  → No open PRs found, attempting to archive preview environment"
-            
+
+            # NOTE: We intentionally archive preview environments even if there are open PRs
+            # This aggressive cleanup ensures we don't accumulate stale preview environments
+            # from long-running or abandoned branches
+            echo "  → Attempting to archive preview environment: $BRANCH"
+
             # Attempt to archive the preview environment
-            if pnpm --filter @liam-hq/jobs exec trigger preview archive --branch "$BRANCH" 2>/dev/null; then
-              echo "  ✓ Successfully archived preview for branch: $BRANCH"
+            # Capture both stdout and stderr to check for failure messages
+            ARCHIVE_OUTPUT=$(pnpm --filter @liam-hq/jobs exec trigger preview archive --branch "$BRANCH" 2>&1)
+
+            # Check if the output contains "Failed to archive"
+            if echo "$ARCHIVE_OUTPUT" | grep -q "Failed to archive"; then
+              echo "  → Archive command failed (environment may not exist or already archived): $BRANCH"
             else
-              # If archive fails, it might already be archived or doesn't exist
-              echo "  → Archive command failed (environment may not exist or already archived)"
+              echo "  ✓ Successfully archived preview for branch: $BRANCH"
             fi
-            
+
             # Small delay to avoid rate limiting
-            sleep 2
-            
-          done <<< "$CLOSED_BRANCHES"
-          
+            sleep 1
+
+          done
+
           echo ""
           echo "Cleanup process completed"


### PR DESCRIPTION
## Issue

- resolve: Follow-up improvements to #2497

## Why is this change needed?
The cleanup workflow from #2497 had issues with loop continuation when encountering errors. Additionally, we need more aggressive cleanup that archives preview environments even if open PRs exist.

## What would you like reviewers to focus on?
- The switch from `while` loop to `for` loop for better reliability
- The aggressive cleanup approach (archiving even with open PRs)
- Error handling improvements

## Testing Verification
tested: https://github.com/liam-hq/liam/actions/runs/16190900195

## What was done
- Switched from `while` loop with file redirection to `for` loop for better reliability
- Removed PR existence check to enable aggressive cleanup of all closed unmerged branches
- Added explicit comment explaining the aggressive cleanup strategy
- Improved error handling to ensure loop continuation
- Better output parsing for trigger.dev archive command failures

### 🤖 Generated by PR Agent at 9850e2466d471bee7bfd5a44a6987913676eb8aa

- Switch from while loop to for loop for better reliability
- Remove PR existence check for aggressive cleanup
- Improve error handling and output parsing
- Add concurrency control to prevent parallel runs


## Detailed Changes

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trigger_dev_preview_cleanup.yml</strong><dd><code>Enhance cleanup workflow reliability and aggressiveness</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/trigger_dev_preview_cleanup.yml

<li>Switch from <code>while</code> loop to <code>for</code> loop for better reliability<br> <li> Remove open PR check to enable aggressive cleanup<br> <li> Improve error handling with output parsing<br> <li> Add concurrency control to prevent parallel workflow runs


</details>


  </td>
  <td><a href="https://github.com/liam-hq/liam/pull/2501/files#diff-7a586374bcc492ea0729e680ed0572841af66db7426a71bf96fc81ff05073773">+30/-31</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

## Additional Notes
This is a follow-up to #2497 based on testing feedback. The workflow now more aggressively cleans up preview environments to prevent accumulation of stale resources.

🤖 Generated with [Claude Code](https://claude.ai/code)

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and efficiency of the development preview cleanup workflow, including better error handling and faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->