### PR TITLE
🐛 fix(ui): fix Toast component styles

### DIFF
--- a/.changeset/long-chairs-retire.md
+++ b/.changeset/long-chairs-retire.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+🐛 fix(ui): fix Toast component styles

--- a/frontend/packages/ui/src/components/Toast/Toast.module.css
+++ b/frontend/packages/ui/src/components/Toast/Toast.module.css
@@ -18,7 +18,7 @@
   color: var(--toast-info-foreground);
   background: var(--toast-info-background);
   border-color: var(--color-teal-800);
-  box-shadow: 0 0 20px 0 rgb(247 80 73 / 40%);
+  box-shadow: 0 0 20px 0 rgb(20 188 255 / 40%);
 }
 
 .wrapper.error {
@@ -67,7 +67,6 @@
   font-weight: 600;
   color: var(--color-gray-1000);
 }
-
 
 .description {
   font-size: var(--font-size-3);

--- a/frontend/packages/ui/src/components/Toast/Toast.module.css
+++ b/frontend/packages/ui/src/components/Toast/Toast.module.css
@@ -15,25 +15,25 @@
 }
 
 .wrapper.info {
-  background: var(--info-background);
+  background: var(--toast-info-background);
   border-color: var(--color-teal-800);
   box-shadow: 0 0 20px 0 rgb(247 80 73 / 40%);
 }
 
 .wrapper.error {
-  background: var(--error-background);
+  background: var(--toast-error-background);
   border-color: var(--color-red-500);
   box-shadow: 0 0 20px 0 rgb(247 80 73 / 40%);
 }
 
 .wrapper.success {
-  background: var(--success-background);
+  background: var(--toast-success-background);
   border-color: var(--color-green-400);
   box-shadow: 0 0 20px 0 rgb(29 237 131 / 40%);
 }
 
 .wrapper.warning {
-  background: var(--warning-background);
+  background: var(--toast-warning-background);
   border-color: var(--color-gold-alpha-100);
   box-shadow: 0 0 20px 0 rgb(255 191 54 / 40%);
 }
@@ -65,19 +65,19 @@
 }
 
 .wrapper.info .title {
-  color: var(--info-foreground);
+  color: var(--toast-info-foreground);
 }
 
 .wrapper.error .title {
-  color: var(--error-foreground);
+  color: var(--toast-error-foreground);
 }
 
 .wrapper.success .title {
-  color: var(--success-foreground);
+  color: var(--toast-success-foreground);
 }
 
 .wrapper.warning .title {
-  color: var(--warning-foreground);
+  color: var(--toast-warning-foreground);
 }
 
 .description {
@@ -87,19 +87,19 @@
 }
 
 .wrapper.info .description {
-  color: var(--info-foreground);
+  color: var(--toast-info-foreground);
 }
 
 .wrapper.error .description {
-  color: var(--error-foreground);
+  color: var(--toast-error-foreground);
 }
 
 .wrapper.success .description {
-  color: var(--success-foreground);
+  color: var(--toast-success-foreground);
 }
 
 .wrapper.warning .description {
-  color: var(--warning-foreground);
+  color: var(--toast-warning-foreground);
 }
 
 .viewport {

--- a/frontend/packages/ui/src/components/Toast/Toast.module.css
+++ b/frontend/packages/ui/src/components/Toast/Toast.module.css
@@ -15,24 +15,28 @@
 }
 
 .wrapper.info {
+  color: var(--toast-info-foreground);
   background: var(--toast-info-background);
   border-color: var(--color-teal-800);
   box-shadow: 0 0 20px 0 rgb(247 80 73 / 40%);
 }
 
 .wrapper.error {
+  color: var(--toast-error-foreground);
   background: var(--toast-error-background);
   border-color: var(--color-red-500);
   box-shadow: 0 0 20px 0 rgb(247 80 73 / 40%);
 }
 
 .wrapper.success {
+  color: var(--toast-success-foreground);
   background: var(--toast-success-background);
   border-color: var(--color-green-400);
   box-shadow: 0 0 20px 0 rgb(29 237 131 / 40%);
 }
 
 .wrapper.warning {
+  color: var(--toast-warning-foreground);
   background: var(--toast-warning-background);
   border-color: var(--color-gold-alpha-100);
   box-shadow: 0 0 20px 0 rgb(255 191 54 / 40%);
@@ -64,42 +68,11 @@
   color: var(--color-gray-1000);
 }
 
-.wrapper.info .title {
-  color: var(--toast-info-foreground);
-}
-
-.wrapper.error .title {
-  color: var(--toast-error-foreground);
-}
-
-.wrapper.success .title {
-  color: var(--toast-success-foreground);
-}
-
-.wrapper.warning .title {
-  color: var(--toast-warning-foreground);
-}
 
 .description {
   font-size: var(--font-size-3);
   font-weight: 500;
   color: var(--color-gray-400);
-}
-
-.wrapper.info .description {
-  color: var(--toast-info-foreground);
-}
-
-.wrapper.error .description {
-  color: var(--toast-error-foreground);
-}
-
-.wrapper.success .description {
-  color: var(--toast-success-foreground);
-}
-
-.wrapper.warning .description {
-  color: var(--toast-warning-foreground);
 }
 
 .viewport {

--- a/frontend/packages/ui/src/components/Toast/Toast.stories.tsx
+++ b/frontend/packages/ui/src/components/Toast/Toast.stories.tsx
@@ -35,7 +35,7 @@ export const Info: Story = {
   },
 }
 
-export const Error: Story = {
+export const ErrorStatus: Story = {
   args: {
     title: 'Error Toast',
     description: 'Error Toast description',

--- a/frontend/packages/ui/src/components/Toast/Toast.stories.tsx
+++ b/frontend/packages/ui/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Toast, ToastProvider } from './Toast'
+
+const meta = {
+  component: Toast,
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['info', 'error', 'success', 'warning'],
+      description: 'The status of the toast',
+    },
+    isOpen: {
+      control: 'boolean',
+      description: 'Whether the toast is shown',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
+  ],
+} satisfies Meta<typeof Toast>
+
+export default meta
+type Story = StoryObj<typeof Toast>
+
+export const Info: Story = {
+  args: {
+    title: 'Info Toast',
+    description: 'Info Toast description',
+    status: 'info',
+    isOpen: true,
+  },
+}
+
+export const Error: Story = {
+  args: {
+    title: 'Error Toast',
+    description: 'Error Toast description',
+    status: 'error',
+    isOpen: true,
+  },
+}
+
+export const Success: Story = {
+  args: {
+    title: 'Success Toast',
+    description: 'Success Toast description',
+    status: 'success',
+    isOpen: true,
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    title: 'Warning Toast',
+    description: 'Warning Toast description',
+    status: 'warning',
+    isOpen: true,
+  },
+}

--- a/frontend/packages/ui/src/styles/Dark/variables.css
+++ b/frontend/packages/ui/src/styles/Dark/variables.css
@@ -161,6 +161,7 @@
   --spacing-10: 40px;
   --spacing-12: 48px;
   --spacing-14: 56px;
+  --spacing-16: 64px;
   --spacing-20: 80px;
   --spacing-30: 120px;
   --spacing-275: 275px;


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

In the previous version, the Toast component is not visible because of the style problems.
This PR fixes the styles to make it works, and create stories for management.

Storybook: https://liam-storybook-git-fix-toast-styles-liambx.vercel.app/?path=/story/ui-components-toast--info

### verification

1. open preview https://liam-app-git-fix-toast-styles-liambx.vercel.app/
2. click "Copy Link" button, then Toasts are shown

<img width="431" height="519" alt="Screenshot 0007-07-31 at 8 05 19" src="https://github.com/user-attachments/assets/cd17c680-7e13-402c-8122-4e61a89d7fd5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Toast notification styles for better color consistency across different status types.

* **New Features**
  * Added Storybook stories for the Toast component, showcasing its appearance for info, error, success, and warning states.

* **Style**
  * Simplified Toast component CSS by consolidating text color styling and updating color variables.
  * Introduced a new spacing variable (`--spacing-16`) in the dark theme styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->