### PR TITLE
🐛 Fix Prisma version mismatch in Next.js build script

### DIFF
--- a/frontend/apps/app/scripts/install-prisma-internals.mjs
+++ b/frontend/apps/app/scripts/install-prisma-internals.mjs
@@ -19,7 +19,7 @@ const main = () => {
 
   process.chdir(nodeModulesPath)
 
-  execSync('npm install @prisma/internals', { stdio: 'inherit' })
+  execSync('npm install @prisma/internals@6.8.2', { stdio: 'inherit' })
 
   const packageJsonPath = path.join(nodeModulesPath, 'package.json')
   const packageLockJsonPath = path.join(nodeModulesPath, '.package-lock.json')


### PR DESCRIPTION
## Issue

- ref: route06/liam-internal#5205

## Why is this change needed?

The Next.js app was installing the latest version of @prisma/internals (6.13.0) instead of the project's specified version (6.8.2), causing "Views cannot have primary keys" errors when parsing Prisma schemas containing views with @id directives. This version mismatch only affected the web app, while the CLI worked correctly.

## Summary

- Specified exact version (6.8.2) in `install-prisma-internals.mjs` script to prevent version conflicts
- The newer Prisma version (6.13.0) has stricter validation for views that was incompatible with existing schemas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation process to use a specific version of an internal package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->