### PR TITLE
feat: Bundle consecutive messages from the same agent

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
@@ -116,19 +116,16 @@ export const Chat: FC<Props> = ({
             // Render grouped agent messages
             const agentRole = 'role' in item[0] ? item[0].role : 'db'
 
-            return (
+            return item.map((message, messageIndex) => (
               <AgentMessage
-                key={`group-${item[0].id}`}
+                key={message.id}
                 state="default"
                 assistantRole={agentRole}
+                showHeader={messageIndex === 0}
               >
-                {item.map((message) => {
-                  return (
-                    <LogMessage key={message.id} content={message.content} />
-                  )
-                })}
+                <LogMessage content={message.content} />
               </AgentMessage>
-            )
+            ))
           }
 
           return (

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
@@ -10,17 +10,22 @@ import { QueryResultMessage } from './components/QueryResultMessage'
 import { UserMessage } from './components/UserMessage'
 import { VersionMessage } from './components/VersionMessage'
 
-type Props = PropsWithChildren & TimelineItemEntry
+type Props = PropsWithChildren &
+  TimelineItemEntry & {
+    showHeader?: boolean
+  }
 
 export const TimelineItem: FC<Props> = (props) => {
-  return match(props)
+  const { showHeader = true, ...timelineItemProps } = props
+
+  return match(timelineItemProps)
     .with({ type: 'schema_version' }, ({ buildingSchemaVersionId }) => (
-      <AgentMessage state="default" assistantRole="db">
+      <AgentMessage state="default" assistantRole="db" showHeader={showHeader}>
         <VersionMessage buildingSchemaVersionId={buildingSchemaVersionId} />
       </AgentMessage>
     ))
     .with({ type: 'query_result' }, ({ queryResultId, results }) => (
-      <AgentMessage state="default" assistantRole="db">
+      <AgentMessage state="default" assistantRole="db" showHeader={showHeader}>
         <QueryResultMessage
           queryResultId={queryResultId}
           results={Array.isArray(results) ? results : undefined}
@@ -31,7 +36,11 @@ export const TimelineItem: FC<Props> = (props) => {
       <UserMessage content={content} timestamp={timestamp} />
     ))
     .with({ type: 'assistant_log' }, ({ content, role }) => (
-      <AgentMessage state="default" assistantRole={role}>
+      <AgentMessage
+        state="default"
+        assistantRole={role}
+        showHeader={showHeader}
+      >
         <LogMessage content={content} />
       </AgentMessage>
     ))
@@ -44,12 +53,13 @@ export const TimelineItem: FC<Props> = (props) => {
           hour: '2-digit',
           minute: '2-digit',
         })}
+        showHeader={showHeader}
       >
         {children}
       </AgentMessage>
     ))
     .with({ type: 'error' }, ({ content, onRetry }) => (
-      <AgentMessage state="default" assistantRole="db">
+      <AgentMessage state="default" assistantRole="db" showHeader={showHeader}>
         <ErrorMessage message={content} onRetry={onRetry} />
       </AgentMessage>
     ))

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.module.css
@@ -5,6 +5,10 @@
   gap: var(--spacing-2);
 }
 
+.container:has(.avatarContainer) + .container:not(:has(.avatarContainer)) {
+  margin-top: calc(var(--spacing-2) * -1);
+}
+
 .avatarContainer {
   display: flex;
   flex-direction: row;

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.tsx
@@ -45,6 +45,10 @@ type AgentMessageProps = {
    * Optional children to render below the message
    */
   children?: ReactNode
+  /**
+   * Whether to show avatar and name (false for consecutive messages from the same agent)
+   */
+  showHeader?: boolean
 }
 
 export const AgentMessage: FC<AgentMessageProps> = ({
@@ -52,16 +56,19 @@ export const AgentMessage: FC<AgentMessageProps> = ({
   message = '',
   assistantRole,
   children,
+  showHeader = true,
 }) => {
   const isGenerating = state === 'generating'
   const { avatar, name } = getAgentInfo(assistantRole)
 
   return (
     <div className={styles.container}>
-      <div className={styles.avatarContainer}>
-        {avatar}
-        <span className={styles.agentName}>{name}</span>
-      </div>
+      {showHeader && (
+        <div className={styles.avatarContainer}>
+          {avatar}
+          <span className={styles.agentName}>{name}</span>
+        </div>
+      )}
       <div className={styles.contentContainer}>
         {isGenerating &&
         (!message || (typeof message === 'string' && message.trim() === '')) ? (


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
When the same agent sends multiple consecutive messages, each message was displaying the avatar and name, making the UI repetitive and cluttered. This change improves readability by showing the avatar and name only on the first message in a consecutive group.

preview: https://liam-app-git-feature-bundle-consecutive-posts-liambx.vercel.app/app/design_sessions/c21ee010-e456-47c7-9570-6d18624d9771

https://github.com/user-attachments/assets/844b0eb0-095d-42b1-b8fe-f4d118fe9f92