### PR TITLE
📝 Add pnpm install reminder to merge/pull slash commands

### DIFF
--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,1 +1,1 @@
-Merge branch: $ARGUMENTS (default: origin main) into current branch. Resolve conflicts if any occur.
+Merge branch: $ARGUMENTS (default: origin main) into current branch. Resolve conflicts if any occur. Run `pnpm install` if lint errors occur after conflict resolution.

--- a/.claude/commands/pull.md
+++ b/.claude/commands/pull.md
@@ -1,1 +1,1 @@
-Pull the latest changes from branch: $ARGUMENTS (default: origin main). Resolve conflicts if any occur.
+Pull the latest changes from branch: $ARGUMENTS (default: origin main). Resolve conflicts if any occur. Run `pnpm install` if lint errors occur after conflict resolution.


### PR DESCRIPTION
## Issue

- resolve: N/A (internal tooling improvement)

## Why is this change needed?

After conflict resolution during merge or pull operations, lint errors commonly occur due to dependency mismatches. Adding a reminder to run `pnpm install` helps developers quickly resolve these issues.

## Summary

- Add guidance to run `pnpm install` after conflict resolution in `/merge` slash command
- Add guidance to run `pnpm install` after conflict resolution in `/pull` slash command

## Test plan

- [x] Verify slash command files are updated correctly
- [ ] Test commands work as expected during conflict scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)