### PR TITLE
🤖 Remove GitHub Actions updates from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,3 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      time: "10:00"
-      timezone: "Asia/Tokyo"


### PR DESCRIPTION
## Issue

- resolve: Remove monthly GitHub Actions dependency updates

## Why is this change needed?
This change removes the GitHub Actions package ecosystem from dependabot.yml to stop automatic monthly dependency updates for GitHub Actions. This helps reduce maintenance overhead and prevents potential issues from automatic GitHub Actions updates.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic update checks for GitHub Actions dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->