### PR TITLE
🐛 Fix hardcoded schema filename display in GitHubSessionFormPresenter

### DIFF
--- a/frontend/apps/app/features/sessions/components/SessionForm/GitHubSessionFormPresenter/GitHubSessionFormPresenter.stories.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/GitHubSessionFormPresenter/GitHubSessionFormPresenter.stories.tsx
@@ -54,6 +54,7 @@ export const Default: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
 }
 
@@ -66,6 +67,7 @@ export const WithProjects: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
 }
 
@@ -78,6 +80,7 @@ export const WithBranches: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: 'schema.rb',
   },
 }
 
@@ -90,6 +93,7 @@ export const BranchesLoading: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
 }
 
@@ -104,6 +108,7 @@ export const WithBranchesError: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
 }
 
@@ -116,6 +121,7 @@ export const WithFormError: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: 'database.sql',
   },
 }
 
@@ -127,6 +133,7 @@ export const Pending: Story = {
     isPending: true,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: 'db/schema.rb',
   },
 }
 
@@ -138,6 +145,7 @@ export const EmptyProjects: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
 }
 
@@ -150,6 +158,7 @@ export const Interactive: Story = {
     formAction: () => {},
     onProjectChange: () => {},
     defaultProjectId: '',
+    schemaFilePath: null,
   },
   render: (args) => {
     const [isPending, setIsPending] = useState(args.isPending)
@@ -191,6 +200,7 @@ export const Interactive: Story = {
         formAction={handleFormAction}
         onProjectChange={handleProjectChange}
         defaultProjectId={selectedProjectId}
+        schemaFilePath={args.schemaFilePath}
       />
     )
   },
@@ -207,6 +217,7 @@ export const InteractiveWithError: Story = {
     formAction: () => {},
     onProjectChange: () => {},
     defaultProjectId: '',
+    schemaFilePath: null,
   },
   render: (args) => {
     const [isPending, setIsPending] = useState(args.isPending)
@@ -329,6 +340,7 @@ export const InteractiveWithError: Story = {
           formAction={handleFormAction}
           onProjectChange={handleProjectChange}
           defaultProjectId={selectedProjectId}
+          schemaFilePath={args.schemaFilePath}
         />
       </div>
     )

--- a/frontend/apps/app/features/sessions/components/SessionForm/GitHubSessionFormPresenter/GitHubSessionFormPresenter.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/GitHubSessionFormPresenter/GitHubSessionFormPresenter.tsx
@@ -24,6 +24,7 @@ type Props = {
   onProjectChange: (projectId: string) => void
   formAction: (formData: FormData) => void
   isTransitioning?: boolean
+  schemaFilePath: string | null
 }
 
 export const GitHubSessionFormPresenter: FC<Props> = ({
@@ -37,6 +38,7 @@ export const GitHubSessionFormPresenter: FC<Props> = ({
   onProjectChange,
   formAction,
   isTransitioning = false,
+  schemaFilePath,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const formRef = useRef<HTMLFormElement>(null)
@@ -196,7 +198,13 @@ export const GitHubSessionFormPresenter: FC<Props> = ({
                     disabled={isPending}
                     isLoading={isBranchesLoading}
                   />
-                  <SchemaDisplay schemaName="database.sql" />
+                  <SchemaDisplay
+                    schemaName={
+                      schemaFilePath
+                        ? schemaFilePath.split('/').pop() || 'database.sql'
+                        : 'database.sql'
+                    }
+                  />
                 </>
               )}
             </div>

--- a/frontend/apps/app/features/sessions/components/SessionForm/SessionForm.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SessionForm.tsx
@@ -25,7 +25,7 @@ export const SessionForm: FC<Props> = ({ projects, defaultProjectId }) => {
 
   const [schemaPathState, schemaPathAction] = useActionState(
     getSchemaFilePath,
-    { path: null, loading: false },
+    { path: null },
   )
 
   const handleProjectChange = (projectId: string) => {

--- a/frontend/apps/app/features/sessions/components/SessionForm/SessionForm.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SessionForm.tsx
@@ -4,6 +4,7 @@ import { type FC, useActionState, useEffect, useTransition } from 'react'
 import type { Projects } from '@/components/CommonLayout/AppBar/ProjectsDropdownMenu/services/getProjects'
 import { createSession } from '../../actions/createSession'
 import { getBranches } from '../../actions/getBranches'
+import { getSchemaFilePath } from './actions/getSchemaFilePath/getSchemaFilePath'
 import { SessionFormPresenter } from './SessionFormPresenter'
 
 type Props = {
@@ -22,11 +23,17 @@ export const SessionForm: FC<Props> = ({ projects, defaultProjectId }) => {
     { branches: [], loading: false },
   )
 
+  const [schemaPathState, schemaPathAction] = useActionState(
+    getSchemaFilePath,
+    { path: null, loading: false },
+  )
+
   const handleProjectChange = (projectId: string) => {
     startTransition(() => {
       const formData = new FormData()
       formData.append('projectId', projectId)
       branchesAction(formData)
+      schemaPathAction(formData)
     })
   }
 
@@ -38,9 +45,10 @@ export const SessionForm: FC<Props> = ({ projects, defaultProjectId }) => {
         const formData = new FormData()
         formData.append('projectId', defaultProjectId)
         branchesAction(formData)
+        schemaPathAction(formData)
       })
     }
-  }, [defaultProjectId, projects, branchesAction])
+  }, [defaultProjectId, projects, branchesAction, schemaPathAction])
 
   return (
     <SessionFormPresenter
@@ -53,6 +61,7 @@ export const SessionForm: FC<Props> = ({ projects, defaultProjectId }) => {
       isPending={isPending}
       onProjectChange={handleProjectChange}
       formAction={formAction}
+      schemaFilePath={schemaPathState.path}
     />
   )
 }

--- a/frontend/apps/app/features/sessions/components/SessionForm/SessionForm.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SessionForm.tsx
@@ -4,7 +4,7 @@ import { type FC, useActionState, useEffect, useTransition } from 'react'
 import type { Projects } from '@/components/CommonLayout/AppBar/ProjectsDropdownMenu/services/getProjects'
 import { createSession } from '../../actions/createSession'
 import { getBranches } from '../../actions/getBranches'
-import { getSchemaFilePath } from './actions/getSchemaFilePath/getSchemaFilePath'
+import { getSchemaFilePath } from './actions/getSchemaFilePath'
 import { SessionFormPresenter } from './SessionFormPresenter'
 
 type Props = {

--- a/frontend/apps/app/features/sessions/components/SessionForm/SessionFormPresenter.stories.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SessionFormPresenter.stories.tsx
@@ -53,6 +53,7 @@ export const Default: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
   parameters: {
     docs: {
@@ -73,6 +74,7 @@ export const WithBranches: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: 'db/schema.rb',
   },
   parameters: {
     docs: {
@@ -93,6 +95,7 @@ export const LoadingBranches: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
   parameters: {
     docs: {
@@ -114,6 +117,7 @@ export const WithBranchesError: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
   parameters: {
     docs: {
@@ -134,6 +138,7 @@ export const Pending: Story = {
     isPending: true,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: 'database.sql',
   },
   parameters: {
     docs: {
@@ -155,6 +160,7 @@ export const WithFormError: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: 'schema.prisma',
   },
   parameters: {
     docs: {
@@ -174,6 +180,7 @@ export const NoProject: Story = {
     isPending: false,
     onProjectChange: () => {},
     formAction: () => {},
+    schemaFilePath: null,
   },
   parameters: {
     docs: {

--- a/frontend/apps/app/features/sessions/components/SessionForm/SessionFormPresenter.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/SessionFormPresenter.tsx
@@ -23,6 +23,7 @@ type Props = {
   isPending: boolean
   onProjectChange: (projectId: string) => void
   formAction: (formData: FormData) => void
+  schemaFilePath: string | null
 }
 
 export const SessionFormPresenter: FC<Props> = ({
@@ -35,6 +36,7 @@ export const SessionFormPresenter: FC<Props> = ({
   isPending,
   onProjectChange,
   formAction,
+  schemaFilePath,
 }) => {
   const [mode, setMode] = useState<SessionMode>('github')
   const [isTransitioning, setIsTransitioning] = useState(false)
@@ -149,6 +151,7 @@ export const SessionFormPresenter: FC<Props> = ({
               onProjectChange={onProjectChange}
               formAction={formAction}
               isTransitioning={isTransitioning}
+              schemaFilePath={schemaFilePath}
             />
           </div>
         )}

--- a/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/fetchSchemaFilePath.ts
+++ b/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/fetchSchemaFilePath.ts
@@ -1,0 +1,24 @@
+'use server'
+
+import { createClient } from '@/libs/db/server'
+
+export const fetchSchemaFilePath = async (projectId: string | null) => {
+  if (!projectId) {
+    return { data: null, error: null }
+  }
+
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('schema_file_paths')
+    .select('path')
+    .eq('project_id', projectId)
+    .single()
+
+  if (error) {
+    console.error('Error fetching schema file path:', error)
+    return { data: null, error: error.message }
+  }
+
+  return { data: data?.path || null, error: null }
+}

--- a/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/getSchemaFilePath.ts
+++ b/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/getSchemaFilePath.ts
@@ -4,7 +4,6 @@ import { fetchSchemaFilePath } from './fetchSchemaFilePath'
 
 type SchemaFilePathState = {
   path: string | null
-  loading: boolean
   error?: string
 }
 
@@ -15,14 +14,14 @@ export async function getSchemaFilePath(
   const projectId = formData.get('projectId')
 
   if (!projectId || typeof projectId !== 'string') {
-    return { path: null, loading: false }
+    return { path: null }
   }
 
   const { data, error } = await fetchSchemaFilePath(projectId)
 
   if (error) {
-    return { path: null, loading: false, error }
+    return { path: null, error }
   }
 
-  return { path: data, loading: false }
+  return { path: data }
 }

--- a/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/getSchemaFilePath.ts
+++ b/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/getSchemaFilePath.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { fetchSchemaFilePath } from './fetchSchemaFilePath'
+
+type SchemaFilePathState = {
+  path: string | null
+  loading: boolean
+  error?: string
+}
+
+export async function getSchemaFilePath(
+  _prevState: SchemaFilePathState,
+  formData: FormData,
+): Promise<SchemaFilePathState> {
+  const projectId = formData.get('projectId')
+
+  if (!projectId || typeof projectId !== 'string') {
+    return { path: null, loading: false }
+  }
+
+  const { data, error } = await fetchSchemaFilePath(projectId)
+
+  if (error) {
+    return { path: null, loading: false, error }
+  }
+
+  return { path: data, loading: false }
+}

--- a/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/index.ts
+++ b/frontend/apps/app/features/sessions/components/SessionForm/actions/getSchemaFilePath/index.ts
@@ -1,0 +1,1 @@
+export * from './getSchemaFilePath'

--- a/frontend/internal-packages/jobs/src/functions/processRepositoryAnalysis.ts
+++ b/frontend/internal-packages/jobs/src/functions/processRepositoryAnalysis.ts
@@ -2,7 +2,14 @@ import { Document } from '@langchain/core/documents'
 import { OpenAIEmbeddings } from '@langchain/openai'
 import { getFileContent } from '@liam-hq/github'
 import { logger } from '@trigger.dev/sdk/v3'
-import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
+import {
+  err,
+  errAsync,
+  ok,
+  okAsync,
+  type Result,
+  ResultAsync,
+} from 'neverthrow'
 import { createClient } from '../libs/supabase'
 
 export type RepositoryAnalysisPayload = {


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
The schema filename was hardcoded as "database.sql" in the GitHubSessionFormPresenter component, regardless of the actual schema file in the repository. This change dynamically fetches and displays the correct schema filename from the database.

## Summary
- Added `getSchemaFilePath` action to fetch the actual schema file path from the database
- Updated SessionForm components to pass the schema file path through props
- Modified GitHubSessionFormPresenter to display the actual filename instead of hardcoded "database.sql"
- Updated all Storybook stories to include the new `schemaFilePath` prop
- Fixed import formatting in processRepositoryAnalysis.ts

## Check

https://github.com/user-attachments/assets/126f902e-ed56-448d-a3b0-4fdd36229114




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying dynamic schema file names in session forms, based on the selected project.
  * Session forms now fetch and display the schema file path relevant to the chosen project.

* **Bug Fixes**
  * Storybook stories updated to support and test the new schema file path feature.

* **Style**
  * Improved formatting and import statements for better code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->