### PR TITLE
🐛 Fix cardinality indicator position when diff is shown

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableColumnList/TableColumn/TableColumn.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableColumnList/TableColumn/TableColumn.module.css
@@ -112,3 +112,7 @@
   left: -20px;
   pointer-events: none;
 }
+
+.handleWithDiff[data-handlepos='left'] {
+  left: -56px; /* diffBox width (36px) + original left position (-20px) = -56px */
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableColumnList/TableColumn/TableColumn.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableColumnList/TableColumn/TableColumn.tsx
@@ -162,7 +162,7 @@ export const TableColumn: FC<TableColumnProps> = ({
             id={handleId}
             type="target"
             position={Position.Left}
-            className={styles.handle}
+            className={clsx(styles.handle, showDiff && styles.handleWithDiff)}
           />
         )}
       </div>


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
When the diff indicator is displayed on a table column, the cardinality indicator (left handle) overlaps with the diff box. This fix adjusts the handle position from -20px to -56px to accommodate the 36px diff box width, ensuring proper visibility of both UI elements.

<img width="1465" height="1034" alt="スクリーンショット 2025-07-30 11 28 52" src="https://github.com/user-attachments/assets/9f6fad7e-d45d-45d5-bab5-a1b039c0a380" />

## Check

**Liam DB**

| All fields | Table name | Key only |
|--------|--------|--------|
| <img width="1685" height="994" alt="スクリーンショット 2025-07-30 11 18 40" src="https://github.com/user-attachments/assets/4bc81c5c-e0ed-4281-a197-3619e1b7fb11" /> | <img width="1686" height="994" alt="スクリーンショット 2025-07-30 11 18 58" src="https://github.com/user-attachments/assets/35528fde-9004-4895-88d1-7afe8ae94a78" /> | <img width="1684" height="993" alt="スクリーンショット 2025-07-30 11 19 12" src="https://github.com/user-attachments/assets/68bac08f-9fc0-47ba-bc3f-5dd00ad89497" /> | 

**Liam ERD**

| All fields | Table name | Key only |
|--------|--------|--------|
| <img width="1684" height="993" alt="スクリーンショット 2025-07-30 11 18 08" src="https://github.com/user-attachments/assets/69191a22-c267-4d3c-b1e5-9637f37ac388" /> | <img width="1684" height="992" alt="スクリーンショット 2025-07-30 11 19 34" src="https://github.com/user-attachments/assets/ef134edf-2f50-496b-ba92-c0e9707e5b03" /> | <img width="1686" height="994" alt="スクリーンショット 2025-07-30 11 19 48" src="https://github.com/user-attachments/assets/46731a9d-6921-4204-9b39-fcf16544ede1" /> | 
