### PR TITLE
💄 style(command palette): set border-radius of option

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.module.css
@@ -58,6 +58,7 @@
   padding: var(--spacing-2);
   align-items: center;
   line-height: 24px;
+  border-radius: var(--border-radius-base);
 }
 
 .main [cmdk-item] .itemText {


### PR DESCRIPTION
## Issue

~resolve:~
- fix for https://github.com/liam-hq/liam/pull/2014

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

To make it look prettier, I added border-radius.

|before|after|
|--|--|
|<img width="914" height="198" alt="Screenshot 0007-07-12 at 10 04 18" src="https://github.com/user-attachments/assets/b65927f6-f0f6-4dbb-9023-53ff18a1f309" />|<img width="914" height="198" alt="Screenshot 0007-07-12 at 10 04 12" src="https://github.com/user-attachments/assets/94a17c81-cd24-4b3d-9361-da34161e3f8e" />|


