### PR TITLE
💄 Fix long text wrapping in VersionMessage component

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/VersionMessage/VersionMessage.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/VersionMessage/VersionMessage.module.css
@@ -201,6 +201,7 @@
   align-items: center;
   gap: 4px;
   flex: 1;
+  flex-wrap: wrap;
 }
 
 .pathPart {
@@ -208,7 +209,7 @@
   font-size: var(--font-size-2);
   font-family: var(--code-font);
   line-height: normal;
-  white-space: nowrap;
+  word-break: break-word;
 }
 
 .arrowContainer {


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
When VersionMessage component displays long paths, the text doesn't wrap and overflows horizontally, breaking the UI layout.
This fix ensures that long paths wrap properly within the container. The arrow icons (→) are also handled correctly with the wrapping, improving  readability.

| Before | After |
| ------ | ----- |
| ![スクリーンショット 2025-07-17 18 25 20](https://github.com/user-attachments/assets/abe9c4d1-a6df-49c8-8630-2d3ccc283647) | ![スクリーンショット 2025-07-18 11 27 35](https://github.com/user-attachments/assets/d8b8fb68-ac16-4f51-8d87-84fb7fdab10f) |
