### PR TITLE
✨ Connect VersionMessage onView to version selection handler

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -105,6 +105,7 @@ Please suggest a specific solution to resolve this problem.`
             designSessionId={designSessionId}
             timelineItems={timelineItems}
             onMessageSend={addOrUpdateTimelineItem}
+            onVersionView={handleChangeSelectedVersion}
           />
         </div>
         {hasSelectedVersion && (

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -58,6 +58,13 @@ export const SessionDetailPageClient: FC<Props> = ({
     [setSelectedVersion],
   )
 
+  const handleViewVersion = useCallback((versionId: string) => {
+    const version = versions.find((version) => version.id === versionId)
+    if (!version) return
+
+    setSelectedVersion(version)
+  }, [])
+
   const { timelineItems, addOrUpdateTimelineItem } = useRealtimeTimelineItems(
     designSessionId,
     designSessionWithTimelineItems.timeline_items.map((timelineItem) =>
@@ -105,7 +112,7 @@ Please suggest a specific solution to resolve this problem.`
             designSessionId={designSessionId}
             timelineItems={timelineItems}
             onMessageSend={addOrUpdateTimelineItem}
-            onVersionView={handleChangeSelectedVersion}
+            onVersionView={handleViewVersion}
           />
         </div>
         {hasSelectedVersion && (

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.stories.tsx
@@ -41,6 +41,7 @@ export const Default: Story = {
     designSessionId: 'design-session-id',
     timelineItems: ITEMS,
     onMessageSend: () => {},
+    onVersionView: () => {},
   },
 }
 
@@ -50,6 +51,7 @@ export const AnimatedDemo: Story = {
     designSessionId: 'design-session-id',
     timelineItems: ITEMS,
     onMessageSend: () => {},
+    onVersionView: () => {},
   },
   render: (props) => <AnimatedChatDemo {...props} />,
 }

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
@@ -15,7 +15,7 @@ type Props = {
   designSessionId: string
   timelineItems: TimelineItemEntry[]
   onMessageSend: (message: TimelineItemEntry) => void
-  onVersionView?: (version: import('../../types').Version) => void
+  onVersionView: (versionId: string) => void
   onRetry?: () => void
   isLoading?: boolean
   isStreaming?: boolean
@@ -134,8 +134,9 @@ export const Chat: FC<Props> = ({
                 key={message.id}
                 {...message}
                 showHeader={messageIndex === 0}
-                {...(message.type === 'schema_version' &&
-                  onVersionView && { onView: onVersionView })}
+                {...(message.type === 'schema_version' && {
+                  onView: onVersionView,
+                })}
               />
             ))
           }
@@ -145,8 +146,7 @@ export const Chat: FC<Props> = ({
               key={item.id}
               {...item}
               {...(item.type === 'error' && { onRetry })}
-              {...(item.type === 'schema_version' &&
-                onVersionView && { onView: onVersionView })}
+              {...(item.type === 'schema_version' && { onView: onVersionView })}
             />
           )
         })}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
@@ -15,6 +15,7 @@ type Props = {
   designSessionId: string
   timelineItems: TimelineItemEntry[]
   onMessageSend: (message: TimelineItemEntry) => void
+  onVersionView?: (version: import('../../types').Version) => void
   onRetry?: () => void
   isLoading?: boolean
   isStreaming?: boolean
@@ -26,6 +27,7 @@ export const Chat: FC<Props> = ({
   designSessionId,
   timelineItems,
   onMessageSend,
+  onVersionView,
   onRetry,
   isLoading = false,
   isStreaming = false,
@@ -132,6 +134,8 @@ export const Chat: FC<Props> = ({
                 key={message.id}
                 {...message}
                 showHeader={messageIndex === 0}
+                {...(message.type === 'schema_version' &&
+                  onVersionView && { onView: onVersionView })}
               />
             ))
           }
@@ -141,6 +145,8 @@ export const Chat: FC<Props> = ({
               key={item.id}
               {...item}
               {...(item.type === 'error' && { onRetry })}
+              {...(item.type === 'schema_version' &&
+                onVersionView && { onView: onVersionView })}
             />
           )
         })}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
@@ -19,9 +19,12 @@ export const TimelineItem: FC<Props> = (props) => {
   const { showHeader = true, ...timelineItemProps } = props
 
   return match(timelineItemProps)
-    .with({ type: 'schema_version' }, ({ buildingSchemaVersionId }) => (
+    .with({ type: 'schema_version' }, ({ buildingSchemaVersionId, onView }) => (
       <AgentMessage state="default" assistantRole="db" showHeader={showHeader}>
-        <VersionMessage buildingSchemaVersionId={buildingSchemaVersionId} />
+        <VersionMessage
+          buildingSchemaVersionId={buildingSchemaVersionId}
+          onView={onView}
+        />
       </AgentMessage>
     ))
     .with({ type: 'query_result' }, ({ queryResultId, results }) => (

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/VersionMessage/VersionMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/VersionMessage/VersionMessage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Json } from '@liam-hq/db'
+import type { Json, Tables } from '@liam-hq/db'
 import { operationsSchema } from '@liam-hq/db-structure'
 import {
   ArrowRight,
@@ -19,7 +19,6 @@ import {
   useTransition,
 } from 'react'
 import * as v from 'valibot'
-import type { Version } from '@/components/SessionDetailPage/types'
 import { createClient } from '@/libs/db/client'
 import styles from './VersionMessage.module.css'
 
@@ -82,22 +81,27 @@ const parsePatchOperations = (
   })
 }
 
+type BuildingSchemaVersion = Pick<
+  Tables<'building_schema_versions'>,
+  'patch' | 'number' | 'id'
+>
+
 type Props = {
   buildingSchemaVersionId: string
-  onView?: (version: Version) => void
+  onView?: (versionId: string) => void
 }
 
 export const VersionMessage: FC<Props> = ({
   buildingSchemaVersionId,
   onView,
 }) => {
-  const [version, setVersion] = useState<Version | null>(null)
+  const [version, setVersion] = useState<BuildingSchemaVersion | null>(null)
   const [isPending, startTransition] = useTransition()
   const [isExpanded, setIsExpanded] = useState(false)
 
   const handleClick = useCallback(() => {
     if (!version) return
-    onView?.(version)
+    onView?.(version.id)
   }, [version, onView])
 
   useEffect(() => {
@@ -105,7 +109,7 @@ export const VersionMessage: FC<Props> = ({
       const supabase = createClient()
       const { data, error } = await supabase
         .from('building_schema_versions')
-        .select('id, number, patch, reverse_patch, building_schema_id')
+        .select('id, number, patch')
         .eq('id', buildingSchemaVersionId)
         .single()
 

--- a/frontend/apps/app/components/SessionDetailPage/types.ts
+++ b/frontend/apps/app/components/SessionDetailPage/types.ts
@@ -80,7 +80,7 @@ export type AssistantTimelineItemEntry = BaseTimelineItemEntry & {
 export type SchemaVersionTimelineItemEntry = BaseTimelineItemEntry & {
   type: 'schema_version'
   buildingSchemaVersionId: string
-  onView?: (version: Version) => void
+  onView?: (versionId: string) => void
 }
 
 export type ErrorTimelineItemEntry = BaseTimelineItemEntry & {

--- a/frontend/apps/app/components/SessionDetailPage/types.ts
+++ b/frontend/apps/app/components/SessionDetailPage/types.ts
@@ -80,6 +80,7 @@ export type AssistantTimelineItemEntry = BaseTimelineItemEntry & {
 export type SchemaVersionTimelineItemEntry = BaseTimelineItemEntry & {
   type: 'schema_version'
   buildingSchemaVersionId: string
+  onView?: (version: Version) => void
 }
 
 export type ErrorTimelineItemEntry = BaseTimelineItemEntry & {


### PR DESCRIPTION
## Issue

- resolve: #

## Why is this change needed?

When users click the "View" button on a version message in the chat, the selected version should be updated to display the corresponding schema. This change connects the VersionMessage component's onView callback to the SessionDetailPageClient's handleChangeSelectedVersion function to enable version switching functionality.

https://github.com/user-attachments/assets/760e5fcb-3573-4d05-9755-c0bce24f63ce


