### PR TITLE
✨ Add reasoning output support to databaseSchemaBuildAgent

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.integration.test.ts
@@ -109,7 +109,10 @@ describe('designSchemaNode -> executeDdlNode integration', () => {
     )
     const mockInvokeDesignAgent = vi.mocked(invokeDesignAgent)
     mockInvokeDesignAgent.mockResolvedValue(
-      ok(new AIMessage('Created users table with id and name fields')),
+      ok({
+        response: new AIMessage('Created users table with id and name fields'),
+        reasoning: null,
+      }),
     )
 
     const initialState = createMockState(initialSchema)
@@ -221,7 +224,10 @@ describe('designSchemaNode -> executeDdlNode integration', () => {
     )
     const mockInvokeDesignAgent = vi.mocked(invokeDesignAgent)
     mockInvokeDesignAgent.mockResolvedValue(
-      ok(new AIMessage('Repository will fail')),
+      ok({
+        response: new AIMessage('Repository will fail'),
+        reasoning: null,
+      }),
     )
 
     // Mock agent invocation failure

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.retry.test.ts
@@ -22,7 +22,10 @@ describe('designSchemaNode retry behavior', () => {
     )
     const mockInvokeDesignAgent = vi.mocked(invokeDesignAgent)
     mockInvokeDesignAgent.mockResolvedValue(
-      ok(new AIMessage('Schema generated successfully')),
+      ok({
+        response: new AIMessage('Schema generated successfully'),
+        reasoning: null,
+      }),
     )
 
     const mockRepositories = {

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -75,8 +75,22 @@ Please fix this issue by analyzing the schema and adding any missing constraints
     }
   }
 
+  const { response, reasoning } = invokeResult.value
+
+  // Log reasoning summary if available
+  if (reasoning?.summary && reasoning.summary.length > 0) {
+    for (const summaryItem of reasoning.summary) {
+      await logAssistantMessage(
+        state,
+        repositories,
+        summaryItem.text,
+        assistantRole,
+      )
+    }
+  }
+
   // Apply timeline sync to the message and clear retry flags
-  const syncedMessage = await withTimelineItemSync(invokeResult.value, {
+  const syncedMessage = await withTimelineItemSync(response, {
     designSessionId: state.designSessionId,
     organizationId: state.organizationId || '',
     userId: state.userId,

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/generateUsecaseNode.ts
@@ -103,10 +103,22 @@ export async function generateUsecaseNode(
   )
 
   return await usecaseResult.match(
-    async (generatedResult) => {
+    async ({ response, reasoning }) => {
+      // Log reasoning summary if available
+      if (reasoning?.summary && reasoning.summary.length > 0) {
+        for (const summaryItem of reasoning.summary) {
+          await logAssistantMessage(
+            state,
+            repositories,
+            summaryItem.text,
+            assistantRole,
+          )
+        }
+      }
+
       const usecaseMessage = await withTimelineItemSync(
         new AIMessage({
-          content: `Generated ${generatedResult.usecases.length} use cases for testing and validation`,
+          content: `Generated ${response.usecases.length} use cases for testing and validation`,
           name: 'QAGenerateUsecaseAgent',
         }),
         {
@@ -121,7 +133,7 @@ export async function generateUsecaseNode(
       const updatedState = {
         ...state,
         messages: [...state.messages, usecaseMessage],
-        generatedUsecases: generatedResult.usecases,
+        generatedUsecases: response.usecases,
         error: undefined, // Clear error on success
       }
 

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/agent.ts
@@ -5,19 +5,29 @@ import {
 } from '@langchain/core/messages'
 import { ChatOpenAI } from '@langchain/openai'
 import { ok, ResultAsync } from 'neverthrow'
+import * as v from 'valibot'
 import type { ToolConfigurable } from '../../../db-agent/getToolConfigurable'
 import { schemaDesignTool } from '../../../db-agent/tools/schemaDesignTool'
+import { reasoningSchema } from '../../utils/schema'
+import type { Reasoning } from '../../utils/types'
 import { type DesignAgentPromptVariables, designAgentPrompt } from './prompts'
 
 const model = new ChatOpenAI({
   model: 'o4-mini',
+  reasoning: { effort: 'high', summary: 'detailed' },
+  useResponsesApi: true,
 }).bindTools([schemaDesignTool])
+
+type DesignAgentResult = {
+  response: AIMessage
+  reasoning: Reasoning | null
+}
 
 export const invokeDesignAgent = (
   variables: DesignAgentPromptVariables,
   messages: BaseMessage[],
   configurable: ToolConfigurable,
-): ResultAsync<AIMessage, Error> => {
+): ResultAsync<DesignAgentResult, Error> => {
   const formatPrompt = ResultAsync.fromSafePromise(
     designAgentPrompt.format(variables),
   )
@@ -29,5 +39,16 @@ export const invokeDesignAgent = (
     (error) => new Error(`Failed to invoke design agent: ${error}`),
   )
 
-  return formatPrompt.andThen(invoke).andThen((response) => ok(response))
+  return formatPrompt.andThen(invoke).andThen((response) => {
+    const parsedReasoning = v.safeParse(
+      reasoningSchema,
+      response.additional_kwargs['reasoning'],
+    )
+    const reasoning = parsedReasoning.success ? parsedReasoning.output : null
+
+    return ok({
+      response,
+      reasoning,
+    })
+  })
 }

--- a/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
@@ -2,6 +2,8 @@ import { type BaseMessage, SystemMessage } from '@langchain/core/messages'
 import type { Runnable } from '@langchain/core/runnables'
 import { ChatOpenAI } from '@langchain/openai'
 import * as v from 'valibot'
+import { reasoningSchema } from '../../utils/schema'
+import type { Reasoning } from '../../utils/types'
 import { PM_ANALYSIS_SYSTEM_MESSAGE } from './prompts'
 
 // Direct JsonSchema definition instead of using toJsonSchema
@@ -46,17 +48,6 @@ const requirementsAnalysisSchema = v.strictObject({
   nonFunctionalRequirements: v.record(v.string(), v.array(v.string())),
 })
 type AnalysisResponse = v.InferOutput<typeof requirementsAnalysisSchema>
-
-const reasoningSchema = v.object({
-  type: v.literal('reasoning'),
-  summary: v.array(
-    v.object({
-      type: v.literal('summary_text'),
-      text: v.string(),
-    }),
-  ),
-})
-type Reasoning = v.InferOutput<typeof reasoningSchema>
 
 type RunInput = (BaseMessage | SystemMessage)[]
 

--- a/frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/qaGenerateUsecaseAgent/agent.ts
@@ -1,8 +1,47 @@
 import { type BaseMessage, SystemMessage } from '@langchain/core/messages'
+import type { Runnable } from '@langchain/core/runnables'
 import { ChatOpenAI } from '@langchain/openai'
-import { toJsonSchema } from '@valibot/to-json-schema'
 import * as v from 'valibot'
+import { reasoningSchema } from '../../utils/schema'
+import type { Reasoning } from '../../utils/types'
 import { QA_GENERATE_USECASE_SYSTEM_MESSAGE } from './prompts'
+
+// Direct JsonSchema definition instead of using toJsonSchema
+// because the generated schema has subtle incompatibilities with withStructuredOutput
+// (specifically the properties:{}, required:[] structure).
+// TODO: Migrate from valibot to zod, which is officially supported by langchain
+const USECASE_GENERATION_SCHEMA = {
+  title: 'UsecaseGeneration',
+  type: 'object',
+  properties: {
+    usecases: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          requirementType: {
+            type: 'string',
+            enum: ['functional', 'non_functional'],
+          },
+          requirementCategory: { type: 'string' },
+          requirement: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+        },
+        required: [
+          'requirementType',
+          'requirementCategory',
+          'requirement',
+          'title',
+          'description',
+        ],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['usecases'],
+  additionalProperties: false,
+}
 
 // Single usecase schema
 const usecaseSchema = v.object({
@@ -22,25 +61,58 @@ const usecaseGenerationSchema = v.object({
 export type Usecase = v.InferOutput<typeof usecaseSchema>
 type UsecaseResponse = v.InferOutput<typeof usecaseGenerationSchema>
 
+type RunInput = (BaseMessage | SystemMessage)[]
+
+type RunOutput = UsecaseResponse
+
+type UsecaseWithReasoning = {
+  response: UsecaseResponse
+  reasoning: Reasoning | null
+}
+
 export class QAGenerateUsecaseAgent {
-  private usecaseModel: ReturnType<ChatOpenAI['withStructuredOutput']>
+  private usecaseModel: Runnable<
+    RunInput,
+    {
+      raw: BaseMessage
+      parsed: RunOutput
+    }
+  >
 
   constructor() {
     const baseModel = new ChatOpenAI({
       model: 'o4-mini',
+      reasoning: { effort: 'high', summary: 'detailed' },
+      useResponsesApi: true,
     })
 
-    const usecaseJsonSchema = toJsonSchema(usecaseGenerationSchema)
-    this.usecaseModel = baseModel.withStructuredOutput(usecaseJsonSchema)
+    this.usecaseModel = baseModel.withStructuredOutput<RunOutput>(
+      USECASE_GENERATION_SCHEMA,
+      {
+        includeRaw: true,
+      },
+    )
   }
 
-  async generate(messages: BaseMessage[]): Promise<UsecaseResponse> {
+  async generate(messages: BaseMessage[]): Promise<UsecaseWithReasoning> {
     const allMessages = [
       new SystemMessage(QA_GENERATE_USECASE_SYSTEM_MESSAGE),
       ...messages,
     ]
 
-    const rawResponse = await this.usecaseModel.invoke(allMessages)
-    return v.parse(usecaseGenerationSchema, rawResponse)
+    const { raw } = await this.usecaseModel.invoke(allMessages)
+    const parsedReasoning = v.safeParse(
+      reasoningSchema,
+      raw.additional_kwargs['reasoning'],
+    )
+    const reasoning = parsedReasoning.success ? parsedReasoning.output : null
+
+    return {
+      response: v.parse(
+        usecaseGenerationSchema,
+        raw.additional_kwargs['parsed'],
+      ),
+      reasoning,
+    }
   }
 }

--- a/frontend/internal-packages/agent/src/langchain/utils/schema.ts
+++ b/frontend/internal-packages/agent/src/langchain/utils/schema.ts
@@ -1,0 +1,11 @@
+import * as v from 'valibot'
+
+export const reasoningSchema = v.object({
+  type: v.literal('reasoning'),
+  summary: v.array(
+    v.object({
+      type: v.literal('summary_text'),
+      text: v.string(),
+    }),
+  ),
+})

--- a/frontend/internal-packages/agent/src/langchain/utils/types.ts
+++ b/frontend/internal-packages/agent/src/langchain/utils/types.ts
@@ -1,3 +1,8 @@
+import type * as v from 'valibot'
+import type { reasoningSchema } from './schema'
+
 export type ChatAgent<TVariables = unknown, TResponse = string> = {
   generate(variables: TVariables): Promise<TResponse>
 }
+
+export type Reasoning = v.InferOutput<typeof reasoningSchema>


### PR DESCRIPTION
## Issue

- resolve: N/A
- Related to: #2730

## Why is this change needed?

This change extends the reasoning output functionality implemented in #2730 for `analyzeRequirementsNode` to the `databaseSchemaBuildAgent`. This is part of a broader effort to add reasoning transparency across all AI agents in the system, providing better visibility into the decision-making process.

## Summary

Following the pattern established in #2730 for the PM Analysis Agent:
- Added reasoning response structure to `invokeDesignAgent` similar to `PMAnalysisAgent`
- Updated `designSchemaNode` to log reasoning summaries via `logAssistantMessage`
- Modified return type to include both response and reasoning fields
- Updated all related tests to handle the new response structure

This ensures consistency across all agents and provides users with insights into how the AI makes decisions during database schema design.

| designSchemaNode | generateUsecaseNode |
|--------|--------|
| <img width="1124" height="994" alt="スクリーンショット 2025-07-29 17 30 08" src="https://github.com/user-attachments/assets/55525108-4e9e-42d8-b31c-3ccf864ef884" /> | <img width="1124" height="993" alt="スクリーンショット 2025-07-29 15 00 01" src="https://github.com/user-attachments/assets/41a1b34a-9c0e-4a0f-af3d-a54ec3c93492" /> | 







