### PR TITLE
🔧 Remove conflicting commit instruction line

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,7 +1,6 @@
 Let's commit the changes.
 
 **Split large changes**: If changes touch multiple concerns, split them into separate commits
-**Commit only what is staged**: When there are staged changes, commit *only* those staged changes and nothing else
 
 - Use gitmoji (optional, recommended): Write commit messages using the emoji (e.g., ✨) itself, not the textual representation (e.g., `:sparkles:`)
 


### PR DESCRIPTION
## Summary
- Remove redundant instruction about committing staged changes that conflicted with the previous instruction about splitting large changes
- Clean up the commit command documentation for better clarity

## Test plan
- [ ] Verify the commit command documentation is clearer and non-conflicting
- [ ] Confirm the commit flow works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)