### PR TITLE
⬆️ Use message.text instead of message.content for LangChain messages

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/utils/withTimelineItemSync.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/utils/withTimelineItemSync.ts
@@ -21,10 +21,7 @@ async function handleAIMessage(
 ): Promise<void> {
   const result = await context.repositories.schema.createTimelineItem({
     designSessionId: context.designSessionId,
-    content:
-      typeof message.content === 'string'
-        ? message.content
-        : JSON.stringify(message.content),
+    content: message.text,
     type: 'assistant',
     role: context.assistantRole || 'db',
   })
@@ -40,10 +37,7 @@ async function handleHumanMessage(
 ): Promise<void> {
   const result = await context.repositories.schema.createTimelineItem({
     designSessionId: context.designSessionId,
-    content:
-      typeof message.content === 'string'
-        ? message.content
-        : JSON.stringify(message.content),
+    content: message.text,
     type: 'user',
     userId: context.userId,
   })
@@ -60,10 +54,7 @@ async function handleToolMessage(
   message: ToolMessage,
   context: TimelineSyncContext,
 ): Promise<void> {
-  const content =
-    typeof message.content === 'string'
-      ? message.content
-      : JSON.stringify(message.content)
+  const content = message.text
 
   const isError = content.toLowerCase().includes('error')
   const timelineType = isError ? 'error' : 'assistant'


### PR DESCRIPTION
## Summary
- Replace manual content handling with the native `.text` property for all message types (AIMessage, HumanMessage, ToolMessage) in timeline sync utility
- Simplifies message content extraction and follows LangChain v0.3 API recommendations

## Changes
- Updated `withTimelineItemSync.ts` to use `message.text` instead of conditional content handling
- Removes verbose type checking and JSON.stringify logic
- Maintains backward compatibility through LangChain's `.text` property

## Test plan
- [x] All existing tests pass (11/11)
- [x] Execute design process script runs successfully
- [x] Error detection logic continues to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)