### PR TITLE
💄 Change ErrorMessage link color from green to red

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ErrorMessage/ErrorMessage.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ErrorMessage/ErrorMessage.module.css
@@ -63,3 +63,15 @@
 .retryButton {
   min-width: auto !important;
 }
+
+/* Override link color for error messages */
+.errorText :global(a) {
+  color: var(--danger-high-contrast-text);
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+.errorText :global(a:hover) {
+  opacity: 0.8;
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
The green link color in ErrorMessage components creates poor visual harmony with the red error background. This change improves consistency by using the danger-high-contrast-text color variable for links within error messages.

|        | image                                                                                                    |
|--------|--------------------------------------------------------------------------------------------------------|
| Before | <img width="696" height="460" alt="Before" src="https://github.com/user-attachments/assets/8df1e8c0-e09d-40b0-86c9-a83e308a5c21" />|
| After  | <img width="716" height="482" alt="After" src="https://github.com/user-attachments/assets/291e1370-0d66-45ff-bc6c-a44f5d273de1" />|
