### PR TITLE
♻️ Refactor database schema design workflow to use function agents and messages

### DIFF
--- a/frontend/internal-packages/agent/eslint-suppressions.json
+++ b/frontend/internal-packages/agent/eslint-suppressions.json
@@ -1,14 +1,6 @@
 {
-  "src/chat/workflow/nodes/designSchemaNode.integration.test.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 3
-    }
-  },
   "src/deepModeling.test.ts": {
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
-    "no-throw-error/no-throw-error": {
       "count": 1
     }
   },

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
@@ -61,7 +61,7 @@ export async function analyzeRequirementsNode(
           ...state.messages,
           new AIMessage({
             content: result.businessRequirement,
-            name: 'PM Analysis Agent',
+            name: 'PMAnalysisAgent',
           }),
         ],
         analyzedRequirements: {

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
@@ -1,12 +1,12 @@
+import { AIMessage } from '@langchain/core/messages'
+import { ok } from 'neverthrow'
 import { describe, expect, it, vi } from 'vitest'
 import type { WorkflowState } from '../types'
 import { designSchemaNode } from './designSchemaNode'
 
-// Mock the agents
-vi.mock('../../../langchain/agents', () => ({
-  DatabaseSchemaBuildAgent: vi.fn().mockImplementation(() => ({
-    generate: vi.fn(),
-  })),
+// Mock the design agent
+vi.mock('../../../langchain/agents/databaseSchemaBuildAgent/agent', () => ({
+  invokeDesignAgent: vi.fn(),
 }))
 
 // Mock the schema converter
@@ -17,21 +17,15 @@ vi.mock('../../../utils/convertSchemaToText', () => ({
 describe('designSchemaNode retry behavior', () => {
   it('should include DDL failure reason in user message when retrying', async () => {
     // Setup the mock implementation
-    const { DatabaseSchemaBuildAgent } = await import(
-      '../../../langchain/agents'
+    const { invokeDesignAgent } = await import(
+      '../../../langchain/agents/databaseSchemaBuildAgent/agent'
     )
-    const mockGenerate = vi.fn().mockResolvedValue({
-      schema: { tables: {} },
-      schemaChanges: [],
-      message: 'Schema generated successfully',
-    })
-
-    vi.mocked(DatabaseSchemaBuildAgent).mockImplementation(
-      () =>
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        ({
-          generate: mockGenerate,
-        }) as never,
+    const mockInvokeDesignAgent = vi.mocked(invokeDesignAgent)
+    mockInvokeDesignAgent.mockResolvedValue(
+      ok({
+        message: new AIMessage('Schema generated successfully'),
+        operations: [],
+      }),
     )
 
     const mockRepositories = {
@@ -80,16 +74,19 @@ describe('designSchemaNode retry behavior', () => {
 
     await designSchemaNode(state, config)
 
-    // Check the generate call arguments
-    expect(mockGenerate).toHaveBeenCalledWith(
+    // Check the invoke call arguments
+    expect(mockInvokeDesignAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        user_message: expect.stringContaining('Create a users table'),
+        schemaText: expect.any(String),
       }),
-    )
-    expect(mockGenerate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user_message: expect.stringContaining('Foreign key constraint error'),
-      }),
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining('Create a users table'),
+        }),
+        expect.objectContaining({
+          content: expect.stringContaining('Foreign key constraint error'),
+        }),
+      ]),
     )
   })
 })

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -11,8 +11,6 @@ import { getConfigurable } from '../shared/getConfigurable'
 import type { WorkflowState } from '../types'
 import { logAssistantMessage } from '../utils/timelineLogger'
 
-const NODE_NAME = 'designSchemaNode'
-
 const formatAnalyzedRequirements = (
   analyzedRequirements: NonNullable<WorkflowState['analyzedRequirements']>,
 ): string => {

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
@@ -114,7 +114,7 @@ export async function generateUsecaseNode(
           ...state.messages,
           new AIMessage({
             content: `Generated ${generatedResult.usecases.length} use cases for testing and validation`,
-            name: 'QA Generate Usecase Agent',
+            name: 'QAGenerateUsecaseAgent',
           }),
         ],
         generatedUsecases: generatedResult.usecases,

--- a/frontend/internal-packages/agent/src/deepModeling.test.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.test.ts
@@ -1,4 +1,6 @@
+import { AIMessage } from '@langchain/core/messages'
 import type { Schema } from '@liam-hq/db-structure'
+import { ResultAsync } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { type DeepModelingParams, deepModeling } from './deepModeling'
 import type { Repositories, SchemaRepository } from './repositories'
@@ -6,9 +8,13 @@ import type { NodeLogger } from './utils/nodeLogger'
 
 // Mock the agents
 vi.mock('./langchain/agents', () => ({
-  DatabaseSchemaBuildAgent: vi.fn(),
   QAGenerateUsecaseAgent: vi.fn(),
   PMAnalysisAgent: vi.fn(),
+}))
+
+// Mock the design agent
+vi.mock('./langchain/agents/databaseSchemaBuildAgent/agent', () => ({
+  invokeDesignAgent: vi.fn(),
 }))
 
 // Mock the schema converter
@@ -44,13 +50,10 @@ vi.mock('@liam-hq/pglite-server', () => ({
 
 describe('Chat Workflow', () => {
   let mockSchemaData: Schema
-  let mockAgent: {
-    generate: ReturnType<typeof vi.fn>
-  }
   let mockPMAnalysisAgent: {
     analyzeRequirements: ReturnType<typeof vi.fn>
   }
-  let MockDatabaseSchemaBuildAgent: ReturnType<typeof vi.fn>
+  let mockInvokeDesignAgent: ReturnType<typeof vi.fn>
   let MockQAGenerateUsecaseAgent: ReturnType<typeof vi.fn>
   let MockPMAnalysisAgent: ReturnType<typeof vi.fn>
   let mockRepositories: Repositories
@@ -133,7 +136,7 @@ describe('Chat Workflow', () => {
       expect(result.value.text).toBe('Mocked agent response')
       expect(typeof result.value.text).toBe('string')
     }
-    expect(mockAgent.generate).toHaveBeenCalledOnce()
+    expect(mockInvokeDesignAgent).toHaveBeenCalledOnce()
 
     return result
   }
@@ -144,10 +147,11 @@ describe('Chat Workflow', () => {
 
     // Get the mocked modules
     const agentsModule = await import('./langchain/agents')
-
-    MockDatabaseSchemaBuildAgent = vi.mocked(
-      agentsModule.DatabaseSchemaBuildAgent,
+    const designAgentModule = await import(
+      './langchain/agents/databaseSchemaBuildAgent/agent'
     )
+
+    mockInvokeDesignAgent = vi.mocked(designAgentModule.invokeDesignAgent)
     MockPMAnalysisAgent = vi.mocked(agentsModule.PMAnalysisAgent)
     MockQAGenerateUsecaseAgent = vi.mocked(agentsModule.QAGenerateUsecaseAgent)
 
@@ -179,13 +183,15 @@ describe('Chat Workflow', () => {
     // Create mock schema data
     mockSchemaData = createMockSchema()
 
-    // Mock agent
-    mockAgent = {
-      generate: vi.fn().mockResolvedValue({
-        message: 'Mocked agent response',
-        schemaChanges: [],
-      }),
-    }
+    // Mock design agent response
+    mockInvokeDesignAgent.mockResolvedValue(
+      ResultAsync.fromSafePromise(
+        Promise.resolve({
+          message: new AIMessage('Mocked agent response'),
+          operations: [],
+        }),
+      ),
+    )
 
     // Mock PM Analysis agent
     mockPMAnalysisAgent = {
@@ -200,8 +206,7 @@ describe('Chat Workflow', () => {
       }),
     }
 
-    // Setup agent mocks
-    MockDatabaseSchemaBuildAgent.mockImplementation(() => mockAgent)
+    // Agent mock is already set up above
     MockPMAnalysisAgent.mockImplementation(() => mockPMAnalysisAgent)
     MockQAGenerateUsecaseAgent.mockImplementation(() => ({
       generate: vi.fn().mockResolvedValue({
@@ -300,7 +305,14 @@ describe('Chat Workflow', () => {
         ],
       }
 
-      mockAgent.generate.mockResolvedValue(structuredResponse)
+      mockInvokeDesignAgent.mockResolvedValue(
+        ResultAsync.fromSafePromise(
+          Promise.resolve({
+            message: new AIMessage(structuredResponse.message),
+            operations: structuredResponse.schemaChanges,
+          }),
+        ),
+      )
 
       const params = createBaseParams({
         userInput: 'Add a created_at timestamp column to the users table',
@@ -333,10 +345,14 @@ describe('Chat Workflow', () => {
     })
 
     it('should handle Build mode with invalid JSON response gracefully', async () => {
-      mockAgent.generate.mockResolvedValue({
-        message: 'Invalid JSON response',
-        schemaChanges: [],
-      })
+      mockInvokeDesignAgent.mockResolvedValue(
+        ResultAsync.fromSafePromise(
+          Promise.resolve({
+            message: new AIMessage('Invalid JSON response'),
+            operations: [],
+          }),
+        ),
+      )
 
       const params = createBaseParams({
         userInput: 'Add a created_at timestamp column to the users table',
@@ -363,7 +379,14 @@ describe('Chat Workflow', () => {
         ],
       }
 
-      mockAgent.generate.mockResolvedValue(structuredResponse)
+      mockInvokeDesignAgent.mockResolvedValue(
+        ResultAsync.fromSafePromise(
+          Promise.resolve({
+            message: new AIMessage(structuredResponse.message),
+            operations: structuredResponse.schemaChanges,
+          }),
+        ),
+      )
       vi.mocked(mockSchemaRepository.createVersion).mockResolvedValue({
         success: false,
         error: 'Database constraint violation',
@@ -399,7 +422,14 @@ describe('Chat Workflow', () => {
         ],
       }
 
-      mockAgent.generate.mockResolvedValue(structuredResponse)
+      mockInvokeDesignAgent.mockResolvedValue(
+        ResultAsync.fromSafePromise(
+          Promise.resolve({
+            message: new AIMessage(structuredResponse.message),
+            operations: structuredResponse.schemaChanges,
+          }),
+        ),
+      )
       vi.mocked(mockSchemaRepository.createVersion).mockRejectedValue(
         new Error('Network error'),
       )
@@ -429,7 +459,9 @@ describe('Chat Workflow', () => {
 
   describe('Error Handling', () => {
     it('should handle agent generation errors', async () => {
-      mockAgent.generate.mockRejectedValue(new Error('Agent generation failed'))
+      mockInvokeDesignAgent.mockRejectedValue(
+        new Error('Agent generation failed'),
+      )
       const params = createBaseParams()
 
       const result = await deepModeling(params, createConfig())
@@ -440,19 +472,17 @@ describe('Chat Workflow', () => {
       }
     })
 
-    it('should handle agent creation failure', async () => {
-      MockDatabaseSchemaBuildAgent.mockImplementation(() => {
-        throw new Error('Failed to create DatabaseSchemaBuildAgent')
-      })
+    it('should handle agent invocation failure', async () => {
+      mockInvokeDesignAgent.mockRejectedValue(
+        new Error('Failed to invoke design agent'),
+      )
       const params = createBaseParams()
 
       const result = await deepModeling(params, createConfig())
 
       expect(result.isErr()).toBe(true)
       if (result.isErr()) {
-        expect(result.error.message).toBe(
-          'Failed to create DatabaseSchemaBuildAgent',
-        )
+        expect(result.error.message).toBe('Failed to invoke design agent')
       }
     })
 
@@ -485,12 +515,12 @@ describe('Chat Workflow', () => {
   })
 
   describe('Agent Selection', () => {
-    it('should instantiate DatabaseSchemaBuildAgent', async () => {
+    it('should invoke design agent', async () => {
       const params = createBaseParams({})
 
       await deepModeling(params, createConfig())
 
-      expect(MockDatabaseSchemaBuildAgent).toHaveBeenCalledOnce()
+      expect(mockInvokeDesignAgent).toHaveBeenCalledOnce()
     })
   })
 

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/index.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/index.ts
@@ -1,1 +1,0 @@
-export { DatabaseSchemaBuildAgent } from './agent'

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -1,6 +1,6 @@
 import { ChatPromptTemplate } from '@langchain/core/prompts'
 
-const buildAgentSystemPrompt = `You are Build Agent, an energetic and innovative system designer who builds and edits ERDs with lightning speed.
+const designAgentSystemPrompt = `You are Design Agent, an energetic and innovative system designer who builds and edits ERDs with lightning speed.
 Your role is to execute user instructions immediately and offer smart suggestions for schema improvements.
 You speak in a lively, action-oriented tone, showing momentum and confidence.
 
@@ -131,12 +131,13 @@ Additional Constraint Examples:
 - Same options apply to "updateConstraint"
 
 Complete Schema Information:
-{schema_text}
+{schemaText}
+`
 
-Previous conversation:
-{chat_history}`
+export const designAgentPrompt = ChatPromptTemplate.fromTemplate(
+  designAgentSystemPrompt,
+)
 
-export const buildAgentPrompt = ChatPromptTemplate.fromMessages([
-  ['system', buildAgentSystemPrompt],
-  ['human', '{user_message}'],
-])
+export type DesignAgentPromptVariables = {
+  schemaText: string
+}

--- a/frontend/internal-packages/agent/src/langchain/agents/index.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/index.ts
@@ -1,3 +1,2 @@
-export { DatabaseSchemaBuildAgent } from './databaseSchemaBuildAgent'
 export { PMAnalysisAgent } from './pmAnalysisAgent'
 export { QAGenerateUsecaseAgent } from './qaGenerateUsecaseAgent'

--- a/frontend/internal-packages/agent/src/langchain/utils/types.ts
+++ b/frontend/internal-packages/agent/src/langchain/utils/types.ts
@@ -3,10 +3,6 @@ export type BasePromptVariables = {
   user_message: string
 }
 
-export type SchemaAwareChatVariables = BasePromptVariables & {
-  schema_text: string
-}
-
 export type ChatAgent<TVariables = BasePromptVariables, TResponse = string> = {
   generate(variables: TVariables): Promise<TResponse>
 }


### PR DESCRIPTION
## Issue

- resolve: #2504

## Why is this change needed?
Refactored DesignSchemaNode and Agent to utilize LangGraph messages. messages makes it easier to retry by adding errors to the end of the messages.We are working on addressing this in the next PR.


🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved schema design workflow with a new, streamlined design agent for database schema operations.

* **Refactor**
  * Replaced the previous class-based schema build agent with a functional design agent approach.
  * Updated prompts and agent naming conventions for clarity and consistency.
  * Simplified agent invocation and message handling for schema design tasks.

* **Bug Fixes**
  * Adjusted agent message sender names to ensure accurate identification in chat history.

* **Tests**
  * Updated and modernized test cases to use the new design agent interface and mocking strategy.

* **Chores**
  * Removed obsolete exports, types, and configuration suppressions related to the old agent implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->