### PR TITLE
✨ add diff highlighting to TableDetail Columns component

### DIFF
--- a/frontend/packages/db-structure/src/diff/buildSchemaDiff.ts
+++ b/frontend/packages/db-structure/src/diff/buildSchemaDiff.ts
@@ -9,6 +9,7 @@ import { buildColumnDefaultDiffItem } from './columns/buildColumnDefaultDiffItem
 import { buildColumnDiffItem } from './columns/buildColumnDiffItem.js'
 import { buildColumnNameDiffItem } from './columns/buildColumnNameDiffItem.js'
 import { buildColumnNotNullDiffItem } from './columns/buildColumnNotNullDiffItem.js'
+import { buildColumnTypeDiffItem } from './columns/buildColumnTypeDiffItem.js'
 import { buildConstraintColumnNameDiffItem } from './constraints/buildConstraintColumnNameDiffItem.js'
 import { buildConstraintDeleteConstraintDiffItem } from './constraints/buildConstraintDeleteConstraintDiffItem.js'
 import { buildConstraintDetailDiffItem } from './constraints/buildConstraintDetailDiffItem.js'
@@ -98,6 +99,17 @@ function buildColumnRelatedDiffItems(
   )
   if (columnNameDiffItem) {
     items.push(columnNameDiffItem)
+  }
+
+  const columnTypeDiffItem = buildColumnTypeDiffItem(
+    tableId,
+    columnId,
+    before,
+    after,
+    operations,
+  )
+  if (columnTypeDiffItem) {
+    items.push(columnTypeDiffItem)
   }
 
   const columnCommentDiffItem = buildColumnCommentDiffItem(

--- a/frontend/packages/db-structure/src/diff/columns/buildColumnTypeDiffItem.ts
+++ b/frontend/packages/db-structure/src/diff/columns/buildColumnTypeDiffItem.ts
@@ -1,0 +1,36 @@
+import type { Operation } from 'fast-json-patch'
+import { PATH_PATTERNS } from '../../operation/constants.js'
+import type { Schema } from '../../schema/index.js'
+import type { ColumnTypeDiffItem } from '../types.js'
+import { getChangeStatus } from '../utils/getChangeStatus.js'
+
+export function buildColumnTypeDiffItem(
+  tableId: string,
+  columnId: string,
+  before: Schema,
+  after: Schema,
+  operations: Operation[],
+): ColumnTypeDiffItem | null {
+  const status = getChangeStatus({
+    tableId,
+    columnId,
+    operations,
+    pathRegExp: PATH_PATTERNS.COLUMN_TYPE,
+  })
+  if (status === 'unchanged') return null
+
+  const data =
+    status === 'removed'
+      ? before.tables[tableId]?.columns[columnId]?.type
+      : after.tables[tableId]?.columns[columnId]?.type
+
+  if (data === undefined) return null
+
+  return {
+    kind: 'column-type',
+    status,
+    data,
+    tableId,
+    columnId,
+  }
+}

--- a/frontend/packages/db-structure/src/diff/types.ts
+++ b/frontend/packages/db-structure/src/diff/types.ts
@@ -14,6 +14,7 @@ import {
   columnNameSchema,
   columnNotNullSchema,
   columnSchema,
+  columnTypeSchema,
   commentSchema,
   constraintNameSchema,
   constraintSchema,
@@ -78,6 +79,14 @@ const columnNameDiffItemSchema = object({
   columnId: string(),
 })
 export type ColumnNameDiffItem = InferOutput<typeof columnNameDiffItemSchema>
+
+const columnTypeDiffItemSchema = object({
+  ...baseSchemaDiffItemSchema.entries,
+  kind: literal('column-type'),
+  data: columnTypeSchema,
+  columnId: string(),
+})
+export type ColumnTypeDiffItem = InferOutput<typeof columnTypeDiffItemSchema>
 
 const columnCommentDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
@@ -249,6 +258,7 @@ export type TableRelatedDiffItem = InferOutput<
 export const columnRelatedDiffItemSchema = union([
   columnDiffItemSchema,
   columnNameDiffItemSchema,
+  columnTypeDiffItemSchema,
   columnCommentDiffItemSchema,
   columnDefaultDiffItemSchema,
   columnCheckDiffItemSchema,

--- a/frontend/packages/db-structure/src/schema/index.ts
+++ b/frontend/packages/db-structure/src/schema/index.ts
@@ -32,6 +32,7 @@ export {
   columnNameSchema,
   columnNotNullSchema,
   columnSchema,
+  columnTypeSchema,
   commentSchema,
   constraintNameSchema,
   constraintSchema,

--- a/frontend/packages/db-structure/src/schema/schema.ts
+++ b/frontend/packages/db-structure/src/schema/schema.ts
@@ -3,6 +3,8 @@ import * as v from 'valibot'
 // Export these schema definitions
 export const columnNameSchema = v.string()
 
+export const columnTypeSchema = v.string()
+
 export const columnDefaultSchema = v.nullable(
   v.union([v.string(), v.number(), v.boolean()]),
 )
@@ -19,7 +21,7 @@ export const constraintNameSchema = v.string()
 
 export const columnSchema = v.object({
   name: columnNameSchema,
-  type: v.string(),
+  type: columnTypeSchema,
   default: columnDefaultSchema,
   check: columnCheckSchema,
   notNull: columnNotNullSchema,

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/Columns.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/Columns.tsx
@@ -1,4 +1,4 @@
-import type { Columns as ColumnsType, Constraints } from '@liam-hq/db-structure'
+import type { Table } from '@liam-hq/db-structure'
 import { Rows3 as Rows3Icon } from '@liam-hq/ui'
 import type { FC } from 'react'
 import { CollapsibleHeader } from '../CollapsibleHeader'
@@ -6,13 +6,12 @@ import styles from './Columns.module.css'
 import { ColumnsItem } from './ColumnsItem'
 
 type Props = {
-  columns: ColumnsType
-  constraints: Constraints
+  table: Table
 }
 
-export const Columns: FC<Props> = ({ columns, constraints }) => {
+export const Columns: FC<Props> = ({ table }) => {
   // NOTE: 300px is the height of one item in the list(when comments are lengthy)
-  const contentMaxHeight = Object.keys(columns).length * 300
+  const contentMaxHeight = Object.keys(table.columns).length * 300
   return (
     <CollapsibleHeader
       title="Columns"
@@ -21,9 +20,13 @@ export const Columns: FC<Props> = ({ columns, constraints }) => {
       stickyTopHeight={0}
       contentMaxHeight={contentMaxHeight}
     >
-      {Object.entries(columns).map(([key, column]) => (
+      {Object.entries(table.columns).map(([key, column]) => (
         <div className={styles.itemWrapper} key={key}>
-          <ColumnsItem column={column} constraints={constraints} />
+          <ColumnsItem
+            tableId={table.name}
+            column={column}
+            constraints={table.constraints}
+          />
         </div>
       ))}
     </CollapsibleHeader>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -13,17 +13,36 @@ import {
   GridTableRow,
   KeyRound,
 } from '@liam-hq/ui'
-import type { FC } from 'react'
+import clsx from 'clsx'
+import { type FC, useMemo } from 'react'
+import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
+import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
 import styles from './ColumnsItem.module.css'
+import { getChangeStatus } from './getChangeStatus'
 
 type Props = {
+  tableId: string
   column: Column
   constraints: Constraints
 }
 
-export const ColumnsItem: FC<Props> = ({ column, constraints }) => {
+export const ColumnsItem: FC<Props> = ({ tableId, column, constraints }) => {
+  const { diffItems } = useSchemaOrThrow()
+  const { showDiff } = useUserEditingOrThrow()
+
+  const changeStatus = useMemo(() => {
+    if (!showDiff) return undefined
+    return getChangeStatus({
+      tableId,
+      diffItems: diffItems ?? [],
+      columnId: column.name,
+    })
+  }, [showDiff, tableId, diffItems])
+
+  const diffStyle = useDiffStyle(showDiff, changeStatus)
+
   return (
-    <div className={styles.wrapper}>
+    <div className={clsx(styles.wrapper, diffStyle)}>
       <h3 className={styles.heading}>{column.name}</h3>
       {column.comment && <p className={styles.comment}>{column.comment}</p>}
       <GridTableRoot>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/getChangeStatus.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/getChangeStatus.ts
@@ -1,0 +1,53 @@
+import {
+  type ChangeStatus,
+  columnRelatedDiffItemSchema,
+  type SchemaDiffItem,
+  tableDiffItemSchema,
+} from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+type Params = {
+  tableId: string
+  columnId: string
+  diffItems: SchemaDiffItem[]
+}
+
+export function getChangeStatus({
+  tableId,
+  columnId,
+  diffItems,
+}: Params): ChangeStatus {
+  const filteredDiffItems = diffItems.filter((d) => d.tableId === tableId)
+
+  // Priority 1: Check for table-level changes (added/removed)
+  // If the table itself has been added or removed, return that status immediately
+  const tableRelatedDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(tableDiffItemSchema, item)
+    return parsed.success
+  })
+
+  if (tableRelatedDiffItem) {
+    return tableRelatedDiffItem.status
+  }
+
+  const columnRelatedDiffItems = filteredDiffItems.filter((item) => {
+    const parsed = safeParse(columnRelatedDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  if (columnRelatedDiffItems.length === 0) {
+    return 'unchanged'
+  }
+
+  // Collect all unique statuses from column changes
+  const statuses = columnRelatedDiffItems.map((item) => item.status)
+  const uniqueStatuses = new Set(statuses)
+
+  // All columns have the same change status
+  if (uniqueStatuses.size === 1 && statuses[0] !== undefined) {
+    return statuses[0]
+  }
+
+  // Mixed statuses indicate the table has been modified
+  return 'modified'
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/TableDetail.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/TableDetail.tsx
@@ -80,7 +80,7 @@ export const TableDetail: FC<Props> = ({ table }) => {
       <Head table={table} />
       <div className={styles.body}>
         {table.comment && <Comment table={table} />}
-        <Columns columns={table.columns} constraints={table.constraints} />
+        <Columns table={table} />
         <Indexes indexes={table.indexes} />
         <Constraints constraints={table.constraints} />
         <div className={styles.relatedTables}>


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This PR adds diff highlighting functionality to the Columns component within TableDetail, enabling visual indication of column changes (added, removed, modified) when viewing schema differences.

The implementation follows the same pattern established in the Head and Comment components, using the shared `useDiffStyle` hook for consistent styling across all TableDetail sections.

## Summary

### Initial Implementation
- Pass entire `table` object to `Columns` component instead of separate props for better data flow
- Add `getChangeStatus` utility to determine column change status based on diff items
- Integrate diff highlighting into `ColumnsItem` component using the shared `useDiffStyle` hook
- Maintain consistency with existing diff highlighting patterns in TableDetail

### Additional Enhancement
- Add support for detecting and highlighting column type changes in schema diffs
- Create `columnTypeSchema` for proper type validation
- Implement `buildColumnTypeDiffItem` function to handle column type change detection
- Integrate column type diff into the main schema diff building flow
- Export necessary types and schemas from the db-structure package

This enables the UI to properly highlight when a column's data type has been modified between schema versions.

<img width="1479" height="883" alt="スクリーンショット 2025-08-04 15 30 03" src="https://github.com/user-attachments/assets/fda46aca-88c8-48a7-95ab-89db2688250b" />
