### PR TITLE
Feat/add css modules kit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
       "source.fixAll.stylelint": "always"
     }
   },
+  "eslint.validate": ["css"],
   "prettier.requireConfig": false,
   "eslint.workingDirectories": [
     {

--- a/frontend/apps/app/eslint-suppressions.json
+++ b/frontend/apps/app/eslint-suppressions.json
@@ -24,6 +24,11 @@
       "count": 1
     }
   },
+  "app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/layout.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
   "app/(app)/app/(with-project-and-branch)/projects/[projectId]/ref/[branchOrCommit]/page.tsx": {
     "no-throw-error/no-throw-error": {
       "count": 1
@@ -59,8 +64,23 @@
       "count": 2
     }
   },
+  "components/BranchDetailPage/BranchDetailPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 7
+    }
+  },
   "components/BranchDetailPage/BranchDetailPage.tsx": {
     "no-throw-error/no-throw-error": {
+      "count": 1
+    }
+  },
+  "components/CommonLayout/AppBar/BranchDropdownMenu/BranchDropdownMenu.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
+  "components/CommonLayout/AppBar/ProjectsDropdownMenu/ProjectsDropdownMenu.module.css": {
+    "css-modules-kit/no-unused-class-names": {
       "count": 1
     }
   },
@@ -69,9 +89,44 @@
       "count": 1
     }
   },
+  "components/CommonLayout/GlobalNav/Item.module.css": {
+    "css-modules-kit/no-missing-component-file": {
+      "count": 1
+    }
+  },
+  "components/CommonLayout/GlobalNav/OrganizationItem/OrganizationItem.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "components/CommonLayout/GlobalNav/RecentsSection/RecentsSection.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 21
+    }
+  },
+  "components/FormatIcon/FormatIcon.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "components/GeneralPage/GeneralPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 17
+    }
+  },
   "components/GeneralPage/GeneralPage.tsx": {
     "no-throw-error/no-throw-error": {
       "count": 1
+    }
+  },
+  "components/GeneralPage/components/GeneralPageClient/components/DeleteOrganizationButtonClient/DeleteOrganizationButtonClient.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 9
+    }
+  },
+  "components/LoginPage/LoginPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 7
     }
   },
   "components/OrganizationMembersPage/OrganizationMembersPage.tsx": {
@@ -79,8 +134,43 @@
       "count": 1
     }
   },
+  "components/OrganizationMembersPage/components/InvitationItem/InvitationItem.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
+  "components/OrganizationMembersPage/components/InviteMemberModal/InviteMemberModal.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
+  "components/OrganizationMembersPage/components/MemberItem/MemberItem.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
+  "components/OrganizationNewPage/OrganizationNewPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
+  "components/PGlitePage/PGlitePlayground.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "components/ProjectLayout/ProjectHeader/ProjectHeader.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 3
+    }
+  },
   "components/ProjectLayout/ProjectHeader/ProjectHeader.tsx": {
     "no-throw-error/no-throw-error": {
+      "count": 1
+    }
+  },
+  "components/ProjectNewPage/components/InstallationSelector/InstallationSelector.module.css": {
+    "css-modules-kit/no-unused-class-names": {
       "count": 1
     }
   },
@@ -90,6 +180,16 @@
     },
     "no-throw-error/no-throw-error": {
       "count": 3
+    }
+  },
+  "components/ProjectSessionsPage/ProjectSessionsPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "components/ProjectsPage/ProjectsPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 9
     }
   },
   "components/ProjectsPage/ProjectsPage.tsx": {
@@ -104,6 +204,21 @@
   },
   "components/SchemaPage/SchemaPage.tsx": {
     "no-throw-error/no-throw-error": {
+      "count": 1
+    }
+  },
+  "components/SchemaPage/components/SchemaHeader/SchemaHeader.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "components/SessionDetailPage/SessionDetailPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 6
+    }
+  },
+  "components/SessionDetailPage/components/Chat/components/ChatInput/ChatInput.module.css": {
+    "css-modules-kit/no-unused-class-names": {
       "count": 1
     }
   },
@@ -122,13 +237,38 @@
       "count": 3
     }
   },
+  "components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/AgentMessage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 6
+    }
+  },
+  "components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/components/MessageOptionButtons/MessageOptionButton.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 5
+    }
+  },
   "components/SessionDetailPage/components/Chat/components/TimelineItem/components/AgentMessage/components/MessageOptionButtons/MessageOptionButton.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
     }
   },
+  "components/SessionDetailPage/components/Chat/components/TimelineItem/components/LogMessage/LogMessage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 3
+    }
+  },
+  "components/SessionDetailPage/components/Chat/components/TimelineItem/components/VersionMessage/VersionMessage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 13
+    }
+  },
   "components/SessionDetailPage/components/Chat/services/aiMessageService.ts": {
     "no-throw-error/no-throw-error": {
+      "count": 2
+    }
+  },
+  "components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css": {
+    "css-modules-kit/no-unused-class-names": {
       "count": 2
     }
   },
@@ -142,6 +282,16 @@
       "count": 2
     }
   },
+  "components/SessionDetailPage/components/Output/components/SchemaUpdates/MigrationsViewer/useMigrationsViewer/Comment/Comment.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "components/SessionDetailPage/components/Output/components/SchemaUpdates/SchemaUpdates.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
   "components/SessionDetailPage/hooks/useRealtimeWorkflowRuns.ts": {
     "no-throw-error/no-throw-error": {
       "count": 1
@@ -150,6 +300,11 @@
   "components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts": {
     "no-throw-error/no-throw-error": {
       "count": 1
+    }
+  },
+  "components/SessionsNewPage/SessionsNewPage.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 19
     }
   },
   "features/organizations/services/getOrganizationId.ts": {
@@ -162,9 +317,39 @@
       "count": 2
     }
   },
+  "features/sessions/components/SessionForm/AttachmentPreview/AttachmentPreview.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "features/sessions/components/SessionForm/BranchesDropdown/BranchesDropdown.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "features/sessions/components/SessionForm/FormatSelectDropdown/FormatSelectDropdown.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "features/sessions/components/SessionForm/GitHubSessionFormPresenter/GitHubSessionFormPresenter.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 3
+    }
+  },
   "features/sessions/components/SessionForm/GitHubSessionFormPresenter/GitHubSessionFormPresenter.stories.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    }
+  },
+  "features/sessions/components/SessionForm/ProjectsDropdown/ProjectsDropdown.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 5
+    }
+  },
+  "features/sessions/components/SessionForm/UploadSessionFormPresenter/UploadSessionFormPresenter.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 50
     }
   },
   "instrumentation.ts": {

--- a/frontend/apps/app/package.json
+++ b/frontend/apps/app/package.json
@@ -72,10 +72,11 @@
     "gen:css": "tcm -p '!(node_modules|.next|.trigger|.turbo)/**/*.module.css'",
     "lint": "concurrently \"pnpm:lint:*\"",
     "lint:biome": "biome check .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint . --prune-suppressions",
     "lint:tsc": "tsc --noEmit",
     "postinstall": "cp ../../packages/db-structure/node_modules/@ruby/prism/src/prism.wasm prism.wasm",
     "start": "next start",
+    "suppressions": "eslint --suppress-all --fix",
     "test": "vitest --watch=false",
     "test:vitest": "pnpm vitest"
   }

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -11,7 +11,7 @@
     "enabled": true,
     "indentStyle": "space",
     "lineWidth": 80,
-    "includes": ["**", "!**/package.json"] // some rules conflict with syncpack
+    "includes": ["**", "!**/package.json","!**/eslint-suppressions.json"] // some rules conflict with syncpack
   },
   "linter": {
     "enabled": true,

--- a/frontend/internal-packages/configs/eslint/base.js
+++ b/frontend/internal-packages/configs/eslint/base.js
@@ -6,6 +6,8 @@ import { noNonEnglishPlugin } from './no-non-english-plugin.js'
 import { noThrowErrorPlugin } from './no-throw-error-plugin.js'
 import { preferClsxPlugin } from './prefer-clsx-plugin.js'
 import { requireUseServerPlugin } from './require-use-server-plugin.js'
+import css from '@eslint/css';
+import cssModulesKit from '@css-modules-kit/eslint-plugin';
 
 /**
  * Base ESLint configuration with typescript-eslint setup
@@ -117,6 +119,15 @@ export function createBaseConfig(options = {}) {
         'no-non-english/no-non-english-characters': 'error',
         'no-throw-error/no-throw-error': 'error',
       },
+    },
+    {
+      files: ['**/*.css'],
+      language: "css/css",
+      plugins: {
+        css,
+        'css-modules-kit': cssModulesKit,
+      },
+      rules: {...cssModulesKit.configs.recommended.rules},
     },
   ]
 }

--- a/frontend/internal-packages/configs/package.json
+++ b/frontend/internal-packages/configs/package.json
@@ -11,7 +11,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.1",
+    "@css-modules-kit/eslint-plugin": "0.2.1",
     "@eslint/compat": "1.3.1",
+    "@eslint/css": "0.10.0",
     "@tsconfig/strictest": "2.0.5",
     "@typescript-eslint/eslint-plugin": "8.36.0",
     "@typescript-eslint/parser": "8.36.0",

--- a/frontend/packages/erd-core/eslint-suppressions.json
+++ b/frontend/packages/erd-core/eslint-suppressions.json
@@ -1,1 +1,32 @@
-{}
+{
+  "src/features/diff/styles/Diff.module.css": {
+    "css-modules-kit/no-missing-component-file": {
+      "count": 1
+    }
+  },
+  "src/features/erd/components/ERDContent/ERDContent.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "src/features/erd/components/ERDRenderer/AppBar/AppBar.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 2
+    }
+  },
+  "src/features/erd/components/ERDRenderer/AppBar/ExportButton/ExportButton.module.css": {
+    "css-modules-kit/no-missing-component-file": {
+      "count": 1
+    }
+  },
+  "src/features/erd/components/ERDRenderer/LeftPane/LeftPane.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 5
+    }
+  },
+  "src/features/erd/components/ERDRenderer/Toolbar/DesktopToolbar.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  }
+}

--- a/frontend/packages/erd-core/package.json
+++ b/frontend/packages/erd-core/package.json
@@ -51,8 +51,9 @@
     "gen:css": "tcm src",
     "lint": "concurrently \"pnpm:lint:*\"",
     "lint:biome": "biome check .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint . --prune-suppressions",
     "lint:tsc": "tsc --noEmit",
+    "suppressions": "eslint --suppress-all --fix",
     "test": "vitest --watch=false"
   }
 }

--- a/frontend/packages/ui/eslint-suppressions.json
+++ b/frontend/packages/ui/eslint-suppressions.json
@@ -1,1 +1,27 @@
-{}
+{
+  "src/components/Avatar/Avatar.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 1
+    }
+  },
+  "src/components/Callout/Callout.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 5
+    }
+  },
+  "src/components/Code/Code.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 11
+    }
+  },
+  "src/components/RemoveButton/RemoveButton.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 11
+    }
+  },
+  "src/components/RoundBadge/RoundBadge.module.css": {
+    "css-modules-kit/no-unused-class-names": {
+      "count": 4
+    }
+  }
+}

--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -53,8 +53,9 @@
     "gen:css": "tcm src",
     "lint": "concurrently \"pnpm:lint:*\"",
     "lint:biome": "biome check .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint . --prune-suppressions",
     "lint:tsc": "tsc --noEmit",
+    "suppressions": "eslint --suppress-all --fix",
     "test": "vitest --watch=false"
   }
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   parallel: true
   commands:
     lint:
-      glob: "*.{js,jsx,ts,tsx,json,md,mdx,yml,yaml}"
+      glob: "*.{js,jsx,ts,tsx,json,md,mdx,yml,yaml,css}"
       run: pnpm lint
       stage_fixed: true
       skip:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,9 +408,15 @@ importers:
       '@biomejs/biome':
         specifier: 2.1.1
         version: 2.1.1
+      '@css-modules-kit/eslint-plugin':
+        specifier: 0.2.1
+        version: 0.2.1(@eslint/css@0.10.0)(eslint@9.31.0(jiti@2.5.1))(postcss@8.5.6)(typescript@5.8.3)
       '@eslint/compat':
         specifier: 1.3.1
         version: 1.3.1(eslint@9.31.0(jiti@2.5.1))
+      '@eslint/css':
+        specifier: 0.10.0
+        version: 0.10.0
       '@tsconfig/strictest':
         specifier: 2.0.5
         version: 2.0.5
@@ -1857,6 +1863,19 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@css-modules-kit/core@0.4.0':
+    resolution: {integrity: sha512-O00cN2b01jzlSoD6+7FANCzZNKYgU1aw7pWwOg377IEzfdiAOVlX6MAp/LHiFwsYQkwLL1azo8Vyebv9EfhRkw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      typescript: ^5.7.3
+
+  '@css-modules-kit/eslint-plugin@0.2.1':
+    resolution: {integrity: sha512-7BS4viOX+I1hsuay3+1bxAsLL6fKn0kHSlzb4SkrJqXhzqdscOz4tJW81WAOXY2pIjwzcHnSIW8+lsqjePXBBQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@eslint/css': '>=0.4.0'
+      eslint: '>=9.0.0'
+
   '@depot/cli-darwin-arm64@0.0.1-cli.2.80.0':
     resolution: {integrity: sha512-H7tQ0zWXVmdYXGFvt3d/v5fmquMlMM1I9JC8C2yiBZ9En9a20hzSbKoiym92RtcfqjKQFvhXL0DT6vQmJ8bgQA==}
     engines: {node: '>=14'}
@@ -2142,8 +2161,20 @@ packages:
     resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.14.0':
+    resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/core@0.15.1':
     resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/css-tree@3.6.2':
+    resolution: {integrity: sha512-ttB4VQguJdWxPVfX/6xB0ugWVeTe6I3nv9izeR+xPcQbtFVb3lhKbcTScWTXZu+OF0PLoLavX7zBiYtLwnlB9w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  '@eslint/css@0.10.0':
+    resolution: {integrity: sha512-pHoYRWS08oeU0qVez1pZCcbqHzoJnM5VMtrxH2nWDJ0ukq9DkwWV1BTY+PWK+eWBbndN9W0O9WjJTyAHsDoPOg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
@@ -8754,6 +8785,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  mdn-data@2.21.0:
+    resolution: {integrity: sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -9756,6 +9790,12 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
   postcss-selector-parser@7.1.0:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
     engines: {node: '>=4'}
@@ -10746,7 +10786,7 @@ packages:
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
@@ -12880,6 +12920,24 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@css-modules-kit/core@0.4.0(typescript@5.8.3)':
+    dependencies:
+      postcss: 8.5.6
+      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      postcss-selector-parser: 7.1.0
+      postcss-value-parser: 4.2.0
+      typescript: 5.8.3
+
+  '@css-modules-kit/eslint-plugin@0.2.1(@eslint/css@0.10.0)(eslint@9.31.0(jiti@2.5.1))(postcss@8.5.6)(typescript@5.8.3)':
+    dependencies:
+      '@css-modules-kit/core': 0.4.0(typescript@5.8.3)
+      '@eslint/css': 0.10.0
+      eslint: 9.31.0(jiti@2.5.1)
+      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+    transitivePeerDependencies:
+      - postcss
+      - typescript
+
   '@depot/cli-darwin-arm64@0.0.1-cli.2.80.0':
     optional: true
 
@@ -13058,9 +13116,24 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/core@0.14.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@eslint/core@0.15.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/css-tree@3.6.2':
+    dependencies:
+      mdn-data: 2.21.0
+      source-map-js: 1.2.1
+
+  '@eslint/css@0.10.0':
+    dependencies:
+      '@eslint/core': 0.14.0
+      '@eslint/css-tree': 3.6.2
+      '@eslint/plugin-kit': 0.3.4
 
   '@eslint/eslintrc@3.3.1':
     dependencies:
@@ -20398,6 +20471,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  mdn-data@2.21.0: {}
+
   media-typer@1.1.0: {}
 
   memfs@3.5.3:
@@ -21595,6 +21670,10 @@ snapshots:
   postcss-modules-values@4.0.0(postcss@8.5.6):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+
+  postcss-safe-parser@7.0.1(postcss@8.5.6):
+    dependencies:
       postcss: 8.5.6
 
   postcss-selector-parser@7.1.0:


### PR DESCRIPTION
## Issue

- resolve: Add ESLint rules for CSS Modules

## Why is this change needed?
We need to add `@css-modules-kit/eslint-plugin` to detect undefined class names when using CSS Modules. This improves type safety for CSS Modules and helps catch errors early in development.

## What was done
・add `@css-modules-kit/eslint-plugin` & `@eslint/css`
・There are many errors, so we use eslint-suppressions to avoid them. First of all, we will prioritize the introduction of Lint.