### PR TITLE
♻️ Rename createEmptyVersion to createEmptyPatchVersion

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.integration.test.ts
@@ -28,7 +28,7 @@ describe('designSchemaNode -> executeDdlNode integration', () => {
   const mockRepository = {
     schema: {
       updateVersion: vi.fn(),
-      createEmptyVersion: vi.fn(),
+      createEmptyPatchVersion: vi.fn(),
       createTimelineItem: vi.fn(),
       getSchema: vi.fn(),
       getDesignSession: vi.fn(),
@@ -66,7 +66,7 @@ describe('designSchemaNode -> executeDdlNode integration', () => {
       timelineItem: { id: 'test-timeline-id' } as const,
     })
     // Setup default successful version creation
-    mockRepository.schema.createEmptyVersion.mockResolvedValue({
+    mockRepository.schema.createEmptyPatchVersion.mockResolvedValue({
       success: true,
       versionId: 'test-version-id',
     })

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
@@ -33,7 +33,7 @@ describe('designSchemaNode retry behavior', () => {
         updateTimelineItem: vi.fn(),
         getSchema: vi.fn(),
         getDesignSession: vi.fn(),
-        createEmptyVersion: vi.fn().mockResolvedValue({
+        createEmptyPatchVersion: vi.fn().mockResolvedValue({
           success: true,
           versionId: 'test-version-id',
         }),

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -153,10 +153,12 @@ export async function designSchemaNode(
   const buildingSchemaId = state.buildingSchemaId
   const latestVersionNumber = state.latestVersionNumber
 
-  const createVersionResult = await repositories.schema.createEmptyVersion({
-    buildingSchemaId,
-    latestVersionNumber,
-  })
+  const createVersionResult = await repositories.schema.createEmptyPatchVersion(
+    {
+      buildingSchemaId,
+      latestVersionNumber,
+    },
+  )
 
   if (!createVersionResult.success) {
     const errorMessage =

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.test.ts
@@ -37,7 +37,7 @@ describe('prepareDmlNode', () => {
         updateTimelineItem: vi.fn(),
         getSchema: vi.fn(),
         getDesignSession: vi.fn(),
-        createEmptyVersion: vi.fn(),
+        createEmptyPatchVersion: vi.fn(),
         updateVersion: vi.fn(),
         createTimelineItem: vi.fn().mockResolvedValue(undefined),
         createArtifact: vi.fn(),

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/validateSchemaNode.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/validateSchemaNode.test.ts
@@ -40,7 +40,7 @@ describe('validateSchemaNode', () => {
         updateTimelineItem: vi.fn(),
         getSchema: vi.fn(),
         getDesignSession: vi.fn(),
-        createEmptyVersion: vi.fn(),
+        createEmptyPatchVersion: vi.fn(),
         updateVersion: vi.fn(),
         createTimelineItem: vi.fn(),
         createArtifact: vi.fn(),

--- a/frontend/internal-packages/agent/src/deepModeling.test.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.test.ts
@@ -159,7 +159,7 @@ describe('Chat Workflow', () => {
     mockSchemaRepository = {
       getSchema: vi.fn(),
       getDesignSession: vi.fn(),
-      createEmptyVersion: vi.fn(),
+      createEmptyPatchVersion: vi.fn(),
       updateVersion: vi.fn(),
       createTimelineItem: vi.fn(),
       createArtifact: vi.fn(),
@@ -226,7 +226,7 @@ describe('Chat Workflow', () => {
     }))
 
     // Setup createEmptyVersion mock
-    vi.mocked(mockSchemaRepository.createEmptyVersion).mockResolvedValue({
+    vi.mocked(mockSchemaRepository.createEmptyPatchVersion).mockResolvedValue({
       success: true,
       versionId: 'test-version-id',
     })
@@ -319,10 +319,12 @@ describe('Chat Workflow', () => {
   describe('Build Mode', () => {
     beforeEach(() => {
       // Reset mocks for each test
-      vi.mocked(mockSchemaRepository.createEmptyVersion).mockResolvedValue({
-        success: true,
-        versionId: 'test-version-id',
-      })
+      vi.mocked(mockSchemaRepository.createEmptyPatchVersion).mockResolvedValue(
+        {
+          success: true,
+          versionId: 'test-version-id',
+        },
+      )
       vi.mocked(mockSchemaRepository.updateVersion).mockResolvedValue({
         success: true,
         newSchema: mockSchemaData,
@@ -504,10 +506,12 @@ describe('Chat Workflow', () => {
   describe('Error Handling', () => {
     beforeEach(() => {
       // Reset mocks for each test
-      vi.mocked(mockSchemaRepository.createEmptyVersion).mockResolvedValue({
-        success: true,
-        versionId: 'test-version-id',
-      })
+      vi.mocked(mockSchemaRepository.createEmptyPatchVersion).mockResolvedValue(
+        {
+          success: true,
+          versionId: 'test-version-id',
+        },
+      )
       vi.mocked(mockSchemaRepository.updateVersion).mockResolvedValue({
         success: true,
         newSchema: mockSchemaData,
@@ -558,10 +562,12 @@ describe('Chat Workflow', () => {
   describe('State Management', () => {
     beforeEach(() => {
       // Reset mocks for each test
-      vi.mocked(mockSchemaRepository.createEmptyVersion).mockResolvedValue({
-        success: true,
-        versionId: 'test-version-id',
-      })
+      vi.mocked(mockSchemaRepository.createEmptyPatchVersion).mockResolvedValue(
+        {
+          success: true,
+          versionId: 'test-version-id',
+        },
+      )
       vi.mocked(mockSchemaRepository.updateVersion).mockResolvedValue({
         success: true,
         newSchema: mockSchemaData,
@@ -593,10 +599,12 @@ describe('Chat Workflow', () => {
   describe('Agent Selection', () => {
     beforeEach(() => {
       // Reset mocks for each test
-      vi.mocked(mockSchemaRepository.createEmptyVersion).mockResolvedValue({
-        success: true,
-        versionId: 'test-version-id',
-      })
+      vi.mocked(mockSchemaRepository.createEmptyPatchVersion).mockResolvedValue(
+        {
+          success: true,
+          versionId: 'test-version-id',
+        },
+      )
       vi.mocked(mockSchemaRepository.updateVersion).mockResolvedValue({
         success: true,
         newSchema: mockSchemaData,
@@ -623,10 +631,12 @@ describe('Chat Workflow', () => {
   describe('Workflow Integration', () => {
     beforeEach(() => {
       // Reset mocks for each test
-      vi.mocked(mockSchemaRepository.createEmptyVersion).mockResolvedValue({
-        success: true,
-        versionId: 'test-version-id',
-      })
+      vi.mocked(mockSchemaRepository.createEmptyPatchVersion).mockResolvedValue(
+        {
+          success: true,
+          versionId: 'test-version-id',
+        },
+      )
       vi.mocked(mockSchemaRepository.updateVersion).mockResolvedValue({
         success: true,
         newSchema: mockSchemaData,

--- a/frontend/internal-packages/agent/src/repositories/supabase.ts
+++ b/frontend/internal-packages/agent/src/repositories/supabase.ts
@@ -14,7 +14,7 @@ import { ensurePathStructure } from '../utils/pathPreparation'
 import type {
   ArtifactResult,
   CreateArtifactParams,
-  CreateEmptyVersionParams,
+  CreateEmptyPatchVersionParams,
   CreateTimelineItemParams,
   CreateVersionResult,
   CreateWorkflowRunParams,
@@ -203,8 +203,8 @@ export class SupabaseSchemaRepository implements SchemaRepository {
     return versions.length > 0 ? Math.max(...versions.map((v) => v.number)) : 0
   }
 
-  async createEmptyVersion(
-    params: CreateEmptyVersionParams,
+  async createEmptyPatchVersion(
+    params: CreateEmptyPatchVersionParams,
   ): Promise<CreateVersionResult> {
     const { buildingSchemaId, latestVersionNumber } = params
 

--- a/frontend/internal-packages/agent/src/repositories/types.ts
+++ b/frontend/internal-packages/agent/src/repositories/types.ts
@@ -24,7 +24,7 @@ export type DesignSessionData = {
   }>
 }
 
-export type CreateEmptyVersionParams = {
+export type CreateEmptyPatchVersionParams = {
   buildingSchemaId: string
   latestVersionNumber: number
 }
@@ -139,8 +139,8 @@ export type SchemaRepository = {
   /**
    * Create a new empty schema version (patch/reverse_patch are null)
    */
-  createEmptyVersion(
-    params: CreateEmptyVersionParams,
+  createEmptyPatchVersion(
+    params: CreateEmptyPatchVersionParams,
   ): Promise<CreateVersionResult>
 
   /**


### PR DESCRIPTION
## Issue

https://github.com/liam-hq/liam/pull/2571#discussion_r2209166494

## Why is this change needed?
The function name `createEmptyVersion` was not descriptive enough about its purpose. The function specifically creates empty patch versions (where patch/reverse_patch are null) as part of the schema versioning system. Renaming it to `createEmptyPatchVersion` makes the intent clearer and improves code readability.

## Changes Made

- Renamed function from `createEmptyVersion` to `createEmptyPatchVersion`
- Updated corresponding type from `CreateEmptyVersionParams` to `CreateEmptyPatchVersionParams`
- Updated all function calls across the agent module
- Updated test mocks and assertions
- Updated imports in affected files

## Files Changed

- `repositories/types.ts` - Updated type definitions and interface
- `repositories/supabase.ts` - Updated implementation and imports
- `deepModeling.test.ts` - Updated test mocks
- `chat/workflow/nodes/designSchemaNode.ts` - Updated function call
- `chat/workflow/nodes/*.test.ts` - Updated test mocks (5 files)

## Test Coverage

All existing tests pass with the updated function name. No behavioral changes were made, only naming improvements.