### PR TITLE
💄 Improve fold gutter markers with Chevron icons and fix memory leak

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/editorTheme.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/editorTheme.ts
@@ -11,7 +11,17 @@ export const customTheme = EditorView.theme({
   '.cm-lineNumbers': { color: 'var(--overlay-20)' },
   '.cm-foldGutter': {
     color: 'var(--overlay-50)',
-    paddingTop: '2px',
+    paddingTop: 'var(--spacing-half)',
+  },
+  '.cm-foldMarker': {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '16px',
+    height: '16px',
+  },
+  '.cm-foldMarker.closed': {
+    marginTop: '-1px',
   },
   '.cm-content': {
     flex: 1,

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/editorTheme.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/editorTheme.ts
@@ -9,7 +9,10 @@ export const customTheme = EditorView.theme({
     background: 'var(--global-background)',
   },
   '.cm-lineNumbers': { color: 'var(--overlay-20)' },
-  '.cm-foldGutter': { color: 'var(--overlay-50)' },
+  '.cm-foldGutter': {
+    color: 'var(--overlay-50)',
+    paddingTop: '2px',
+  },
   '.cm-content': {
     flex: 1,
     background: 'var(--global-background)',

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
@@ -12,43 +12,20 @@ import type { ReviewComment } from '../../../../../../types'
 import { commentStateField, setCommentsEffect } from './commentExtension'
 import { customTheme, sqlHighlightStyle } from './editorTheme'
 
+// Function to create fold gutter marker DOM elements
+const createFoldMarkerElement = (isOpen: boolean): HTMLElement => {
+  const span = document.createElement('span')
+  span.className = `cm-foldMarker ${isOpen ? 'open' : 'closed'}`
+  const transform = isOpen ? ' transform="rotate(90 8 8)"' : ''
+  span.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 4L10 8L6 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"${transform}/></svg>`
+  return span
+}
+
 const baseExtensions: Extension[] = [
   lineNumbers(),
   foldGutter({
-    markerDOM: (open) => {
-      const container = document.createElement('span')
-      container.style.display = 'inline-flex'
-      container.style.alignItems = 'center'
-      container.style.justifyContent = 'center'
-      container.style.width = '16px'
-      container.style.height = '16px'
-      container.style.marginTop = open ? '0px' : '-1px'
-
-      // Directly insert SVG without React
-      const svgNS = 'http://www.w3.org/2000/svg'
-      const svg = document.createElementNS(svgNS, 'svg')
-      svg.setAttribute('width', '12')
-      svg.setAttribute('height', '12')
-      svg.setAttribute('viewBox', '0 0 24 24')
-      svg.setAttribute('fill', 'none')
-      svg.setAttribute('stroke', 'currentColor')
-      svg.setAttribute('stroke-width', '1.5')
-      svg.setAttribute('stroke-linecap', 'round')
-      svg.setAttribute('stroke-linejoin', 'round')
-
-      const path = document.createElementNS(svgNS, 'path')
-      if (open) {
-        // ChevronDown path
-        path.setAttribute('d', 'M6 9l6 6 6-6')
-      } else {
-        // ChevronRight path
-        path.setAttribute('d', 'M9 18l6-6-6-6')
-      }
-
-      svg.appendChild(path)
-      container.appendChild(svg)
-
-      return container
+    markerDOM: (open): HTMLElement => {
+      return createFoldMarkerElement(open)
     },
   }),
   drawSelection(),

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
@@ -6,10 +6,8 @@ import { lintGutter } from '@codemirror/lint'
 import { unifiedMergeView } from '@codemirror/merge'
 import { EditorState, type Extension } from '@codemirror/state'
 import { drawSelection, lineNumbers } from '@codemirror/view'
-import { ChevronDown, ChevronRight } from '@liam-hq/ui'
 import { EditorView } from 'codemirror'
 import { useEffect, useRef, useState } from 'react'
-import { createRoot } from 'react-dom/client'
 import type { ReviewComment } from '../../../../../../types'
 import { commentStateField, setCommentsEffect } from './commentExtension'
 import { customTheme, sqlHighlightStyle } from './editorTheme'
@@ -26,12 +24,29 @@ const baseExtensions: Extension[] = [
       container.style.height = '16px'
       container.style.marginTop = open ? '0px' : '-1px'
 
-      const root = createRoot(container)
+      // Directly insert SVG without React
+      const svgNS = 'http://www.w3.org/2000/svg'
+      const svg = document.createElementNS(svgNS, 'svg')
+      svg.setAttribute('width', '12')
+      svg.setAttribute('height', '12')
+      svg.setAttribute('viewBox', '0 0 24 24')
+      svg.setAttribute('fill', 'none')
+      svg.setAttribute('stroke', 'currentColor')
+      svg.setAttribute('stroke-width', '1.5')
+      svg.setAttribute('stroke-linecap', 'round')
+      svg.setAttribute('stroke-linejoin', 'round')
+
+      const path = document.createElementNS(svgNS, 'path')
       if (open) {
-        root.render(<ChevronDown size={12} />)
+        // ChevronDown path
+        path.setAttribute('d', 'M6 9l6 6 6-6')
       } else {
-        root.render(<ChevronRight size={12} />)
+        // ChevronRight path
+        path.setAttribute('d', 'M9 18l6-6-6-6')
       }
+
+      svg.appendChild(path)
+      container.appendChild(svg)
 
       return container
     },

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
@@ -6,15 +6,36 @@ import { lintGutter } from '@codemirror/lint'
 import { unifiedMergeView } from '@codemirror/merge'
 import { EditorState, type Extension } from '@codemirror/state'
 import { drawSelection, lineNumbers } from '@codemirror/view'
+import { ChevronDown, ChevronRight } from '@liam-hq/ui'
 import { EditorView } from 'codemirror'
 import { useEffect, useRef, useState } from 'react'
+import { createRoot } from 'react-dom/client'
 import type { ReviewComment } from '../../../../../../types'
 import { commentStateField, setCommentsEffect } from './commentExtension'
 import { customTheme, sqlHighlightStyle } from './editorTheme'
 
 const baseExtensions: Extension[] = [
   lineNumbers(),
-  foldGutter(),
+  foldGutter({
+    markerDOM: (open) => {
+      const container = document.createElement('span')
+      container.style.display = 'inline-flex'
+      container.style.alignItems = 'center'
+      container.style.justifyContent = 'center'
+      container.style.width = '16px'
+      container.style.height = '16px'
+      container.style.marginTop = open ? '0px' : '-1px'
+
+      const root = createRoot(container)
+      if (open) {
+        root.render(<ChevronDown size={12} />)
+      } else {
+        root.render(<ChevronRight size={12} />)
+      }
+
+      return container
+    },
+  }),
   drawSelection(),
   sql(),
   lintGutter(),


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
This PR improves the fold gutter markers in the Schema Updates viewer:

1. **Visual consistency**: Replaces default CodeMirror text characters with Chevron icons from our UI library to match our
design system
2. **Memory leak fix**: The initial React implementation using `createRoot()` caused memory leaks when fold markers were
created/destroyed. This has been fixed by using direct DOM manipulation while maintaining the same visual appearance

The implementation now creates SVG icons directly with the same styling as our lucide-react icons (stroke-width: 1.5).

|        | Open | Close |
|--------|--------------------|--------------------|
| **Before** | ![スクリーンショット 2025-07-23 21:06:55](https://github.com/user-attachments/assets/3babdfe0-1705-4223-bad5-7c27515c3af3) | ![スクリーンショット 2025-07-23 21:07:01](https://github.com/user-attachments/assets/bd404e1b-37c5-4d67-ba68-5d69cafc504e) |
| **After**  | ![スクリーンショット 2025-07-23 21:07:12](https://github.com/user-attachments/assets/25ecdcf6-f975-4a6c-b145-3ccb7ea5de08) | ![スクリーンショット 2025-07-23 21:07:07](https://github.com/user-attachments/assets/6204dc33-cb6a-4d3d-b2a3-573c6742b818) |
