### PR TITLE
fix: prevent duplicate semicolons in SQL statements

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.ts
@@ -121,7 +121,10 @@ export async function prepareDmlNode(
       const header = op.description
         ? `-- ${op.description}`
         : `-- ${op.operation_type} operation for use case ${op.useCaseId}`
-      return `${header}\n${op.sql};`
+      const sqlWithSemicolon = op.sql.trim().endsWith(';')
+        ? op.sql
+        : `${op.sql};`
+      return `${header}\n${sqlWithSemicolon}`
     })
     .join('\n\n')
 


### PR DESCRIPTION
## Summary
- Check if SQL already ends with semicolon before appending in prepareDmlNode
- Prevents potential SQL syntax errors from double semicolons (e.g., `SELECT * FROM users;;`)

## Context
This fix addresses the code review comment: https://github.com/liam-hq/liam/pull/2749#discussion_r2244740606

The SQL statement was being appended with a semicolon unconditionally, which could result in double semicolons if the SQL already contained one.

## Changes
- Added check in `prepareDmlNode.ts` to only append semicolon if not already present
- Maintains consistent SQL formatting while avoiding syntax errors

🤖 Generated with [Claude Code](https://claude.ai/code)