### PR TITLE
 Add PostgreSQL support for CHECK and table-level UNIQUE constraints in Drizzle parser

### DIFF
--- a/.changeset/stupid-boats-hang.md
+++ b/.changeset/stupid-boats-hang.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/db-structure": patch
+---
+
+✨ Add PostgreSQL support for CHECK and table-level UNIQUE constraints in Drizzle parser

--- a/frontend/packages/db-structure/src/parser/drizzle/__tests__/unified.test.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/__tests__/unified.test.ts
@@ -864,10 +864,8 @@ describe.each(Object.entries(dbConfigs))(
         }
       })
 
-      // Add MySQL-specific check constraint test (PostgreSQL parser doesn't support check constraints yet)
-      if (dbType === 'mysql') {
-        it('check constraints', async () => {
-          const schema = `
+      it('check constraints', async () => {
+        const schema = `
           import { ${config.functions.table}, ${config.types.id}, varchar, ${config.functions.check} } from '${config.imports.core}';
           import { sql } from '${config.imports.relations}';
 
@@ -881,31 +879,28 @@ describe.each(Object.entries(dbConfigs))(
           }));
         `
 
-          const { value } = await config.processor(schema)
+        const { value } = await config.processor(schema)
 
-          expect(value.tables['users']?.constraints).toHaveProperty(
-            'users_age_check',
-          )
-          expect(value.tables['users']?.constraints['users_age_check']).toEqual(
-            {
-              type: 'CHECK',
-              name: 'users_age_check',
-              detail: 'age >= 0 AND age <= 150',
-            },
-          )
-
-          expect(value.tables['users']?.constraints).toHaveProperty(
-            'users_username_check',
-          )
-          expect(
-            value.tables['users']?.constraints['users_username_check'],
-          ).toEqual({
-            type: 'CHECK',
-            name: 'users_username_check',
-            detail: 'CHAR_LENGTH(username) >= 3',
-          })
+        expect(value.tables['users']?.constraints).toHaveProperty(
+          'users_age_check',
+        )
+        expect(value.tables['users']?.constraints['users_age_check']).toEqual({
+          type: 'CHECK',
+          name: 'users_age_check',
+          detail: 'age >= 0 AND age <= 150',
         })
-      }
+
+        expect(value.tables['users']?.constraints).toHaveProperty(
+          'users_username_check',
+        )
+        expect(
+          value.tables['users']?.constraints['users_username_check'],
+        ).toEqual({
+          type: 'CHECK',
+          name: 'users_username_check',
+          detail: 'CHAR_LENGTH(username) >= 3',
+        })
+      })
 
       // Add multi-schema tests for each database type
       it(`multiple ${config.name} schemas`, async () => {
@@ -962,11 +957,8 @@ describe.each(Object.entries(dbConfigs))(
         expect(foreignKeyCount).toBe(2)
       })
 
-      // table-level unique constraints test
-      // TODO: postgres - add support for unique() function to enable this test for PostgreSQL
-      if (dbType === 'mysql') {
-        it('table-level unique constraints', async () => {
-          const schema = `
+      it('table-level unique constraints', async () => {
+        const schema = `
           import { ${config.functions.table}, ${config.types.id}, varchar, unique } from '${config.imports.core}';
 
           export const users = ${config.functions.table}('users', {
@@ -980,31 +972,30 @@ describe.each(Object.entries(dbConfigs))(
           }));
         `
 
-          const { value } = await config.processor(schema)
+        const { value } = await config.processor(schema)
 
-          expect(value.tables['users']?.constraints).toHaveProperty(
-            'users_full_name_unique',
-          )
-          expect(
-            value.tables['users']?.constraints['users_full_name_unique'],
-          ).toEqual({
-            type: 'UNIQUE',
-            name: 'users_full_name_unique',
-            columnNames: ['first_name', 'last_name'],
-          })
-
-          expect(value.tables['users']?.constraints).toHaveProperty(
-            'users_email_unique',
-          )
-          expect(
-            value.tables['users']?.constraints['users_email_unique'],
-          ).toEqual({
-            type: 'UNIQUE',
-            name: 'users_email_unique',
-            columnNames: ['email'],
-          })
+        expect(value.tables['users']?.constraints).toHaveProperty(
+          'users_full_name_unique',
+        )
+        expect(
+          value.tables['users']?.constraints['users_full_name_unique'],
+        ).toEqual({
+          type: 'UNIQUE',
+          name: 'users_full_name_unique',
+          columnNames: ['first_name', 'last_name'],
         })
-      }
+
+        expect(value.tables['users']?.constraints).toHaveProperty(
+          'users_email_unique',
+        )
+        expect(
+          value.tables['users']?.constraints['users_email_unique'],
+        ).toEqual({
+          type: 'UNIQUE',
+          name: 'users_email_unique',
+          columnNames: ['email'],
+        })
+      })
     })
   },
 )

--- a/frontend/packages/db-structure/src/parser/drizzle/postgres/converter.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/postgres/converter.ts
@@ -149,6 +149,13 @@ const convertToTable = (
     }
   }
 
+  // Convert table-level constraints
+  if (tableDef.constraints) {
+    for (const constraint of Object.values(tableDef.constraints)) {
+      constraints[constraint.name] = constraint
+    }
+  }
+
   // Convert indexes
   for (const [_, indexDef] of Object.entries(tableDef.indexes)) {
     // Map JS property names to actual column names

--- a/frontend/packages/db-structure/src/parser/drizzle/postgres/types.ts
+++ b/frontend/packages/db-structure/src/parser/drizzle/postgres/types.ts
@@ -2,10 +2,13 @@
  * Type definitions for Drizzle ORM schema parsing
  */
 
+import type { Constraint } from '../../../schema/index.js'
+
 export type DrizzleTableDefinition = {
   name: string
   columns: Record<string, DrizzleColumnDefinition>
   indexes: Record<string, DrizzleIndexDefinition>
+  constraints?: Record<string, Constraint>
   compositePrimaryKey?: CompositePrimaryKeyDefinition
   comment?: string | undefined
 }
@@ -39,6 +42,12 @@ export type DrizzleIndexDefinition = {
 export type DrizzleEnumDefinition = {
   name: string
   values: string[]
+}
+
+export type DrizzleCheckConstraintDefinition = {
+  type: 'check'
+  name: string
+  condition: string
 }
 
 export type CompositePrimaryKeyDefinition = {


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
  The Drizzle PostgreSQL parser was missing support for table-level CHECK and UNIQUE constraints,
  while MySQL parser already supported them. This created inconsistency between database parsers and limited PostgreSQL schema parsing capabilities.



###  1. CHECK Constraints Support

  Added support for parsing CHECK constraints in PostgreSQL tables using the `check('constraint_name', sql 'condition')` syntax. This enables validation rules like age limits, string length requirements, and custom business logic constraints to be properly parsed and displayed in ERD visualizations.

https://liam-app-git-feat-drizzle-postgres-table-constraints-liambx.vercel.app/erd/p/github.com/FunamaYukina/drizzle-sample-schema/blob/main/drizzle/mysql/advanced/schema.ts?showMode=ALL_FIELDS&active=users

<img width="1372" height="772" alt="ss 3634" src="https://github.com/user-attachments/assets/c096236a-dde5-47bb-8315-feb5a8b37ec9" />


###  2. Table-level UNIQUE Constraints Support

  Implemented parsing for table-level UNIQUE constraints using the `unique('constraint_name').on(table.column1, table.column2)` syntax. This allows composite unique constraints across multiple columns to be correctly identified and processed, with proper mapping from JavaScript property names to database column names.

https://liam-app-git-feat-drizzle-postgres-table-constraints-liambx.vercel.app/erd/p/github.com/FunamaYukina/drizzle-sample-schema/blob/main/drizzle/mysql/advanced/schema.ts?showMode=ALL_FIELDS&active=bookings

<img width="1201" height="871" alt="ss 3635" src="https://github.com/user-attachments/assets/ea27f0e2-addd-45ef-9bb7-8e7e8348a704" />