### PR TITLE
✨ Add benchmark execute command for schema comparison

### DIFF
--- a/.claude/commands/benchmark-execute.md
+++ b/.claude/commands/benchmark-execute.md
@@ -1,0 +1,57 @@
+---
+description: Execute schema benchmark for specified model (LiamDB or OpenAI)
+---
+
+# Benchmark Command
+
+Execute schema benchmark comparison between LiamDB and OpenAI models.
+
+## Arguments
+- `model`: Target model to benchmark (LiamDB or OpenAI, case-insensitive)
+
+## Usage
+```
+/benchmark LiamDB
+/benchmark openai
+```
+
+## Execution
+
+First, I'll clean up any existing workspace and set up a fresh benchmark environment:
+
+```bash
+rm -rf benchmark-workspace && pnpm --filter @liam-hq/schema-bench setupWorkspace
+```
+
+Next, I'll execute the specified model:
+
+{{#if (eq (lower model) "liamdb")}}
+```bash
+pnpm --filter @liam-hq/schema-bench executeLiamDB
+```
+{{else if (eq (lower model) "openai")}}
+```bash
+pnpm --filter @liam-hq/schema-bench executeOpenai
+```
+{{else}}
+**Error**: Invalid model specified. Please use 'LiamDB' or 'OpenAI'.
+{{/if}}
+
+If execution succeeds, I'll run the evaluation:
+
+```bash
+pnpm --filter @liam-hq/schema-bench evaluateSchema
+```
+
+Finally, I'll read the latest summary results from `benchmark-workspace/evaluation/` and display the metrics in a formatted table.
+
+The results will show average metrics including:
+- Table F1 Score
+- Table All Correct Rate
+- Column F1 Score Average
+- Column All Correct Rate Average
+- Primary Key Accuracy Average
+- Constraint Accuracy
+- Foreign Key F1 Score
+- Foreign Key All Correct Rate
+- Overall Schema Accuracy


### PR DESCRIPTION
## Issue

- resolve: route06/liam-internal#5193

## Why is this change needed?
Added new Claude command to execute and evaluate schema benchmarks between LiamDB and OpenAI models. The command supports templating for different models and includes comprehensive benchmark workflow execution with automated workspace setup, model execution, and results evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation detailing the benchmark execution command for comparing schema performance between LiamDB and OpenAI models, including usage instructions, argument options, and explanation of output metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->