### PR TITLE
Replace repository mocks with InMemoryRepository in prepareDmlNode.test.ts

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DMLGenerationAgent } from '../../../langchain/agents/dmlGenerationAgent/agent'
 import type { Repositories } from '../../../repositories'
+import { InMemoryRepository } from '../../../repositories/InMemoryRepository'
 import { convertSchemaToText } from '../../../utils/convertSchemaToText'
 import type { NodeLogger } from '../../../utils/nodeLogger'
 import type { WorkflowState } from '../types'
@@ -33,20 +34,7 @@ describe('prepareDmlNode', () => {
 
   const createMockState = (overrides?: Partial<WorkflowState>) => {
     const repositories: Repositories = {
-      schema: {
-        updateTimelineItem: vi.fn(),
-        getSchema: vi.fn(),
-        getDesignSession: vi.fn(),
-        createVersion: vi.fn(),
-        createTimelineItem: vi.fn().mockResolvedValue(undefined),
-        createArtifact: vi.fn(),
-        updateArtifact: vi.fn(),
-        getArtifact: vi.fn(),
-        createValidationQuery: vi.fn(),
-        createValidationResults: vi.fn(),
-        createWorkflowRun: vi.fn(),
-        updateWorkflowRunStatus: vi.fn(),
-      },
+      schema: new InMemoryRepository(),
     }
 
     return {


### PR DESCRIPTION
resolve: # ## Issue

##2713

### Why is this change needed?
Replace manual repository mocks with InMemoryRepository pattern for more reliable testing and consistency with established patterns.

### Changes
- Replace manual vi.fn() mocks with InMemoryRepository instance
- Remove 14 lines of manual repository method mocking
- Simplify test state creation using InMemoryRepository pattern
- All tests continue to pass with more reliable repository behavior

Generated with [Claude Code](https://claude.ai/code)