### PR TITLE
💄 Update version dropdown option labels for better usability

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/VersionDropdown/VersionDropdown.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/VersionDropdown/VersionDropdown.tsx
@@ -45,7 +45,7 @@ export const VersionDropdown: FC<Props> = ({
               key={version.id}
               onSelect={() => handleVersionSelect(version)}
             >
-              {`v${version.number}`}
+              {`Version ${version.number}`}
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
This change updates the version dropdown option labels from "vXX" to "Version XX" format to increase the clickable area and improve usability.

- Before: v1, v2, v3...
- After: Version 1, Version 2, Version 3...

By expanding the text in dropdown menu items, users have a larger clickable area. The trigger button remains as "vXX" to maintain a compact appearance.

preview: https://liam-app-git-feature-version-dropdown-label-update-liambx.vercel.app/app/design_sessions/445655f9-f87d-4da0-ae4e-7e74ef55a4fc

<img width="392" height="266" alt="スクリーンショット 2025-07-24 9 49 07" src="https://github.com/user-attachments/assets/5e64c31b-166f-4eb2-91f3-e16ea1ee5ebf" />

