### PR TITLE
fix: remove non-existent 'primary' property references from database schema prompts

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -85,9 +85,9 @@ Example Response:
         "comment": null,
         "indexes": {{}},
         "constraints": {{
-          "users_pkey": {{
+          "pk_users": {{
             "type": "PRIMARY KEY",
-            "name": "users_pkey",
+            "name": "pk_users",
             "columnNames": ["id"]
           }}
         }}

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -52,7 +52,7 @@ Schema Change Rules:
 Schema Structure Reference:
 - Tables: /tables/TABLE_NAME
 - Columns: /tables/TABLE_NAME/columns/COLUMN_NAME
-- Column properties: type, notNull, primary, unique, default, comment, check
+- Column properties: type, notNull, unique, default, comment, check
 - Table properties: name, columns, comment, indexes, constraints (ALL REQUIRED)
 
 IMPORTANT Table Structure Rules:
@@ -61,7 +61,7 @@ IMPORTANT Table Structure Rules:
 - Use null for comment if no comment is provided
 
 CRITICAL Validation Rules:
-- Column properties MUST be: name (string), type (string), notNull (boolean), primary (boolean), unique (boolean), default (string|number|boolean|null), comment (string|null), check (string|null)
+- Column properties MUST be: name (string), type (string), notNull (boolean), unique (boolean), default (string|number|boolean|null), comment (string|null), check (string|null)
 - All boolean values must be true/false, not strings
 - Constraint types: "PRIMARY KEY", "FOREIGN KEY", "UNIQUE", "CHECK"
 - Foreign key constraint actions MUST use these EXACT values: "CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "NO_ACTION"
@@ -78,13 +78,19 @@ Example Response:
       "value": {{
         "name": "users",
         "columns": {{
-          "id": {{"name": "id", "type": "uuid", "notNull": true, "primary": true, "default": "gen_random_uuid()", "comment": "Unique identifier for each user", "check": null, "unique": false}},
-          "name": {{"name": "name", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "Name of the user", "check": null, "unique": false}},
-          "email": {{"name": "email", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "User email required for login", "check": null, "unique": true}}
+          "id": {{"name": "id", "type": "uuid", "notNull": true, "default": "gen_random_uuid()", "comment": "Unique identifier for each user", "check": null, "unique": false}},
+          "name": {{"name": "name", "type": "text", "notNull": true, "default": null, "comment": "Name of the user", "check": null, "unique": false}},
+          "email": {{"name": "email", "type": "text", "notNull": true, "default": null, "comment": "User email required for login", "check": null, "unique": true}}
         }},
         "comment": null,
         "indexes": {{}},
-        "constraints": {{}}
+        "constraints": {{
+          "users_pkey": {{
+            "type": "PRIMARY KEY",
+            "name": "users_pkey",
+            "columnNames": ["id"]
+          }}
+        }}
       }}
     }}
   ]
@@ -100,13 +106,18 @@ Example with Foreign Key Constraint:
       "value": {{
         "name": "posts",
         "columns": {{
-          "id": {{"name": "id", "type": "uuid", "notNull": true, "primary": true, "default": "gen_random_uuid()", "comment": "Primary key for posts", "check": null, "unique": false}},
-          "title": {{"name": "title", "type": "text", "notNull": true, "primary": false, "default": null, "comment": "Post title", "check": null, "unique": false}},
-          "user_id": {{"name": "user_id", "type": "uuid", "notNull": true, "primary": false, "default": null, "comment": "References the user who created the post", "check": null, "unique": false}}
+          "id": {{"name": "id", "type": "uuid", "notNull": true, "default": "gen_random_uuid()", "comment": "Primary key for posts", "check": null, "unique": false}},
+          "title": {{"name": "title", "type": "text", "notNull": true, "default": null, "comment": "Post title", "check": null, "unique": false}},
+          "user_id": {{"name": "user_id", "type": "uuid", "notNull": true, "default": null, "comment": "References the user who created the post", "check": null, "unique": false}}
         }},
         "comment": null,
         "indexes": {{}},
         "constraints": {{
+          "posts_pkey": {{
+            "type": "PRIMARY KEY",
+            "name": "posts_pkey",
+            "columnNames": ["id"]
+          }},
           "posts_user_fk": {{
             "type": "FOREIGN KEY",
             "name": "posts_user_fk",

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -113,9 +113,9 @@ Example with Foreign Key Constraint:
         "comment": null,
         "indexes": {{}},
         "constraints": {{
-          "posts_pkey": {{
+          "pk_posts": {{
             "type": "PRIMARY KEY",
-            "name": "posts_pkey",
+            "name": "pk_posts",
             "columnNames": ["id"]
           }},
           "posts_user_fk": {{


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
The database schema build agent prompts incorrectly referenced a 'primary' property in column definitions, but this property doesn't exist in the actual column schema.

https://github.com/liam-hq/liam/blob/434b169c169b0fe597b47b8172949bb68fc9cd22/frontend/packages/db-structure/src/schema/schema.ts#L20-L27

Primary keys should only be defined through the constraints object using `primaryKeyConstraintSchema`, not as a column property. This mismatch could lead to confusion and incorrect schema generation attempts by the agent.

This change:
- Removes all references to the non-existent 'primary' column property
- Updates examples to show proper primary key definition via constraints
- Aligns the prompts with the actual schema structure

## Testing

https://liam-app-git-fix-remove-invalid-primary-column-property-liambx.vercel.app/app/design_sessions/88afe70f-8744-4d93-9367-2be2ac9a62fe?showMode=ALL_FIELDS

<img width="1771" height="864" alt="ss 3584" src="https://github.com/user-attachments/assets/04b82876-6825-41ce-a319-8a9309b8836d" />

