### PR TITLE
Knip 5.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/node": "22.16.0",
     "@vitest/coverage-v8": "3.2.4",
     "concurrently": "9.2.0",
-    "knip": "5.60.2",
+    "knip": "5.62.0",
     "lefthook": "1.11.16",
     "syncpack": "13.0.4",
     "turbo": "2.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 9.2.0
         version: 9.2.0
       knip:
-        specifier: 5.60.2
-        version: 5.60.2(@types/node@22.16.0)(typescript@5.8.3)
+        specifier: 5.62.0
+        version: 5.62.0(@types/node@22.16.0)(typescript@5.8.3)
       lefthook:
         specifier: 1.11.16
         version: 1.11.16
@@ -8424,8 +8424,8 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
-  knip@5.60.2:
-    resolution: {integrity: sha512-TsYqEsoL3802RmhGL5MN7RLI6/03kocMYx/4BpMmwo3dSwEJxmzV7HqRxMVZr6c1llbd25+MqjgA86bv1IwsPA==}
+  knip@5.62.0:
+    resolution: {integrity: sha512-hfTUVzmrMNMT1khlZfAYmBABeehwWUUrizLQoLamoRhSFkygsGIXWx31kaWKBgEaIVL77T3Uz7IxGvSw+CvQ6A==}
     engines: {node: '>=18.18.0'}
     hasBin: true
     peerDependencies:
@@ -20142,7 +20142,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knip@5.60.2(@types/node@22.16.0)(typescript@5.8.3):
+  knip@5.62.0(@types/node@22.16.0)(typescript@5.8.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 22.16.0

--- a/renovate.json5
+++ b/renovate.json5
@@ -70,11 +70,8 @@
         "@playwright/test",
         "pnpm",
         "concurrently",
-        "node"
-        // "knip" - Temporarily commented out due to compatibility issues with biome2
-        // See: https://github.com/webpro-nl/knip/issues/1154
-        // This has caused manual downgrades in PRs #2376 and #2534
-        // Re-enable knip when the compatibility issue is resolved
+        "node",
+        "knip"
       ],
       "matchDepTypes": [
         "devDependencies"


### PR DESCRIPTION

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

- Knip 5.62 might solve https://github.com/liam-hq/liam/pull/2630 issue.
- see https://github.com/webpro-nl/knip/releases/tag/5.62.0