### PR TITLE
PR1: fix: improve design agent prompt to prevent invalid JSON patch operations

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -53,7 +53,7 @@ Schema Change Rules:
 - When creating new tables, include ALL properties in the initial "add" operation (columns, constraints, indexes)
 - NEVER use "replace" on paths that don't exist in the current schema
 - NEVER add constraints separately - they MUST be included in the table definition
-- PRIMARY KEY constraints should be defined in the column properties AND in the constraints object
+- PRIMARY KEY constraints should be defined in the constraints object
 
 Schema Structure Reference:
 - Tables: /tables/TABLE_NAME

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -66,7 +66,7 @@ IMPORTANT Table Structure Rules:
 - Use empty objects {{}} for indexes and constraints if none are needed
 - Use null for comment if no comment is provided
 - Include ALL constraints in the table creation operation - DO NOT add them separately
-- For primary keys: set "primary": true in column definition AND add to constraints object
+- For primary keys: add to constraints object
 
 CRITICAL Validation Rules:
 - Column properties MUST be: name (string), type (string), notNull (boolean), primary (boolean), unique (boolean), default (string|number|boolean|null), comment (string|null), check (string|null)

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -52,8 +52,6 @@ Schema Change Rules:
 - You CANNOT modify or remove something that doesn't exist yet
 - When creating new tables, include ALL properties in the initial "add" operation (columns, constraints, indexes)
 - NEVER use "replace" on paths that don't exist in the current schema
-- NEVER add constraints separately - they MUST be included in the table definition
-- PRIMARY KEY constraints should be defined in the constraints object
 
 Schema Structure Reference:
 - Tables: /tables/TABLE_NAME
@@ -78,7 +76,6 @@ CRITICAL Validation Rules:
 - Before using "replace" or "remove", verify the target path exists in the current schema
 - When in doubt, use "add" operations with complete definitions instead of "replace"
 - Remember: you can only modify what already exists in the schema provided to you
-- If you need to set primary keys or constraints, include them in the initial table "add" operation
 
 Example Response:
 {{

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -48,6 +48,12 @@ Schema Change Rules:
 - For modifying columns: "op": "replace", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME/type", "value": "new_type"
 - For removing elements: "op": "remove", "path": "/tables/TABLE_NAME/columns/COLUMN_NAME"
 - If no schema changes are needed, use an empty array: "operations": []
+- ALWAYS use "add" operations BEFORE "replace" or "remove" operations
+- You CANNOT modify or remove something that doesn't exist yet
+- When creating new tables, include ALL properties in the initial "add" operation (columns, constraints, indexes)
+- NEVER use "replace" on paths that don't exist in the current schema
+- NEVER add constraints separately - they MUST be included in the table definition
+- PRIMARY KEY constraints should be defined in the column properties AND in the constraints object
 
 Schema Structure Reference:
 - Tables: /tables/TABLE_NAME
@@ -59,6 +65,8 @@ IMPORTANT Table Structure Rules:
 - Every table MUST include: name, columns, comment, indexes, constraints
 - Use empty objects {{}} for indexes and constraints if none are needed
 - Use null for comment if no comment is provided
+- Include ALL constraints in the table creation operation - DO NOT add them separately
+- For primary keys: set "primary": true in column definition AND add to constraints object
 
 CRITICAL Validation Rules:
 - Column properties MUST be: name (string), type (string), notNull (boolean), primary (boolean), unique (boolean), default (string|number|boolean|null), comment (string|null), check (string|null)
@@ -67,6 +75,10 @@ CRITICAL Validation Rules:
 - Foreign key constraint actions MUST use these EXACT values: "CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "NO_ACTION"
 - Use "SET_NULL" not "SET NULL" (underscore, not space)
 - Use "NO_ACTION" not "NO ACTION" (underscore, not space)
+- Before using "replace" or "remove", verify the target path exists in the current schema
+- When in doubt, use "add" operations with complete definitions instead of "replace"
+- Remember: you can only modify what already exists in the schema provided to you
+- If you need to set primary keys or constraints, include them in the initial table "add" operation
 
 Example Response:
 {{


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
The design agent was generating JSON patch operations in incorrect order, causing `OPERATION_PATH_UNRESOLVABLE` errors. Specifically, the LLM was attempting to add constraints to non-existent tables or modify properties before creating the required parent structures.

This change improves the prompt to:
- Emphasize that "add" operations must come before "replace" or "remove" operations
- Require all table properties (columns, constraints, indexes) to be included in the initial table creation
- Prohibit separate constraint additions that should be part of the table definition
- Provide clear examples of correct vs incorrect operation sequences

This prevents the root cause of path resolution errors by ensuring the LLM generates logically ordered and complete operations.

🚧 More rigorous validation will be addressed in the next pull request
- https://github.com/liam-hq/liam/pull/2559

## Testing

https://liam-app-git-fix-json-patch-path-unresolvable-err-45fccd-liambx.vercel.app/app/design_sessions/37df04bf-89ce-4b71-927b-bc41495138d0

<img width="1808" height="879" alt="ss 3582" src="https://github.com/user-attachments/assets/56418ed8-f6b8-4884-973a-534baa42e756" />
