### PR TITLE
fix: enable noUnusedImports rule and remove unused imports

### DIFF
--- a/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/layout.tsx
+++ b/frontend/apps/app/app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/layout.tsx
@@ -1,6 +1,5 @@
 import * as v from 'valibot'
 import type { LayoutProps } from '@/app/types'
-import {} from '@/components'
 import { CommonLayout } from '@/components/CommonLayout'
 import { ProjectLayout } from '@/components/ProjectLayout'
 import { branchOrCommitSchema } from '@/libs/routes'

--- a/frontend/apps/app/features/sessions/actions/createSession.ts
+++ b/frontend/apps/app/features/sessions/actions/createSession.ts
@@ -3,7 +3,6 @@
 import { createHash } from 'node:crypto'
 import path from 'node:path'
 import type { SupabaseClientType } from '@liam-hq/db'
-import type { TablesInsert } from '@liam-hq/db/supabase/database.types'
 import type { Schema } from '@liam-hq/db-structure'
 import { parse, setPrismWasmUrl } from '@liam-hq/db-structure/parser'
 import { getFileContent } from '@liam-hq/github'

--- a/frontend/apps/app/features/sessions/components/SessionForm/SchemaInfoSection/SchemaInfoSection.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SchemaInfoSection/SchemaInfoSection.tsx
@@ -11,7 +11,7 @@ import type { FormatType } from '../../../../../components/FormatIcon/FormatIcon
 import { FormatIcon } from '../../../../../components/FormatIcon/FormatIcon'
 import { FormatSelectDropdown } from '../FormatSelectDropdown'
 import { SchemaLink } from '../SchemaLink'
-import { type ErrorInfo, ViewErrorsCollapsible } from '../ViewErrorsCollapsible'
+import { ViewErrorsCollapsible } from '../ViewErrorsCollapsible'
 import styles from './SchemaInfoSection.module.css'
 
 // Helper function to parse error message and wrap code in backticks with Code component

--- a/frontend/apps/app/features/sessions/components/SessionForm/UploadSessionFormPresenter/UploadSessionFormPresenter.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/UploadSessionFormPresenter/UploadSessionFormPresenter.tsx
@@ -1,12 +1,7 @@
-import { Button } from '@liam-hq/ui'
 import clsx from 'clsx'
 import { type ChangeEvent, type FC, useRef, useState } from 'react'
-import {
-  FormatIcon,
-  type FormatType,
-} from '../../../../../components/FormatIcon/FormatIcon'
+import { type FormatType } from '../../../../../components/FormatIcon/FormatIcon'
 import { AttachmentsContainer } from '../AttachmentsContainer'
-import { FormatSelectDropdown } from '../FormatSelectDropdown'
 import { useFileAttachments } from '../hooks/useFileAttachments'
 import { useFileDragAndDrop } from '../hooks/useFileDragAndDrop'
 import { SessionFormActions } from '../SessionFormActions'

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -24,8 +24,7 @@
       "correctness": {
         "noUndeclaredDependencies": "error",
         "noUndeclaredVariables": "error",
-        // TODO: Re-enable noUnusedImports after fixing unused imports
-        "noUnusedImports": "off",
+        "noUnusedImports": "error",
         // TODO: Re-enable noUnusedVariables after fixing unused variables
         "noUnusedVariables": "off",
         // TODO: Re-enable useExhaustiveDependencies after fixing hook dependencies


### PR DESCRIPTION
Fix unused imports and enable noUnusedImports rule

## Changes
- Remove unused imports from 4 files in the main app package
- Enable noUnusedImports rule in biome.jsonc configuration
- Fix violations: empty import, unused type imports, unused component imports

Resolves #2315

Generated with [Claude Code](https://claude.ai/code)