### PR TITLE
🐛(agent): Remove reasoning field from AIMessages instead of filtering

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -68,7 +68,7 @@ export async function designSchemaNode(
     // Return state with error feedback as HumanMessage for self-recovery
     return {
       ...state,
-      messages: [...state.messages, errorFeedbackMessage],
+      messages: [errorFeedbackMessage],
       error: invokeResult.error,
     }
   }
@@ -98,7 +98,7 @@ export async function designSchemaNode(
 
   return {
     ...state,
-    messages: [...state.messages, syncedMessage],
+    messages: [syncedMessage],
     latestVersionNumber: state.latestVersionNumber + 1,
   }
 }

--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -1,3 +1,4 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages'
 import type { RunnableConfig } from '@langchain/core/runnables'
 import type { Database } from '@liam-hq/db'
 import { invokeDesignAgent } from '../../../langchain/agents/databaseSchemaBuildAgent/agent'
@@ -27,8 +28,28 @@ export async function designSchemaNode(
 
   const schemaText = convertSchemaToText(state.schemaData)
 
-  // Use existing messages
-  const messages = [...state.messages]
+  // Remove reasoning field from AIMessages to avoid API issues
+  // This prevents the "reasoning without required following item" error
+  const messages = state.messages.map((msg) => {
+    if (msg instanceof AIMessage) {
+      // Create a new AIMessage without the reasoning field
+      // Clone the message but exclude reasoning if it exists
+      const { content, additional_kwargs, response_metadata } = msg
+      const cleanedKwargs = { ...additional_kwargs }
+
+      // Remove reasoning from additional_kwargs if it exists
+      if ('reasoning' in cleanedKwargs) {
+        delete cleanedKwargs['reasoning']
+      }
+
+      return new AIMessage({
+        content,
+        additional_kwargs: cleanedKwargs,
+        response_metadata,
+      })
+    }
+    return msg
+  })
 
   const invokeResult = await invokeDesignAgent({ schemaText }, messages, {
     buildingSchemaId: state.buildingSchemaId,
@@ -38,14 +59,16 @@ export async function designSchemaNode(
   })
 
   if (invokeResult.isErr()) {
-    await logAssistantMessage(
-      state,
-      repositories,
-      'Unable to complete the database design. There may be conflicts in the requirements...',
-      assistantRole,
-    )
+    // Create a human message for error feedback to avoid reasoning API issues
+    // Using HumanMessage prevents the "reasoning without required following item" error
+    const errorFeedbackMessage = new HumanMessage({
+      content: `The previous attempt failed with the following error: ${invokeResult.error.message}. Please try a different approach to resolve the issue.`,
+    })
+
+    // Return state with error feedback as HumanMessage for self-recovery
     return {
       ...state,
+      messages: [...state.messages, errorFeedbackMessage],
       error: invokeResult.error,
     }
   }
@@ -75,7 +98,7 @@ export async function designSchemaNode(
 
   return {
     ...state,
-    messages: [syncedMessage],
+    messages: [...state.messages, syncedMessage],
     latestVersionNumber: state.latestVersionNumber + 1,
   }
 }


### PR DESCRIPTION
## Issue

- resolve: AIMessage reasoning field causing API errors when invoking design agent
- Alternative approach to message filtering that preserves context

## Why is this change needed?

This change addresses a validation issue with the OpenAI API when processing messages that include a malformed reasoning field inside AIMessage.additional_kwargs.

In our previous implementation, some AIMessage objects retained a reasoning field containing improperly structured data. When such messages were passed to the OpenAI API (e.g., via LangChain agents), they triggered validation errors — specifically, errors like "reasoning without required following item". This was due to the OpenAI API's strict schema expectations for system-level metadata, which reasoning accidentally violated.

To prevent this, we now filter out the reasoning field from all AIMessage instances before invoking the agent. This ensures all messages conform to the API's expected structure, avoiding runtime failures. Notably, HumanMessage objects are unaffected and safely passed through without modification.


🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that could cause API errors by ensuring the `reasoning` field is removed from AI-generated messages before processing.
  * Improved error handling by displaying error feedback as a user message, preventing related API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->