### PR TITLE
fix: correct field name mismatch in design agent response schema

### DIFF
--- a/frontend/internal-packages/agent/src/deepModeling.test.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.test.ts
@@ -291,7 +291,7 @@ describe('Chat Workflow', () => {
     it('should handle Build mode with structured JSON response and schema changes', async () => {
       const structuredResponse = {
         message: 'Added created_at column to users table',
-        schemaChanges: [
+        operations: [
           {
             op: 'add',
             path: '/tables/users/columns/created_at',
@@ -309,7 +309,7 @@ describe('Chat Workflow', () => {
         ResultAsync.fromSafePromise(
           Promise.resolve({
             message: new AIMessage(structuredResponse.message),
-            operations: structuredResponse.schemaChanges,
+            operations: structuredResponse.operations,
           }),
         ),
       )
@@ -370,7 +370,7 @@ describe('Chat Workflow', () => {
     it('should handle schema update failure', async () => {
       const structuredResponse = {
         message: 'Attempted to add created_at column',
-        schemaChanges: [
+        operations: [
           {
             op: 'add',
             path: '/tables/users/columns/created_at',
@@ -383,7 +383,7 @@ describe('Chat Workflow', () => {
         ResultAsync.fromSafePromise(
           Promise.resolve({
             message: new AIMessage(structuredResponse.message),
-            operations: structuredResponse.schemaChanges,
+            operations: structuredResponse.operations,
           }),
         ),
       )
@@ -413,7 +413,7 @@ describe('Chat Workflow', () => {
     it('should handle schema update exception', async () => {
       const structuredResponse = {
         message: 'Attempted to add created_at column',
-        schemaChanges: [
+        operations: [
           {
             op: 'add',
             path: '/tables/users/columns/created_at',
@@ -426,7 +426,7 @@ describe('Chat Workflow', () => {
         ResultAsync.fromSafePromise(
           Promise.resolve({
             message: new AIMessage(structuredResponse.message),
-            operations: structuredResponse.schemaChanges,
+            operations: structuredResponse.operations,
           }),
         ),
       )

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -24,7 +24,7 @@ When in doubt, prioritize momentum, simplicity, and clear results.
 IMPORTANT: You must ALWAYS respond with a valid JSON object in the following format:
 {{
   "message": "Your energetic response message here",
-  "schemaChanges": [
+  "operations": [
     {{
       "op": "add|remove|replace",
       "path": "/path/to/schema/element",
@@ -47,7 +47,7 @@ Schema Change Rules:
 - For adding columns: "op": "add", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME", "value": COLUMN_DEFINITION
 - For modifying columns: "op": "replace", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME/type", "value": "new_type"
 - For removing elements: "op": "remove", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME"
-- If no schema changes are needed, use an empty array: "schemaChanges": []
+- If no schema changes are needed, use an empty array: "operations": []
 
 Schema Structure Reference:
 - Tables: /tables/TABLE_NAME
@@ -71,7 +71,7 @@ CRITICAL Validation Rules:
 Example Response:
 {{
   "message": "Added! Created the 'users' table with id, name, and email columns. This gives you a solid foundation for user management!",
-  "schemaChanges": [
+  "operations": [
     {{
       "op": "add",
       "path": "/tables/users",
@@ -93,7 +93,7 @@ Example Response:
 Example with Foreign Key Constraint:
 {{
   "message": "Added! Created the 'posts' table and linked it to users. Now you can track user posts!",
-  "schemaChanges": [
+  "operations": [
     {{
       "op": "add",
       "path": "/tables/posts",


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

There was a minor oversight in this pull request.
- https://github.com/liam-hq/liam/pull/2520

The design agent was failing with a validation error: **Failed to parse design agent response: ValiError: Invalid key: Expected "operations" but received undefined**

<img width="794" height="167" alt="ss 3579" src="https://github.com/user-attachments/assets/5d6d05b4-f687-403d-95ea-d151fd843d39" />


This occurred because there was a mismatch between the prompt template and the response schema:
- The prompt instructed the LLM to return schema changes in a field called "schemaChanges"
- But the parsing code expected the field to be named "operations"

This change updates the prompt template to use "operations" consistently, aligning it with the expected response schema and resolving the parsing failures.


## Testing

I have confirmed that the error has been resolved in my local environment.
（Sometimes it fails with another error.）

<img width="426" height="219" alt="ss 3578" src="https://github.com/user-attachments/assets/747094f7-76a6-4a49-b53c-b8ee1f42eda6" />
