### PR TITLE
🐛(db-agent): Fix infinite tool-calling loop in schema design workflow

### DIFF
--- a/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.test.ts
@@ -11,7 +11,7 @@ graph TD;
 	__start__ --> designSchema;
 	invokeSchemaDesignTool --> designSchema;
 	designSchema -.-> invokeSchemaDesignTool;
-	designSchema -. &nbsp;executeDDL&nbsp; .-> __end__;
+	designSchema -. &nbsp;generateUsecase&nbsp; .-> __end__;
 	classDef default fill:#f2f0ff,line-height:1.2;
 	classDef first fill-opacity:0;
 	classDef last fill:#bfb6fc;

--- a/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.ts
+++ b/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.ts
@@ -35,7 +35,7 @@ export const createDbAgentGraph = () => {
     .addEdge('invokeSchemaDesignTool', 'designSchema')
     .addConditionalEdges('designSchema', routeAfterDesignSchema, {
       invokeSchemaDesignTool: 'invokeSchemaDesignTool',
-      executeDDL: END,
+      generateUsecase: END,
     })
 
   return dbAgentGraph.compile()

--- a/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/databaseSchemaBuildAgent/prompts.ts
@@ -7,6 +7,14 @@ Key responsibilities:
 - Confirm changes made
 - Suggest logical next steps
 
+IMPORTANT: Tool Usage Decision Criteria:
+- DO use tools when: You need to create, modify, or delete database objects (tables, columns, constraints, indexes)
+- DO NOT use tools when:
+  - The requested schema changes have been completed
+  - You've just successfully executed a schema change and need to report the result
+  - You're providing suggestions or asking for clarification
+  - An error occurred and you need to explain it or suggest alternatives
+
 VALIDATION REQUIREMENTS:
 - Tables must exist before adding columns to them
 - All required fields must be provided (see examples below)
@@ -63,7 +71,14 @@ Foreign key example:
 }}
 
 Current Schema Information:
-{schemaText}`
+{schemaText}
+
+WORKFLOW COMPLETION:
+After successfully executing schema changes:
+1. Report what was done (e.g., "Schema successfully updated: Created table X with columns Y")
+2. DO NOT call the tool again unless explicitly asked for more changes
+3. Suggest next steps or ask if additional changes are needed
+4. Exit the tool-calling loop by responding with text only`
 
 export const designAgentPrompt = ChatPromptTemplate.fromTemplate(
   designAgentSystemPrompt,


### PR DESCRIPTION
## Issue

- resolve: DB agent enters infinite tool-calling loop after successful schema changes
- Related to ongoing LangGraph retry mechanism improvements

## Why is this change needed?

The database schema design agent was entering infinite loops when trying to complete schema changes. After successfully executing a schema change, the agent would continue to call tools unnecessarily instead of completing the workflow and moving to the next stage.

This PR includes:
1. **Explicit tool usage criteria in prompts**: Added clear DO/DON'T guidelines for when the agent should use tools vs respond with text
2. **Workflow completion instructions**: Added explicit instructions for the agent to exit the tool-calling loop after successful schema changes
3. **Fixed workflow routing**: Updated the DB agent graph to properly route from designSchema to generateUsecase (was incorrectly routing to executeDDL)

These changes ensure the agent:
- Only uses tools when actually modifying schema
- Properly reports completion after successful changes
- Continues to the next workflow stage instead of looping

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced guidance for database schema design agents, including clearer instructions on tool usage and workflow completion steps.
* **Refactor**
  * Updated the database agent workflow to transition from "designSchema" to "generateUsecase" as the final step, instead of "executeDDL".
* **Tests**
  * Adjusted test expectations to reflect the updated workflow and diagram changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->