### PR TITLE
refactor(agent): separate system prompt and context in PMAnalysisAgent

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
@@ -3,10 +3,8 @@ import type { RunnableConfig } from '@langchain/core/runnables'
 import type { Database } from '@liam-hq/db'
 import { ResultAsync } from 'neverthrow'
 import { PMAnalysisAgent } from '../../../langchain/agents'
-import type { BasePromptVariables } from '../../../langchain/utils/types'
 import { getConfigurable } from '../shared/getConfigurable'
 import type { WorkflowState } from '../types'
-import { formatMessagesToHistory } from '../utils/messageUtils'
 import { logAssistantMessage } from '../utils/timelineLogger'
 import { withTimelineItemSync } from '../utils/withTimelineItemSync'
 
@@ -74,11 +72,6 @@ export async function analyzeRequirementsNode(
 
   const pmAnalysisAgent = new PMAnalysisAgent()
 
-  const promptVariables: BasePromptVariables = {
-    chat_history: formatMessagesToHistory(state.messages),
-    user_message: state.userInput,
-  }
-
   const retryCount = state.retryCount['analyzeRequirementsNode'] ?? 0
 
   await logAssistantMessage(
@@ -89,7 +82,7 @@ export async function analyzeRequirementsNode(
   )
 
   const analysisResult = await ResultAsync.fromPromise(
-    pmAnalysisAgent.analyzeRequirements(promptVariables),
+    pmAnalysisAgent.generate(state.messages),
     (error) => (error instanceof Error ? error : new Error(String(error))),
   )
 

--- a/frontend/internal-packages/agent/src/deepModeling.test.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.test.ts
@@ -62,7 +62,7 @@ vi.mock('@langchain/openai', () => ({
 describe('Chat Workflow', () => {
   let mockSchemaData: Schema
   let mockPMAnalysisAgent: {
-    analyzeRequirements: ReturnType<typeof vi.fn>
+    generate: ReturnType<typeof vi.fn>
   }
   let mockInvokeDesignAgent: ReturnType<typeof vi.fn>
   let MockQAGenerateUsecaseAgent: ReturnType<typeof vi.fn>
@@ -206,7 +206,7 @@ describe('Chat Workflow', () => {
 
     // Mock PM Analysis agent
     mockPMAnalysisAgent = {
-      analyzeRequirements: vi.fn().mockResolvedValue({
+      generate: vi.fn().mockResolvedValue({
         businessRequirement: 'Mocked BRD',
         functionalRequirements: {
           'Test Category': ['Mocked functional requirement'],

--- a/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/prompts.ts
@@ -1,16 +1,15 @@
-import { ChatPromptTemplate } from '@langchain/core/prompts'
+/**
+ * Prompts for PM Analysis Agent
+ */
 
-// Requirements Analysis System Prompt
-const pmAnalysisSystemPrompt = `You are PM Agent, a skilled project manager who specializes in analyzing user requirements and extracting structured Business Requirements Documents (BRDs).
+export const PM_ANALYSIS_SYSTEM_MESSAGE = `You are PM Agent, a skilled project manager who specializes in analyzing user requirements and extracting structured Business Requirements Documents (BRDs).
+
 Your role is to:
 1. Analyze user input and conversation history
 2. Extract clear, structured requirements
 3. Convert ambiguous expressions into specific, actionable requirements
 4. Separate multiple use cases into individual requirements
 5. Include specific screens, operations, constraints, and processing details when available
-
-Previous Conversation Context:
-{chat_history}
 
 OUTPUT REQUIREMENTS (STRICT):
 - Output ONLY valid JSON in the format:
@@ -64,9 +63,3 @@ Example output:
     ]
   }}
 }}`
-
-// Analysis Prompt Template
-export const pmAnalysisPrompt = ChatPromptTemplate.fromMessages([
-  ['system', pmAnalysisSystemPrompt],
-  ['human', '{user_message}'],
-])


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5106

## Why is this change needed?

PMAnalysisAgent was using `ChatPromptTemplate.fromMessages()` with chat history embedded in the system prompt, which mixed system instructions with user context. This change separates system prompt from context by using `BaseMessage[]` directly, similar to other agents like `databaseSchemaBuildAgent`.

## Summary

- Updated PMAnalysisAgent to accept `BaseMessage[]` directly instead of `BasePromptVariables`
- Removed string-based `chat_history` formatting in favor of native message handling  
- Eliminated redundant `analyzeRequirements()` method, keeping only `generate()`
- Updated `analyzeRequirementsNode` to pass `state.messages` directly
- Removed `ChatPromptTemplate` usage and manual prompt formatting
- Aligned with `databaseSchemaBuildAgent` pattern for consistency
- Made `requirementsAnalysisSchema` internal to fix lint warning

|before|after|
| --- | --- |
| <img width="1094" height="1396" alt="image" src="https://github.com/user-attachments/assets/4906566a-528a-494a-bb0c-ac2767b56e12" /> | <img width="1094" height="1396" alt="image" src="https://github.com/user-attachments/assets/91c9af8b-065a-4218-aa91-07c691e7d600" /> |






## Test plan

- [x] TypeScript type checking passes
- [x] All linting rules pass
- [x] Code formatting is consistent
- [x] Agent interface remains compatible with workflow

🤖 Generated with [Claude Code](https://claude.ai/code)