### PR TITLE
✨ erd-core(command palette): add CommandPalette component

### DIFF
--- a/.changeset/clean-otters-sin.md
+++ b/.changeset/clean-otters-sin.md
@@ -1,0 +1,8 @@
+---
+"@liam-hq/erd-core": minor
+---
+
+✨ add CommandPalette component
+- open with ⌘K / Ctrl+K
+- search tables
+- click to view in ERD

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/AppBar.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/AppBar/AppBar.tsx
@@ -7,6 +7,7 @@ import {
   TooltipTrigger,
 } from '@liam-hq/ui'
 import type { FC } from 'react'
+import { CommandPaletteTriggerButton } from '../CommandPalette'
 import styles from './AppBar.module.css'
 import { CopyLinkButton } from './CopyLinkButton'
 import { GithubButton } from './GithubButton'
@@ -44,6 +45,7 @@ export const AppBar: FC = () => {
 
       <div className={styles.rightSide}>
         <div className={styles.iconButtonGroup}>
+          <CommandPaletteTriggerButton />
           <GithubButton />
           <ReleaseNoteButton />
           <HelpButton />


### PR DESCRIPTION
## Issue

https://github.com/liam-hq/liam/issues/507

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

Public releasing CommandPalette component 🎉 

This PR will add command palette trigger button in the AppBar to show people can open it by clicking it or ⌘K.

<img width="1201" height="484" alt="Screenshot 0007-08-03 at 10 30 49" src="https://github.com/user-attachments/assets/f75eaf75-791a-4e37-8e45-a3c50328f66e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Command Palette that can be opened with ⌘K or Ctrl+K, allowing users to search for tables and quickly navigate to them in the ERD.
  * Added a Command Palette trigger button to the app bar for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->