### PR TITLE
feat: add pre-commit hooks for MCP GitHub API commits

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github_file_ops__commit_files",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-mcp-commit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/pre-mcp-commit.sh
+++ b/.claude/hooks/pre-mcp-commit.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Find git root directory
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$GIT_ROOT" ]; then
+  echo '{"continue": false, "message": "Not in a git repository"}' | jq -c
+  exit 2
+fi
+
+cd "$GIT_ROOT"
+
+echo "Running pre-commit checks before MCP GitHub commit..."
+
+# Run pnpm fmt
+echo "Running pnpm fmt..."
+pnpm fmt
+FMT_EXIT=$?
+
+# Run pnpm lint
+echo "Running pnpm lint..."
+pnpm lint
+LINT_EXIT=$?
+
+if [ $FMT_EXIT -eq 0 ] && [ $LINT_EXIT -eq 0 ]; then
+  echo "Pre-commit checks passed!"
+  echo '{"continue": true}' | jq -c
+else
+  echo "Pre-commit checks failed!"
+  echo '{"continue": false, "message": "Pre-commit checks failed. Please fix formatting and linting issues before committing via GitHub API."}' | jq -c
+  exit 2
+fi


### PR DESCRIPTION
## Summary
- Add Claude Code hooks to run formatting and linting before MCP GitHub API commits
- Ensures code quality checks are enforced even when using GitHub API directly
- Automatically runs from git repository root regardless of current working directory

## Test plan
- [ ] Test that `mcp__github_file_ops__commit_files` triggers the pre-commit hook
- [ ] Verify that commits are blocked if `pnpm fmt` or `pnpm lint` fails
- [ ] Confirm that commits proceed when all checks pass
- [ ] Test that the hook works from any subdirectory within the repository

🤖 Generated with [Claude Code](https://claude.ai/code)