### PR TITLE
💄 Fix box-shadow clipping in SessionForm presenters

### DIFF
--- a/frontend/apps/app/features/sessions/components/SessionForm/SessionFormPresenter.module.css
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SessionFormPresenter.module.css
@@ -9,7 +9,6 @@
   position: relative;
   width: 100%;
   border-radius: var(--border-radius-xl);
-  overflow: hidden;
   max-height: 2000px;
   transition: max-height 600ms cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/frontend/apps/app/features/sessions/components/SessionForm/URLSessionFormPresenter/URLSessionFormPresenter.module.css
+++ b/frontend/apps/app/features/sessions/components/SessionForm/URLSessionFormPresenter/URLSessionFormPresenter.module.css
@@ -6,10 +6,19 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  transition:
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
 }
 
 .container.pending {
-  opacity: 0.7;
+  border-color: var(--primary-overlay-40);
+  box-shadow: 0px 0px 40px 0px var(--primary-overlay-40);
+}
+
+.container.error {
+  border-color: var(--danger-overlay-40);
+  box-shadow: 0px 0px 20px 0px var(--severity-critical-40);
 }
 
 .container.dragActive {


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
The box-shadow effects (blur) were being clipped due to overflow: hidden on SessionFormPresenter's `.formContainer`. Additionally, URLSessionFormPresenter was missing the loading/error state box-shadow effects that other presenters had, causing UI inconsistency.
This change fixes the clipping issue and ensures all form presenters have consistent visual feedback for loading and error states.