### PR TITLE
🔧 Update CodeRabbit configuration to disable high-level summaries

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
-
 reviews:
   review_status: false
+  high_level_summary: false


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?
CodeRabbit's high-level summaries were enabled by default, but they may not be needed for our workflow. This change disables the high-level summary feature to streamline the review process and reduce noise in PR reviews.
