### PR TITLE
fix: resolve message channel update error in design schema workflow

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -198,7 +198,11 @@ export async function designSchemaNode(
   // Clear retry flags after processing
   const finalResult = {
     ...result,
-    messages: [...messages, invokeResult.value.message],
+    messages: [
+      ...state.messages,
+      new HumanMessage(userMessage),
+      invokeResult.value.message,
+    ],
     shouldRetryWithDesignSchema: undefined,
     ddlExecutionFailureReason: undefined,
   }


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
<img width="369" height="253" alt="ss 3585" src="https://github.com/user-attachments/assets/7ab77da7-31ba-4919-af4e-ce8f88270e40" />

The workflow was failing with "Invalid update for channel 'messages'" errors due to incorrect message state management. The issue occurred because the code was creating a local `messages` array (including a new HumanMessage) and then referencing it when updating the workflow state, causing message duplication and serialization issues.



This change fixes the message update logic by:
- Building the final messages array directly from `state.messages`
- Adding the new HumanMessage and AI response in the correct sequence
- Avoiding references to intermediate message arrays that could cause state conflicts

This ensures proper message channel updates in the LangGraph workflow and prevents the workflow from crashing due to invalid state transitions.

## Testing

https://liam-app-git-fix-message-channel-update-error-liambx.vercel.app/app/design_sessions/5b7985d0-4152-42dd-9ddf-6453da0010d4

<img width="1813" height="889" alt="ss 3583" src="https://github.com/user-attachments/assets/2a44fc23-2379-4297-9442-37b0b8c59669" />

