### PR TITLE
update .claude/commands/commit.md ? 

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,8 +1,20 @@
 Let's commit the changes.
 
 **Split large changes**: If changes touch multiple concerns, split them into separate commits
-**Write a commit message that matches the content of your change**: Clearly describe what was changed in this commit.
+**Write a commit message that matches the content of your change**: Clearly describe what was changed in this commit. A good commit message should:
+- Specify the component or feature affected (e.g., "authentication module").
+- Describe the action taken (e.g., "fixed a bug," "added a new feature").
+- Avoid vague messages like "fix bug" or "update code."
 
+Examples of good commit messages:
+- 🐛 Fixed a bug in the authentication module causing login failures
+- ✨ Added a new feature to filter tables by column
+- 📝 Updated README.md with new installation instructions
+
+Examples of bad commit messages:
+- "fix bug"
+- "update code"
+- "changes made"
 - Use gitmoji (optional, recommended): Write commit messages using the emoji (e.g., ✨) itself, not the textual representation (e.g., `:sparkles:`)
 
 ## Examples


### PR DESCRIPTION
## Issue

Perhaps because my context was too long, there were times when the commit message was completely unrelated to the actual changes (even though I wasn't in the middle of a rebase or using --amend).

I'd like to add a reminder to double-check that the commit message accurately describes the changes.


## Why is this change needed?

* 2d4cbc9ff : 📝 Simplify gitmoji reference in commit command
     * now I want to try shorter list. see https://github.com/liam-hq/liam/pull/2284/files#r2192356164
* ca2d99b95 : 📝 Add guidance for descriptive commit messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved commit message guidelines with clearer instructions and examples.
  * Replaced the extensive Gitmoji reference with a concise list of six core categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->