### PR TITLE
✨ Add reasoning summary logging in analyze requirements node

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/analyzeRequirementsNode.ts
@@ -121,11 +121,23 @@ export async function analyzeRequirementsNode(
   )
 
   return analysisResult.match(
-    async (result) => {
+    async ({ response, reasoning }) => {
       const analyzedRequirements = {
-        businessRequirement: result.businessRequirement,
-        functionalRequirements: result.functionalRequirements,
-        nonFunctionalRequirements: result.nonFunctionalRequirements,
+        businessRequirement: response.businessRequirement,
+        functionalRequirements: response.functionalRequirements,
+        nonFunctionalRequirements: response.nonFunctionalRequirements,
+      }
+
+      // Log reasoning summary if available
+      if (reasoning?.summary && reasoning.summary.length > 0) {
+        for (const summaryItem of reasoning.summary) {
+          await logAssistantMessage(
+            state,
+            repositories,
+            summaryItem.text,
+            assistantRole,
+          )
+        }
       }
 
       // Create complete message with all analyzed requirements and sync to timeline

--- a/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
@@ -1,38 +1,116 @@
 import { type BaseMessage, SystemMessage } from '@langchain/core/messages'
+import type { Runnable } from '@langchain/core/runnables'
 import { ChatOpenAI } from '@langchain/openai'
-import { toJsonSchema } from '@valibot/to-json-schema'
 import * as v from 'valibot'
 import { PM_ANALYSIS_SYSTEM_MESSAGE } from './prompts'
 
-const requirementsAnalysisSchema = v.object({
+// Direct JsonSchema definition instead of using toJsonSchema
+// because the generated schema has subtle incompatibilities with withStructuredOutput
+// (specifically the properties:{}, required:[] structure).
+// TODO: Migrate from valibot to zod, which is officially supported by langchain
+const REQUIREMENTS_ANALYSIS_SCHEMA = {
+  title: 'RequirementsAnalysis',
+  type: 'object',
+  properties: {
+    businessRequirement: { type: 'string' },
+    functionalRequirements: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: {
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+    nonFunctionalRequirements: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: {
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+  },
+  required: [
+    'businessRequirement',
+    'functionalRequirements',
+    'nonFunctionalRequirements',
+  ],
+  additionalProperties: false,
+}
+
+const requirementsAnalysisSchema = v.strictObject({
   businessRequirement: v.string(),
   functionalRequirements: v.record(v.string(), v.array(v.string())),
   nonFunctionalRequirements: v.record(v.string(), v.array(v.string())),
 })
-
 type AnalysisResponse = v.InferOutput<typeof requirementsAnalysisSchema>
 
+const reasoningSchema = v.object({
+  type: v.literal('reasoning'),
+  summary: v.array(
+    v.object({
+      type: v.literal('summary_text'),
+      text: v.string(),
+    }),
+  ),
+})
+type Reasoning = v.InferOutput<typeof reasoningSchema>
+
+type RunInput = (BaseMessage | SystemMessage)[]
+
+type RunOutput = AnalysisResponse
+
+type AnalysisWithReasoning = {
+  response: AnalysisResponse
+  reasoning: Reasoning | null
+}
+
 export class PMAnalysisAgent {
-  private analysisModel: ReturnType<ChatOpenAI['withStructuredOutput']>
+  private analysisModel: Runnable<
+    RunInput,
+    {
+      raw: BaseMessage
+      parsed: RunOutput
+    }
+  >
 
   constructor() {
     const baseModel = new ChatOpenAI({
       model: 'o4-mini',
+      reasoning: { effort: 'high', summary: 'detailed' },
+      useResponsesApi: true,
     })
 
-    // Convert valibot schema to JSON Schema and bind to model
-    const analysisJsonSchema = toJsonSchema(requirementsAnalysisSchema)
-
-    this.analysisModel = baseModel.withStructuredOutput(analysisJsonSchema)
+    this.analysisModel = baseModel.withStructuredOutput<RunOutput>(
+      REQUIREMENTS_ANALYSIS_SCHEMA,
+      {
+        includeRaw: true,
+      },
+    )
   }
 
-  async generate(messages: BaseMessage[]): Promise<AnalysisResponse> {
-    const allMessages = [
+  async generate(messages: BaseMessage[]): Promise<AnalysisWithReasoning> {
+    const allMessages: (BaseMessage | SystemMessage)[] = [
       new SystemMessage(PM_ANALYSIS_SYSTEM_MESSAGE),
       ...messages,
     ]
 
-    const rawResponse = await this.analysisModel.invoke(allMessages)
-    return v.parse(requirementsAnalysisSchema, rawResponse)
+    const { raw } = await this.analysisModel.invoke(allMessages)
+
+    const parsedReasoning = v.safeParse(
+      reasoningSchema,
+      raw.additional_kwargs['reasoning'],
+    )
+    const reasoning = parsedReasoning.success ? parsedReasoning.output : null
+
+    return {
+      response: v.parse(
+        requirementsAnalysisSchema,
+        raw.additional_kwargs['parsed'],
+      ),
+      reasoning,
+    }
   }
 }


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
This change adds logging for AI reasoning summaries in the analyze requirements node. When the PM Analysis Agent generates reasoning summaries, they are now logged as assistant messages before the main analysis result, providing better transparency into the AI's decision-making process.

<img width="1126" height="993" alt="スクリーンショット 2025-07-28 15 18 18" src="https://github.com/user-attachments/assets/f27692fe-c0fa-4756-bb45-ec856ba7939f" />
