### PR TITLE
✨ Add timeline sync support for ToolNode messages

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/utils/withTimelineItemSync.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/utils/withTimelineItemSync.test.ts
@@ -1,0 +1,259 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages'
+import type { Database } from '@liam-hq/db'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SchemaRepository } from '../../../repositories/types'
+import { withTimelineItemSync } from './withTimelineItemSync'
+
+describe('withTimelineItemSync', () => {
+  let mockCreateTimelineItem: ReturnType<typeof vi.fn>
+  let mockConsoleError: ReturnType<typeof vi.spyOn>
+  let mockRepository: { schema: SchemaRepository }
+
+  const createContext = (
+    assistantRole?: Database['public']['Enums']['assistant_role_enum'],
+  ) => {
+    const context = {
+      designSessionId: 'test-session-id',
+      organizationId: 'test-org-id',
+      userId: 'test-user-id',
+      repositories: mockRepository,
+      ...(assistantRole && { assistantRole }),
+    }
+    return context
+  }
+
+  beforeEach(() => {
+    mockCreateTimelineItem = vi.fn().mockResolvedValue({ success: true })
+    mockRepository = {
+      schema: {
+        createTimelineItem: mockCreateTimelineItem,
+        getSchema: vi.fn(),
+        getDesignSession: vi.fn(),
+        createEmptyPatchVersion: vi.fn(),
+        updateVersion: vi.fn(),
+        updateTimelineItem: vi.fn(),
+        createArtifact: vi.fn(),
+        updateArtifact: vi.fn(),
+        getArtifact: vi.fn(),
+        createValidationQuery: vi.fn(),
+        createValidationResults: vi.fn(),
+        createWorkflowRun: vi.fn(),
+        updateWorkflowRunStatus: vi.fn(),
+      },
+    }
+    mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('AIMessage handling', () => {
+    it('should create assistant timeline item with correct parameters', async () => {
+      const message = new AIMessage('Test AI response')
+      const context = createContext('pm')
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+        designSessionId: 'test-session-id',
+        content: 'Test AI response',
+        type: 'assistant',
+        role: 'pm',
+      })
+      expect(result).toBe(message)
+    })
+
+    it('should default to "db" role when assistantRole not provided', async () => {
+      const message = new AIMessage('Test AI response')
+      const context = createContext()
+
+      await withTimelineItemSync(message, context)
+
+      expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+        designSessionId: 'test-session-id',
+        content: 'Test AI response',
+        type: 'assistant',
+        role: 'db',
+      })
+    })
+  })
+
+  describe('HumanMessage handling', () => {
+    it('should create user timeline item with correct parameters', async () => {
+      const message = new HumanMessage('User input message')
+      const context = createContext()
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+        designSessionId: 'test-session-id',
+        content: 'User input message',
+        type: 'user',
+        userId: 'test-user-id',
+      })
+      expect(result).toBe(message)
+    })
+  })
+
+  describe('ToolMessage handling', () => {
+    it('should create error timeline item when content contains "error"', async () => {
+      const message = new ToolMessage({
+        content: 'Error: Something went wrong',
+        tool_call_id: 'test-call-id',
+      })
+      const context = createContext('db')
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+        designSessionId: 'test-session-id',
+        content: 'Error: Something went wrong',
+        type: 'error',
+      })
+      expect(result).toBe(message)
+    })
+
+    it('should create assistant timeline item when content does not contain error', async () => {
+      const message = new ToolMessage({
+        content: 'Tool execution successful',
+        tool_call_id: 'test-call-id',
+      })
+      const context = createContext('qa')
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+        designSessionId: 'test-session-id',
+        content: 'Tool execution successful',
+        type: 'assistant',
+        role: 'qa',
+      })
+      expect(result).toBe(message)
+    })
+
+    it('should detect error case-insensitively', async () => {
+      const testCases = [
+        'ERROR: Something failed',
+        'An Error occurred',
+        'error in processing',
+        'System ERROR detected',
+      ]
+
+      for (const content of testCases) {
+        const message = new ToolMessage({
+          content,
+          tool_call_id: 'test-call-id',
+        })
+        const context = createContext()
+
+        await withTimelineItemSync(message, context)
+
+        expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+          designSessionId: 'test-session-id',
+          content,
+          type: 'error',
+        })
+      }
+    })
+
+    it('should handle object content by stringifying and detecting error', async () => {
+      const complexContent = JSON.stringify({
+        status: 'error',
+        code: 500,
+        details: {},
+      })
+      const message = new ToolMessage({
+        content: complexContent,
+        tool_call_id: 'test-call-id',
+      })
+      const context = createContext()
+
+      await withTimelineItemSync(message, context)
+
+      expect(mockCreateTimelineItem).toHaveBeenCalledWith({
+        designSessionId: 'test-session-id',
+        content: complexContent,
+        type: 'error',
+      })
+    })
+  })
+
+  describe('return value', () => {
+    it('should return the original message unchanged for all message types', async () => {
+      const aiMessage = new AIMessage('AI response')
+      const humanMessage = new HumanMessage('Human input')
+      const toolMessage = new ToolMessage({
+        content: 'Tool output',
+        tool_call_id: 'test-id',
+      })
+      const context = createContext()
+
+      const aiResult = await withTimelineItemSync(aiMessage, context)
+      const humanResult = await withTimelineItemSync(humanMessage, context)
+      const toolResult = await withTimelineItemSync(toolMessage, context)
+
+      expect(aiResult).toBe(aiMessage)
+      expect(humanResult).toBe(humanMessage)
+      expect(toolResult).toBe(toolMessage)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should log error and continue when createTimelineItem fails for AIMessage', async () => {
+      const message = new AIMessage('Test message')
+      const context = createContext()
+      const error = new Error('Database connection failed')
+
+      mockCreateTimelineItem.mockResolvedValue({
+        success: false,
+        error: error.message,
+      })
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        'Failed to create timeline item for AIMessage:',
+        error.message,
+      )
+      expect(result).toBe(message)
+    })
+
+    it('should log error and continue when createTimelineItem fails for HumanMessage', async () => {
+      const message = new HumanMessage('Test message')
+      const context = createContext()
+      const error = new Error('Network timeout')
+
+      mockCreateTimelineItem.mockResolvedValue({
+        success: false,
+        error: error.message,
+      })
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        'Failed to create timeline item for HumanMessage:',
+        error.message,
+      )
+      expect(result).toBe(message)
+    })
+
+    it('should log error and continue when createTimelineItem fails for ToolMessage', async () => {
+      const message = new ToolMessage({
+        content: 'Error: Tool failed',
+        tool_call_id: 'test-id',
+      })
+      const context = createContext()
+      const error = new Error('Validation failed')
+
+      mockCreateTimelineItem.mockResolvedValue({
+        success: false,
+        error: error.message,
+      })
+
+      const result = await withTimelineItemSync(message, context)
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        'Failed to create timeline item for ToolMessage (error):',
+        error.message,
+      )
+      expect(result).toBe(message)
+    })
+  })
+})

--- a/frontend/internal-packages/agent/src/chat/workflow/utils/withTimelineItemSync.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/utils/withTimelineItemSync.ts
@@ -2,6 +2,7 @@ import {
   AIMessage,
   type BaseMessage,
   HumanMessage,
+  ToolMessage,
 } from '@langchain/core/messages'
 import type { Database } from '@liam-hq/db'
 import type { SchemaRepository } from '../../../repositories/types'
@@ -14,44 +15,90 @@ type TimelineSyncContext = {
   assistantRole?: Database['public']['Enums']['assistant_role_enum']
 }
 
+async function handleAIMessage(
+  message: AIMessage,
+  context: TimelineSyncContext,
+): Promise<void> {
+  const result = await context.repositories.schema.createTimelineItem({
+    designSessionId: context.designSessionId,
+    content:
+      typeof message.content === 'string'
+        ? message.content
+        : JSON.stringify(message.content),
+    type: 'assistant',
+    role: context.assistantRole || 'db',
+  })
+
+  if (!result.success) {
+    console.error('Failed to create timeline item for AIMessage:', result.error)
+  }
+}
+
+async function handleHumanMessage(
+  message: HumanMessage,
+  context: TimelineSyncContext,
+): Promise<void> {
+  const result = await context.repositories.schema.createTimelineItem({
+    designSessionId: context.designSessionId,
+    content:
+      typeof message.content === 'string'
+        ? message.content
+        : JSON.stringify(message.content),
+    type: 'user',
+    userId: context.userId,
+  })
+
+  if (!result.success) {
+    console.error(
+      'Failed to create timeline item for HumanMessage:',
+      result.error,
+    )
+  }
+}
+
+async function handleToolMessage(
+  message: ToolMessage,
+  context: TimelineSyncContext,
+): Promise<void> {
+  const content =
+    typeof message.content === 'string'
+      ? message.content
+      : JSON.stringify(message.content)
+
+  const isError = content.toLowerCase().includes('error')
+  const timelineType = isError ? 'error' : 'assistant'
+
+  const result = isError
+    ? await context.repositories.schema.createTimelineItem({
+        designSessionId: context.designSessionId,
+        content,
+        type: 'error',
+      })
+    : await context.repositories.schema.createTimelineItem({
+        designSessionId: context.designSessionId,
+        content,
+        type: 'assistant',
+        role: context.assistantRole || 'db',
+      })
+
+  if (!result.success) {
+    console.error(
+      `Failed to create timeline item for ToolMessage (${timelineType}):`,
+      result.error,
+    )
+  }
+}
+
 export async function withTimelineItemSync(
   message: BaseMessage,
   context: TimelineSyncContext,
 ): Promise<BaseMessage> {
   if (message instanceof AIMessage) {
-    const result = await context.repositories.schema.createTimelineItem({
-      designSessionId: context.designSessionId,
-      content:
-        typeof message.content === 'string'
-          ? message.content
-          : JSON.stringify(message.content),
-      type: 'assistant',
-      role: context.assistantRole || 'db',
-    })
-
-    if (!result.success) {
-      console.error(
-        'Failed to create timeline item for AIMessage:',
-        result.error,
-      )
-    }
+    await handleAIMessage(message, context)
   } else if (message instanceof HumanMessage) {
-    const result = await context.repositories.schema.createTimelineItem({
-      designSessionId: context.designSessionId,
-      content:
-        typeof message.content === 'string'
-          ? message.content
-          : JSON.stringify(message.content),
-      type: 'user',
-      userId: context.userId,
-    })
-
-    if (!result.success) {
-      console.error(
-        'Failed to create timeline item for HumanMessage:',
-        result.error,
-      )
-    }
+    await handleHumanMessage(message, context)
+  } else if (message instanceof ToolMessage) {
+    await handleToolMessage(message, context)
   }
 
   return message

--- a/frontend/internal-packages/agent/src/db-agent/nodes/invokeSchemaDesignToolNode.ts
+++ b/frontend/internal-packages/agent/src/db-agent/nodes/invokeSchemaDesignToolNode.ts
@@ -1,18 +1,53 @@
+import type { BaseMessage } from '@langchain/core/messages'
 import type { RunnableConfig } from '@langchain/core/runnables'
 import { ToolNode } from '@langchain/langgraph/prebuilt'
+import { getConfigurable } from '../../chat/workflow/shared/getConfigurable'
 import type { WorkflowState } from '../../chat/workflow/types'
+import { withTimelineItemSync } from '../../chat/workflow/utils/withTimelineItemSync'
 import { schemaDesignTool } from '../tools/schemaDesignTool'
 
-export const invokeSchemaDesignToolNode = (
+export const invokeSchemaDesignToolNode = async (
   state: WorkflowState,
   config: RunnableConfig,
 ) => {
-  const toolNode = new ToolNode([schemaDesignTool])
+  const configurableResult = getConfigurable(config)
+  if (configurableResult.isErr()) {
+    return {
+      ...state,
+      error: configurableResult.error,
+    }
+  }
+  const { repositories } = configurableResult.value
 
-  return toolNode.invoke(state, {
+  const toolNode = new ToolNode<{ messages: BaseMessage[] }>([schemaDesignTool])
+
+  const result = await toolNode.invoke(state, {
     configurable: {
       ...config.configurable,
       buildingSchemaVersionId: state.buildingSchemaVersionId,
     },
   })
+
+  // Sync all ToolMessages to timeline
+  const messages = result.messages
+  if (!Array.isArray(messages)) {
+    return result
+  }
+
+  const syncedMessages = await Promise.all(
+    messages.map(async (message: BaseMessage) => {
+      return await withTimelineItemSync(message, {
+        designSessionId: state.designSessionId,
+        organizationId: state.organizationId || '',
+        userId: state.userId,
+        repositories,
+        assistantRole: 'db',
+      })
+    }),
+  )
+
+  return {
+    ...result,
+    messages: syncedMessages,
+  }
 }


### PR DESCRIPTION
## Issue

- resolve: Add timeline synchronization for ToolNode message execution

## Why is this change needed?

This change enables timeline synchronization for ToolNode messages in the agent workflow, ensuring that tool execution results (both successful and error responses) are properly tracked and displayed in the timeline UI. Previously, ToolNode executions were not being saved to the timeline_items table, making it difficult to track the complete workflow execution history.

Key improvements:
- Extends `withTimelineItemSync` to handle `ToolMessage` instances
- Adds automatic error detection (messages containing "error" are saved as 'error' type)
- Updates `invokeSchemaDesignToolNode` to sync all tool messages to timeline
- Refactors `withTimelineItemSync` to reduce complexity by extracting helper functions
- Ensures proper type safety and follows existing patterns

This provides complete visibility into the AI workflow execution process, including schema design tool interactions.