### PR TITLE
🔥 Remove quick fix functionality and review comment UI toggle

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -2,7 +2,7 @@
 
 import type { Schema } from '@liam-hq/db-structure'
 import clsx from 'clsx'
-import { type FC, useCallback, useState } from 'react'
+import { type FC, useCallback } from 'react'
 import { Chat } from './components/Chat'
 import { Output } from './components/Output'
 import { useRealtimeArtifact } from './components/Output/components/Artifact/hooks/useRealtimeArtifact'
@@ -65,17 +65,6 @@ export const SessionDetailPageClient: FC<Props> = ({
     ),
   )
 
-  const [, setQuickFixMessage] = useState<string>('')
-
-  const handleQuickFix = useCallback((comment: string) => {
-    const fixMessage = `Please fix the following issue pointed out by the QA Agent:
-
-"${comment}"
-
-Please suggest a specific solution to resolve this problem.`
-    setQuickFixMessage(fixMessage)
-  }, [])
-
   const hasSelectedVersion = selectedVersion !== null
 
   // Use realtime artifact hook to monitor artifact changes
@@ -115,7 +104,6 @@ Please suggest a specific solution to resolve this problem.`
                 schema={displayedSchema}
                 prevSchema={prevSchema}
                 schemaUpdatesReviewComments={SCHEMA_UPDATES_REVIEW_COMMENTS}
-                onQuickFix={handleQuickFix}
                 versions={versions}
                 selectedVersion={selectedVersion}
                 onSelectedVersionChange={handleChangeSelectedVersion}

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
@@ -14,7 +14,6 @@ type Props = ComponentProps<typeof Header> & {
   schema: Schema
   prevSchema: Schema
   schemaUpdatesReviewComments: ReviewComment[]
-  onQuickFix?: (comment: string) => void
 }
 
 export const Output: FC<Props> = ({
@@ -22,7 +21,6 @@ export const Output: FC<Props> = ({
   schema,
   prevSchema,
   schemaUpdatesReviewComments,
-  onQuickFix,
   ...propsForHeader
 }) => {
   return (
@@ -39,7 +37,6 @@ export const Output: FC<Props> = ({
           currentSchema={schema}
           prevSchema={prevSchema}
           comments={schemaUpdatesReviewComments}
-          onQuickFix={onQuickFix}
         />
       </TabsContent>
       <TabsContent value={OUTPUT_TABS.ARTIFACT} className={styles.tabsContent}>

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/SchemaUpdates.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/SchemaUpdates.module.css
@@ -5,14 +5,6 @@
   height: 100%;
 }
 
-.head {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: var(--spacing-1) var(--spacing-2);
-  border-bottom: solid 1px var(--pane-border);
-}
-
 .sectionTitle {
   font-size: var(--font-size-7);
   font-weight: 600;

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/SchemaUpdates.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SchemaUpdates/SchemaUpdates.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import type { Schema } from '@liam-hq/db-structure'
-import clsx from 'clsx'
-import { MessageSquareCode } from 'lucide-react'
-import { type FC, useState } from 'react'
-import { IconButton } from '@/components'
+import type { FC } from 'react'
 import type { ReviewComment } from '@/components/SessionDetailPage/types'
 import { useSchemaUpdates } from './hooks/useSchemaUpdates'
 import { MigrationsViewer } from './MigrationsViewer'
@@ -14,17 +11,13 @@ type Props = {
   currentSchema: Schema
   prevSchema: Schema
   comments?: ReviewComment[]
-  onQuickFix?: (comment: string) => void
 }
 
 export const SchemaUpdates: FC<Props> = ({
   currentSchema,
   prevSchema,
   comments = [],
-  onQuickFix,
 }) => {
-  const [showReviewComments, setShowReviewComments] = useState(true)
-
   const { cumulativeDdl, prevCumulativeDdl } = useSchemaUpdates({
     currentSchema,
     prevSchema,
@@ -32,25 +25,13 @@ export const SchemaUpdates: FC<Props> = ({
 
   return (
     <section className={styles.section}>
-      <div className={styles.head}>
-        <IconButton
-          icon={
-            <MessageSquareCode
-              className={clsx(showReviewComments && styles.active)}
-            />
-          }
-          tooltipContent="Migration Review"
-          onClick={() => setShowReviewComments((prev) => !prev)}
-        />
-      </div>
       <div className={styles.body}>
         <MigrationsViewer
           showDiff
           doc={cumulativeDdl}
           prevDoc={prevCumulativeDdl}
           comments={comments}
-          showComments={showReviewComments}
-          onQuickFix={onQuickFix}
+          showComments={false}
         />
       </div>
     </section>


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
This PR removes the quick fix functionality and review comment UI toggle button from the schema updates view. The quick fix feature with the `onQuickFix` handler was not being used effectively, and the UI toggle for showing/hiding review comments added unnecessary complexity to the interface.

The changes simplify the component hierarchy by removing unused props and state management, resulting in cleaner and more maintainable code.

| Before | After |
|--------|--------|
| <img width="1129" height="992" alt="スクリーンショット 2025-07-29 19 15 33" src="https://github.com/user-attachments/assets/5dda4667-56d6-49bb-8602-3432256637f9" /> | <img width="1130" height="994" alt="スクリーンショット 2025-07-29 19 14 29" src="https://github.com/user-attachments/assets/b6e2cb97-2729-4b04-bbb9-1c746a3150bf" /> | 

