### PR TITLE
✨ Add ViewLink component for timeline item navigation

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -2,10 +2,11 @@
 
 import type { Schema } from '@liam-hq/db-structure'
 import clsx from 'clsx'
-import { type FC, useCallback } from 'react'
+import { type FC, useCallback, useState } from 'react'
 import { Chat } from './components/Chat'
 import { Output } from './components/Output'
 import { useRealtimeArtifact } from './components/Output/components/Artifact/hooks/useRealtimeArtifact'
+import { OUTPUT_TABS } from './components/Output/constants'
 import { OutputPlaceholder } from './components/OutputPlaceholder'
 import { useRealtimeTimelineItems } from './hooks/useRealtimeTimelineItems'
 import { useRealtimeVersionsWithSchema } from './hooks/useRealtimeVersionsWithSchema'
@@ -72,6 +73,12 @@ export const SessionDetailPageClient: FC<Props> = ({
     ),
   )
 
+  const [activeTab, setActiveTab] = useState<string | undefined>(undefined)
+
+  const handleArtifactLinkClick = useCallback(() => {
+    setActiveTab(OUTPUT_TABS.ARTIFACT)
+  }, [])
+
   const hasSelectedVersion = selectedVersion !== null
 
   // Use realtime artifact hook to monitor artifact changes
@@ -103,20 +110,35 @@ export const SessionDetailPageClient: FC<Props> = ({
             isWorkflowRunning={status === 'pending'}
             onMessageSend={addOrUpdateTimelineItem}
             onVersionView={handleViewVersion}
+            onArtifactLinkClick={handleArtifactLinkClick}
           />
         </div>
         {hasSelectedVersion && (
           <div className={styles.outputSection}>
             {shouldShowOutput ? (
-              <Output
-                designSessionId={designSessionId}
-                schema={displayedSchema}
-                prevSchema={prevSchema}
-                sqlReviewComments={SQL_REVIEW_COMMENTS}
-                versions={versions}
-                selectedVersion={selectedVersion}
-                onSelectedVersionChange={handleChangeSelectedVersion}
-              />
+              activeTab !== undefined ? (
+                <Output
+                  designSessionId={designSessionId}
+                  schema={displayedSchema}
+                  prevSchema={prevSchema}
+                  sqlReviewComments={SQL_REVIEW_COMMENTS}
+                  versions={versions}
+                  selectedVersion={selectedVersion}
+                  onSelectedVersionChange={handleChangeSelectedVersion}
+                  activeTab={activeTab}
+                  onTabChange={setActiveTab}
+                />
+              ) : (
+                <Output
+                  designSessionId={designSessionId}
+                  schema={displayedSchema}
+                  prevSchema={prevSchema}
+                  sqlReviewComments={SQL_REVIEW_COMMENTS}
+                  versions={versions}
+                  selectedVersion={selectedVersion}
+                  onSelectedVersionChange={handleChangeSelectedVersion}
+                />
+              )
             ) : (
               <OutputPlaceholder />
             )}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.stories.tsx
@@ -42,6 +42,7 @@ export const Default: Story = {
     timelineItems: ITEMS,
     onMessageSend: () => {},
     onVersionView: () => {},
+    onArtifactLinkClick: () => {},
   },
 }
 
@@ -52,6 +53,7 @@ export const AnimatedDemo: Story = {
     timelineItems: ITEMS,
     onMessageSend: () => {},
     onVersionView: () => {},
+    onArtifactLinkClick: () => {},
   },
   render: (props) => <AnimatedChatDemo {...props} />,
 }

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
@@ -19,7 +19,7 @@ type Props = {
   onVersionView: (versionId: string) => void
   onRetry?: () => void
   isWorkflowRunning?: boolean
-  onArtifactLinkClick?: () => void
+  onArtifactLinkClick: () => void
 }
 
 export const Chat: FC<Props> = ({

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
@@ -19,6 +19,7 @@ type Props = {
   onVersionView: (versionId: string) => void
   onRetry?: () => void
   isWorkflowRunning?: boolean
+  onArtifactLinkClick?: () => void
 }
 
 export const Chat: FC<Props> = ({
@@ -29,6 +30,7 @@ export const Chat: FC<Props> = ({
   onVersionView,
   onRetry,
   isWorkflowRunning = false,
+  onArtifactLinkClick,
 }) => {
   const { containerRef } = useScrollToBottom<HTMLDivElement>(
     timelineItems.length,
@@ -136,6 +138,7 @@ export const Chat: FC<Props> = ({
                 {...(message.type === 'schema_version' && {
                   onView: onVersionView,
                 })}
+                onArtifactLinkClick={onArtifactLinkClick}
               />
             ))
           }
@@ -146,6 +149,7 @@ export const Chat: FC<Props> = ({
               {...item}
               {...(item.type === 'error' && { onRetry })}
               {...(item.type === 'schema_version' && { onView: onVersionView })}
+              onArtifactLinkClick={onArtifactLinkClick}
             />
           )
         })}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
@@ -9,14 +9,54 @@ import { LogMessage } from './components/LogMessage'
 import { QueryResultMessage } from './components/QueryResultMessage'
 import { UserMessage } from './components/UserMessage'
 import { VersionMessage } from './components/VersionMessage'
+import { ViewLink } from './components/ViewLink'
+import {
+  ARTIFACT_TRIGGER_MESSAGES,
+  PM_AGENT_ROLE,
+  QA_AGENT_ROLE,
+} from './constants'
 
 type Props = PropsWithChildren &
   TimelineItemEntry & {
     showHeader?: boolean
+    onArtifactLinkClick?: () => void
   }
 
+type AgentRole = typeof PM_AGENT_ROLE | typeof QA_AGENT_ROLE
+
+type ViewLinkConfig = {
+  text: string
+}
+
+type ViewLinkKey = `${AgentRole}:${string}`
+
+const viewLinkConfigMap: Record<ViewLinkKey, ViewLinkConfig> = {
+  [`${PM_AGENT_ROLE}:${ARTIFACT_TRIGGER_MESSAGES.REQUIREMENTS_ANALYZED}`]: {
+    text: 'View Requirements',
+  },
+  [`${QA_AGENT_ROLE}:${ARTIFACT_TRIGGER_MESSAGES.USE_CASES_SAVED}`]: {
+    text: 'View Use Cases',
+  },
+}
+
+const isAgentRole = (role: string): role is AgentRole => {
+  return role === PM_AGENT_ROLE || role === QA_AGENT_ROLE
+}
+
+const getViewLinkConfig = (
+  content: string,
+  role: string,
+): ViewLinkConfig | null => {
+  if (!isAgentRole(role)) {
+    return null
+  }
+
+  const key: ViewLinkKey = `${role}:${content}`
+  return viewLinkConfigMap[key] || null
+}
+
 export const TimelineItem: FC<Props> = (props) => {
-  const { showHeader = true, ...timelineItemProps } = props
+  const { showHeader = true, onArtifactLinkClick, ...timelineItemProps } = props
 
   return match(timelineItemProps)
     .with({ type: 'schema_version' }, ({ buildingSchemaVersionId, onView }) => (
@@ -42,29 +82,49 @@ export const TimelineItem: FC<Props> = (props) => {
         userName={userName}
       />
     ))
-    .with({ type: 'assistant_log' }, ({ content, role }) => (
-      <AgentMessage
-        state="default"
-        assistantRole={role}
-        showHeader={showHeader}
-      >
-        <LogMessage content={content} />
-      </AgentMessage>
-    ))
-    .with({ type: 'assistant' }, ({ content, role, timestamp, children }) => (
-      <AgentMessage
-        state="default"
-        assistantRole={role}
-        message={content}
-        time={timestamp.toLocaleTimeString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-        })}
-        showHeader={showHeader}
-      >
-        {children}
-      </AgentMessage>
-    ))
+    .with({ type: 'assistant_log' }, ({ content, role }) => {
+      const viewLinkConfig = getViewLinkConfig(content, role)
+      return (
+        <AgentMessage
+          state="default"
+          assistantRole={role}
+          showHeader={showHeader}
+        >
+          <LogMessage content={content} />
+          {viewLinkConfig && (
+            <ViewLink
+              text={viewLinkConfig.text}
+              onClick={onArtifactLinkClick}
+              ariaLabel={`Navigate to ${viewLinkConfig.text.toLowerCase()} tab`}
+            />
+          )}
+        </AgentMessage>
+      )
+    })
+    .with({ type: 'assistant' }, ({ content, role, timestamp, children }) => {
+      const viewLinkConfig = getViewLinkConfig(content, role)
+      return (
+        <AgentMessage
+          state="default"
+          assistantRole={role}
+          message={content}
+          time={timestamp.toLocaleTimeString([], {
+            hour: '2-digit',
+            minute: '2-digit',
+          })}
+          showHeader={showHeader}
+        >
+          {children}
+          {viewLinkConfig && (
+            <ViewLink
+              text={viewLinkConfig.text}
+              onClick={onArtifactLinkClick}
+              ariaLabel={`Navigate to ${viewLinkConfig.text.toLowerCase()} tab`}
+            />
+          )}
+        </AgentMessage>
+      )
+    })
     .with({ type: 'error' }, ({ content, onRetry }) => (
       <AgentMessage state="default" assistantRole="db" showHeader={showHeader}>
         <ErrorMessage message={content} onRetry={onRetry} />

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/TimelineItem.tsx
@@ -15,7 +15,7 @@ import { PM_AGENT_ROLE, QA_AGENT_ROLE } from './constants'
 type Props = PropsWithChildren &
   TimelineItemEntry & {
     showHeader?: boolean
-    onArtifactLinkClick?: () => void
+    onArtifactLinkClick: () => void
   }
 
 type ViewLinkConfig = {

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.stories.tsx
@@ -4,6 +4,7 @@ import {
   MessageOptionButtons,
 } from '@/components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/components/MessageOptionButtons/MessageOptionButtons'
 import { ProcessIndicator } from '../ProcessIndicator'
+import { ViewLink } from '../ViewLink'
 import { AgentMessage } from './AgentMessage'
 
 const meta = {
@@ -513,6 +514,38 @@ export const BuildAfterOptionSelectedCompleteCollapsed: Story = {
         primaryActionLabel="View Schema"
         secondaryActionLabel="Close"
         initialExpanded={false}
+      />
+    ),
+  },
+}
+
+export const PMWithRequirementsAnalyzed: Story = {
+  args: {
+    state: 'default',
+    message: 'Your requirements have been analyzed and saved',
+    time: '14:30',
+    assistantRole: 'pm',
+    children: (
+      <ViewLink
+        text="View Requirements"
+        ariaLabel="Navigate to requirements tab"
+        onClick={() => {}}
+      />
+    ),
+  },
+}
+
+export const QAWithUseCasesSaved: Story = {
+  args: {
+    state: 'default',
+    message: 'Your use cases have been saved and are ready for implementation',
+    time: '14:35',
+    assistantRole: 'qa',
+    children: (
+      <ViewLink
+        text="View Use Cases"
+        ariaLabel="Navigate to use cases tab"
+        onClick={() => {}}
       />
     ),
   },

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.module.css
@@ -1,0 +1,6 @@
+.viewLinkContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: var(--spacing-2);
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ViewLink } from './ViewLink'
+
+const meta = {
+  component: ViewLink,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onClick: { action: 'clicked' },
+  },
+} satisfies Meta<typeof ViewLink>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    ariaLabel: 'Navigate to artifact view',
+  },
+}
+
+export const WithCustomText: Story = {
+  args: {
+    text: 'View Details',
+    ariaLabel: 'Navigate to details view',
+  },
+}
+
+export const ToUseCasesSection: Story = {
+  args: {
+    text: 'View Use Cases',
+    ariaLabel: 'Navigate to use cases tab',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Link to navigate to Use Cases section in Artifact tab',
+      },
+    },
+  },
+}
+
+export const ToERDTab: Story = {
+  args: {
+    text: 'View ERD',
+    ariaLabel: 'Navigate to ERD tab',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Link to navigate to ERD tab',
+      },
+    },
+  },
+}
+
+export const ToUpdateSchemaTab: Story = {
+  args: {
+    text: 'View Schema Updates',
+    ariaLabel: 'Navigate to update schema tab',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Link to navigate to Update Schema tab',
+      },
+    },
+  },
+}
+
+export const ToSpecificIssue: Story = {
+  args: {
+    text: 'View Issue Details',
+    ariaLabel: 'Navigate to issue details in update schema tab',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Link to navigate to a specific issue within Update Schema tab',
+      },
+    },
+  },
+}
+
+export const WithClickHandler: Story = {
+  args: {
+    text: 'Click Me',
+    ariaLabel: 'Custom action button',
+    onClick: () => {
+      // Handle click event
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Example with a custom click handler',
+      },
+    },
+  },
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
+    text: 'View Artifact',
     ariaLabel: 'Navigate to artifact view',
   },
 }

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.tsx
@@ -8,7 +8,7 @@ type ViewLinkProps = {
   /**
    * The text to display in the link
    */
-  text?: string
+  text: string
   /**
    * Callback function when the link is clicked
    */
@@ -22,11 +22,7 @@ type ViewLinkProps = {
 /**
  * A link component for navigating to different views or sections
  */
-export const ViewLink: FC<ViewLinkProps> = ({
-  text = 'View Artifact',
-  onClick,
-  ariaLabel,
-}) => {
+export const ViewLink: FC<ViewLinkProps> = ({ text, onClick, ariaLabel }) => {
   return (
     <div className={styles.viewLinkContainer}>
       <Button

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/ViewLink.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { ArrowRight, Button } from '@liam-hq/ui'
+import type { FC } from 'react'
+import styles from './ViewLink.module.css'
+
+type ViewLinkProps = {
+  /**
+   * The text to display in the link
+   */
+  text?: string
+  /**
+   * Callback function when the link is clicked
+   */
+  onClick?: (() => void) | undefined
+  /**
+   * Accessible label for screen readers - required for proper accessibility
+   */
+  ariaLabel: string
+}
+
+/**
+ * A link component for navigating to different views or sections
+ */
+export const ViewLink: FC<ViewLinkProps> = ({
+  text = 'View Artifact',
+  onClick,
+  ariaLabel,
+}) => {
+  return (
+    <div className={styles.viewLinkContainer}>
+      <Button
+        variant="outline-secondary"
+        size="xs"
+        rightIcon={<ArrowRight size={14} />}
+        onClick={onClick}
+        disabled={!onClick}
+        aria-label={ariaLabel}
+      >
+        {text}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/index.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/components/ViewLink/index.ts
@@ -1,0 +1,1 @@
+export { ViewLink } from './ViewLink'

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/constants.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Predefined messages triggered by artifact-related events
+ */
+export const ARTIFACT_TRIGGER_MESSAGES = {
+  REQUIREMENTS_ANALYZED: 'Your requirements have been analyzed and saved',
+  USE_CASES_SAVED:
+    'Your use cases have been saved and are ready for implementation',
+} as const
+
+/**
+ * Role identifier for the project manager agent
+ * Fixed value: 'pm' - must match backend API values
+ */
+export const PM_AGENT_ROLE = 'pm' as const
+
+/**
+ * Role identifier for the quality assurance agent
+ * Fixed value: 'qa' - must match backend API values
+ */
+export const QA_AGENT_ROLE = 'qa' as const

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/constants.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/TimelineItem/constants.ts
@@ -1,13 +1,4 @@
 /**
- * Predefined messages triggered by artifact-related events
- */
-export const ARTIFACT_TRIGGER_MESSAGES = {
-  REQUIREMENTS_ANALYZED: 'Your requirements have been analyzed and saved',
-  USE_CASES_SAVED:
-    'Your use cases have been saved and are ready for implementation',
-} as const
-
-/**
  * Role identifier for the project manager agent
  * Fixed value: 'pm' - must match backend API values
  */

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
@@ -42,7 +42,8 @@ export const Output: FC<Props> = ({
   onTabChange,
   ...propsForVersionDropdown
 }) => {
-  const [internalTabValue, setInternalTabValue] = useState<OutputTabValue>(DEFAULT_OUTPUT_TAB)
+  const [internalTabValue, setInternalTabValue] =
+    useState<OutputTabValue>(DEFAULT_OUTPUT_TAB)
 
   const isTabValue = (value: string): value is OutputTabValue => {
     return Object.values(OUTPUT_TABS).some((tabValue) => tabValue === value)
@@ -56,7 +57,8 @@ export const Output: FC<Props> = ({
 
   // Use external control if provided, otherwise use internal state
   const isControlled = activeTab !== undefined
-  const tabValue = isControlled && isTabValue(activeTab) ? (activeTab as OutputTabValue) : internalTabValue
+  const tabValue =
+    isControlled && isTabValue(activeTab) ? activeTab : internalTabValue
   const handleTabChange = isControlled ? onTabChange : handleChangeValue
 
   return (

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
@@ -14,21 +14,35 @@ import {
 } from './constants'
 import styles from './Output.module.css'
 
-type Props = ComponentProps<typeof VersionDropdown> & {
+type BaseProps = ComponentProps<typeof VersionDropdown> & {
   designSessionId: string
   schema: Schema
   prevSchema: Schema
   sqlReviewComments: ReviewComment[]
 }
 
+type ControlledProps = BaseProps & {
+  activeTab: string
+  onTabChange: (value: string) => void
+}
+
+type UncontrolledProps = BaseProps & {
+  activeTab?: never
+  onTabChange?: never
+}
+
+type Props = ControlledProps | UncontrolledProps
+
 export const Output: FC<Props> = ({
   designSessionId,
   schema,
   prevSchema,
   sqlReviewComments,
+  activeTab,
+  onTabChange,
   ...propsForVersionDropdown
 }) => {
-  const [tabValue, setTabValue] = useState<OutputTabValue>(DEFAULT_OUTPUT_TAB)
+  const [internalTabValue, setInternalTabValue] = useState<OutputTabValue>(DEFAULT_OUTPUT_TAB)
 
   const isTabValue = (value: string): value is OutputTabValue => {
     return Object.values(OUTPUT_TABS).some((tabValue) => tabValue === value)
@@ -36,15 +50,20 @@ export const Output: FC<Props> = ({
 
   const handleChangeValue = useCallback((value: string) => {
     if (isTabValue(value)) {
-      setTabValue(value)
+      setInternalTabValue(value)
     }
   }, [])
+
+  // Use external control if provided, otherwise use internal state
+  const isControlled = activeTab !== undefined
+  const tabValue = isControlled && isTabValue(activeTab) ? (activeTab as OutputTabValue) : internalTabValue
+  const handleTabChange = isControlled ? onTabChange : handleChangeValue
 
   return (
     <TabsRoot
       value={tabValue}
       className={styles.tabsRoot}
-      onValueChange={handleChangeValue}
+      onValueChange={handleTabChange}
     >
       <Header
         schema={schema}

--- a/frontend/apps/app/components/SessionDetailPage/services/convertTimelineItemToTimelineItemEntry.ts
+++ b/frontend/apps/app/components/SessionDetailPage/services/convertTimelineItemToTimelineItemEntry.ts
@@ -17,6 +17,8 @@ export const convertTimelineItemToTimelineItemEntry = (
     id: timelineItem.id,
     content: timelineItem.content,
     timestamp: new Date(timelineItem.created_at),
+    // Include artifact_action from backend if available
+    artifactAction: timelineItem.artifact_action,
   }
 
   return match(timelineItem)
@@ -42,8 +44,6 @@ export const convertTimelineItemToTimelineItemEntry = (
         ...baseItem,
         type: 'assistant',
         role: item.assistant_role ?? 'db',
-        // TODO: Backend needs to provide artifact_action field
-        artifactAction: item.artifact_action,
       }),
     )
     .with(
@@ -59,8 +59,6 @@ export const convertTimelineItemToTimelineItemEntry = (
         ...baseItem,
         type: 'assistant_log',
         role: item.assistant_role ?? 'db',
-        // TODO: Backend needs to provide artifact_action field
-        artifactAction: item.artifact_action,
       }),
     )
     .with(

--- a/frontend/apps/app/components/SessionDetailPage/services/convertTimelineItemToTimelineItemEntry.ts
+++ b/frontend/apps/app/components/SessionDetailPage/services/convertTimelineItemToTimelineItemEntry.ts
@@ -42,6 +42,8 @@ export const convertTimelineItemToTimelineItemEntry = (
         ...baseItem,
         type: 'assistant',
         role: item.assistant_role ?? 'db',
+        // TODO: Backend needs to provide artifact_action field
+        artifactAction: item.artifact_action,
       }),
     )
     .with(
@@ -57,6 +59,8 @@ export const convertTimelineItemToTimelineItemEntry = (
         ...baseItem,
         type: 'assistant_log',
         role: item.assistant_role ?? 'db',
+        // TODO: Backend needs to provide artifact_action field
+        artifactAction: item.artifact_action,
       }),
     )
     .with(

--- a/frontend/apps/app/components/SessionDetailPage/types.ts
+++ b/frontend/apps/app/components/SessionDetailPage/types.ts
@@ -46,6 +46,10 @@ export type TimelineItem = Pick<
       executed_at: string
     }>
   } | null
+  // TODO: Backend needs to add artifact_action field to timeline_items table
+  // This field should be set to 'created' when PM agent creates requirements artifact
+  // and 'updated' when QA agent adds use cases to the artifact
+  artifact_action?: 'created' | 'updated' | null
 }
 
 export type DesignSessionWithTimelineItems = Pick<
@@ -81,6 +85,7 @@ export type UserTimelineItemEntry = BaseTimelineItemEntry & {
 export type AssistantTimelineItemEntry = BaseTimelineItemEntry & {
   type: 'assistant'
   role: AssistantRole
+  artifactAction?: 'created' | 'updated' | null
 }
 
 export type SchemaVersionTimelineItemEntry = BaseTimelineItemEntry & {
@@ -97,6 +102,7 @@ export type ErrorTimelineItemEntry = BaseTimelineItemEntry & {
 export type AssistantLogTimelineItemEntry = BaseTimelineItemEntry & {
   type: 'assistant_log'
   role: AssistantRole
+  artifactAction?: 'created' | 'updated' | null
 }
 
 export type QueryResultTimelineItemEntry = BaseTimelineItemEntry & {

--- a/frontend/apps/app/components/SessionDetailPage/types.ts
+++ b/frontend/apps/app/components/SessionDetailPage/types.ts
@@ -75,6 +75,8 @@ type BaseTimelineItemEntry = {
     | 'assistant_log'
     | 'query_result'
   timestamp: Date
+  // Backend artifact_action field - used to determine when to show view links
+  artifactAction?: 'created' | 'updated' | null
 }
 
 export type UserTimelineItemEntry = BaseTimelineItemEntry & {
@@ -85,7 +87,6 @@ export type UserTimelineItemEntry = BaseTimelineItemEntry & {
 export type AssistantTimelineItemEntry = BaseTimelineItemEntry & {
   type: 'assistant'
   role: AssistantRole
-  artifactAction?: 'created' | 'updated' | null
 }
 
 export type SchemaVersionTimelineItemEntry = BaseTimelineItemEntry & {
@@ -102,7 +103,6 @@ export type ErrorTimelineItemEntry = BaseTimelineItemEntry & {
 export type AssistantLogTimelineItemEntry = BaseTimelineItemEntry & {
   type: 'assistant_log'
   role: AssistantRole
-  artifactAction?: 'created' | 'updated' | null
 }
 
 export type QueryResultTimelineItemEntry = BaseTimelineItemEntry & {


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
To add navigation links from timeline items in assistant logs to tabs like artifacts.

<img width="2122" height="1018" alt="スクリーンショット 2025-07-29 18 08 34" src="https://github.com/user-attachments/assets/d5ddd6d3-7812-4439-8d31-ee4746651f01" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive "View Artifact" links to assistant messages, enabling quick navigation to relevant output tabs when artifacts are created or updated.
  * Introduced a new "ViewLink" component for accessible, styled navigation buttons within chat messages.

* **Enhancements**
  * Output tab state now supports both controlled and uncontrolled modes for more intuitive tab navigation.
  * Added state management for active output tabs, improving user interaction with session details.

* **Documentation**
  * Expanded Storybook stories to demonstrate new link components and assistant message scenarios for project management and quality assurance roles.

* **Style**
  * Added new styling for artifact navigation links to ensure consistent and user-friendly appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->