### PR TITLE
feat: use shared TypeScript base config for app tsconfig.json

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/commentExtension.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/commentExtension.tsx
@@ -12,11 +12,13 @@ import { Comment } from './Comment'
 
 // Widget that displays comments as DOM elements
 class CommentWidget extends WidgetType {
-  constructor(
-    readonly comment: ReviewComment,
-    readonly onQuickFix: (comment: string) => void,
-  ) {
+  readonly comment: ReviewComment
+  readonly onQuickFix: (comment: string) => void
+
+  constructor(comment: ReviewComment, onQuickFix: (comment: string) => void) {
     super()
+    this.comment = comment
+    this.onQuickFix = onQuickFix
   }
 
   toDOM() {
@@ -33,7 +35,7 @@ class CommentWidget extends WidgetType {
     return container
   }
 
-  ignoreEvent() {
+  override ignoreEvent() {
     return false
   }
 }

--- a/frontend/apps/app/tsconfig.json
+++ b/frontend/apps/app/tsconfig.json
@@ -1,20 +1,14 @@
 {
+  "extends": "../../internal-packages/configs/tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
-    "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": false,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/2673

## Why is this change needed?

Update `frontend/apps/app/tsconfig.json` to use the shared base configuration from `@frontend/internal-packages/configs/tsconfig/base.json` for consistent strict type checking across the project. This provides improved type safety and eliminates duplicate configuration.

## Changes Made

- **Updated app tsconfig.json** to extend shared base configuration
- **Applied gradual migration approach** by temporarily disabling the most restrictive settings (`noPropertyAccessFromIndexSignature`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`) to avoid extensive codebase changes
- **Fixed TypeScript compatibility issues** in `commentExtension.tsx` including parameter property declarations and override modifiers

## Test plan

- [x] TypeScript compilation passes (`pnpm lint:tsc`)
- [x] All linting passes (`pnpm lint`)
- [x] Code formatting is correct (`pnpm fmt`)
- [x] Pre-commit hooks pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)