### PR TITLE
🐛(agent): Fix tool message ordering to prevent sync errors

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/designSchemaNode.ts
@@ -96,7 +96,7 @@ export async function designSchemaNode(
     // Return state with error feedback as HumanMessage for self-recovery
     return {
       ...state,
-      messages: [...messages, errorFeedbackMessage],
+      messages: [errorFeedbackMessage],
       error: invokeResult.error,
     }
   }
@@ -126,7 +126,7 @@ export async function designSchemaNode(
 
   return {
     ...state,
-    messages: [...messages, syncedMessage],
+    messages: [syncedMessage],
     latestVersionNumber: state.latestVersionNumber + 1,
   }
 }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5201

<img width="1475" height="817" alt="スクリーンショット 2025-08-01 18 04 12" src="https://github.com/user-attachments/assets/28d2ad02-3115-49d3-8527-f10e0a50ad9c" />


## Why is this change needed?

The issue was caused by accidentally removing necessary fields when attempting to
  remove the reasoning field.

  The original code only extracted three properties (content, additional_kwargs, 
  response_metadata) from the AIMessage to create a new instance, which
  unintentionally discarded important fields like `tool_calls`.

  This fix ensures that only the reasoning field is removed while preserving all
  other fields including `tool_calls`.



🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI-generated messages to ensure all relevant metadata is preserved during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->