### PR TITLE
feat: Implement automated lint and format checks for Claude Code Actions

### DIFF
--- a/.github/scripts/setup-claude.sh
+++ b/.github/scripts/setup-claude.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure GITHUB_WORKSPACE is set
+if [ -z "${GITHUB_WORKSPACE:-}" ]; then
+    echo "❌ Error: GITHUB_WORKSPACE is not set" >&2
+    exit 1
+fi
+
+# Create Claude settings directory
+mkdir -p "$HOME/.claude"
+
+# Create settings.json with hooks configuration
+# Note: Using environment variable expansion here
+cat > "$HOME/.claude/settings.json" << EOF
+{
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github_file_ops__commit_files",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd $GITHUB_WORKSPACE && echo \"🔍 Pre-commit validation starting...\" >&2 && pnpm fmt && pnpm lint && echo \"✅ All checks passed\" >&2 || { echo \"❌ Pre-commit validation failed\" >&2 && exit 2; }'",
+            "run_in_background": false
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+echo "✅ Claude settings configured with pre-commit hook"

--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/pnpm-setup
 
+      - name: Setup Claude settings with lint hook
+        run: |
+          chmod +x .github/scripts/setup-claude.sh
+          ./.github/scripts/setup-claude.sh
+
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@b92e56a96bb2fce337ece11f6dcb03bab4826536 # beta
         id: claude-code
@@ -48,6 +53,21 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: 60
+          additional_permissions: |
+            actions: read
+          custom_instructions: |
+            You have also been granted tools for editing files and running pnpm commands (fmt, install, lint, test) for testing your changes: pnpm fmt, pnpm install, pnpm lint, pnpm test.
+
+            MANDATORY PRE-COMMIT HOOK POLICY:
+            - When you see "mcp__github_file_ops__commit_files operation blocked by hook", this means lint/format errors exist
+            - You MUST immediately run "pnpm lint --fix" and "pnpm fmt" to fix all errors
+            - You MUST then manually fix any remaining violations shown in the error output
+            - You MUST continue fixing until "pnpm lint" and "pnpm fmt" both pass completely
+            - Only after ALL checks pass should you retry the commit
+            - NEVER abandon the task when blocked by pre-commit hook - always fix the issues
+            - Your task is NOT complete until the commit succeeds after passing all checks
+            - This is a REQUIREMENT, not a suggestion - commits MUST pass all lint/format checks
           allowed_tools: |
             Bash(pnpm fmt:*),
             Bash(pnpm install),

--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -39,9 +39,7 @@ jobs:
         uses: ./.github/actions/pnpm-setup
 
       - name: Setup Claude settings with lint hook
-        run: |
-          chmod +x .github/scripts/setup-claude.sh
-          ./.github/scripts/setup-claude.sh
+        run: bash .github/scripts/setup-claude.sh
 
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@b92e56a96bb2fce337ece11f6dcb03bab4826536 # beta

--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -12,7 +12,7 @@ jobs:
   claude-pr-creator:
     if: github.event.label.name == 'claude-create-pr'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,9 +39,7 @@ jobs:
         uses: ./.github/actions/pnpm-setup
 
       - name: Setup Claude settings with lint hook
-        run: |
-          chmod +x .github/scripts/setup-claude.sh
-          ./.github/scripts/setup-claude.sh
+        run: bash .github/scripts/setup-claude.sh
 
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@b92e56a96bb2fce337ece11f6dcb03bab4826536 # beta

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,14 +38,30 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/pnpm-setup
 
+      - name: Setup Claude settings with lint hook
+        run: |
+          chmod +x .github/scripts/setup-claude.sh
+          ./.github/scripts/setup-claude.sh
+
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@b92e56a96bb2fce337ece11f6dcb03bab4826536 # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: 60
           additional_permissions: |
             actions: read
           custom_instructions: |
             You have also been granted tools for editing files and running pnpm commands (fmt, install, lint, test) for testing your changes: pnpm fmt, pnpm install, pnpm lint, pnpm test.
+
+            MANDATORY PRE-COMMIT HOOK POLICY:
+            - When you see "mcp__github_file_ops__commit_files operation blocked by hook", this means lint/format errors exist
+            - You MUST immediately run "pnpm lint --fix" and "pnpm fmt" to fix all errors
+            - You MUST then manually fix any remaining violations shown in the error output
+            - You MUST continue fixing until "pnpm lint" and "pnpm fmt" both pass completely
+            - Only after ALL checks pass should you retry the commit
+            - NEVER abandon the task when blocked by pre-commit hook - always fix the issues
+            - Your task is NOT complete until the commit succeeds after passing all checks
+            - This is a REQUIREMENT, not a suggestion - commits MUST pass all lint/format checks
           allowed_tools: |
             Bash(pnpm fmt:*),
             Bash(pnpm install),


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This change ensures Claude Code Action can successfully complete tasks across multiple packages in our monorepo by enforcing lint and format checks before committing.
This prevents CI failures from unresolved lint errors and enables Claude to iterate and fix issues autonomously.

## Target Workflow

- .github/workflows/claude.yml
- .github/workflows/claude-pr-creator.yml

When requesting a task with `@claude` and when running claude at night with the issue label https://github.com/liam-hq/liam/labels/scheduled-task.

## Testing

I tested the changes by forking the repository in my personal account:
https://github.com/FunamaYukina/liam

Here are the results of the verification:
While the issue descriptions could be refined a bit further, the workflow is now able to handle changes that span across multiple packages and fix related lint errors accordingly.


| Issue                                                                                                                     | PR                                                  | Result                                                                                                               |
| ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| [Enable Biome rule: useUniqueElementIds (nursery)](https://github.com/liam-hq/liam/issues/2314)                                                                 | [#16](https://github.com/FunamaYukina/liam/pull/16) | ✅<br>Successfully handled changes across multiple packages                                                           |
| [Enable Biome rule: noUnusedImports (correctness) ](https://github.com/liam-hq/liam/issues/2315)                                                                 | [#17](https://github.com/FunamaYukina/liam/pull/17) | ⚠️<br>No lint errors reported, but this was due to disabling Biome rules (possibly a misunderstanding of the intent) |
| [Enable Biome rule: noUnusedVariables (correctness)](https://github.com/liam-hq/liam/issues/2316)                                                               | [#18](https://github.com/FunamaYukina/liam/pull/18) | ⚠️<br>Same as above — no errors, but only because Biome rules were disabled                                          |
| [Enable Biome rule: useExhaustiveDependencies (correctness)](https://github.com/liam-hq/liam/issues/2317)<br>(Added a note to clarify that Biome rules should not be disabled) | [#19](https://github.com/FunamaYukina/liam/pull/19)| ✅<br>Successfully handled multiple-package changes with Biome rules intact                                           |


### Testing Log

When the pre-commit check fails, you'll see output like this:
<img width="1112" height="383" alt="ss 3587" src="https://github.com/user-attachments/assets/9003df83-3103-4451-b33c-92f2249e692a" />

When it passes successfully, the log will look like this:

<img width="1122" height="425" alt="ss 3588" src="https://github.com/user-attachments/assets/6a213355-bc7c-4ae0-b400-1a59f25f93de" />