### PR TITLE
Add community articles to docs

### DIFF
--- a/frontend/apps/docs/content/docs/community-resources.mdx
+++ b/frontend/apps/docs/content/docs/community-resources.mdx
@@ -19,6 +19,24 @@ description: A collection of community-created resources and articles about Liam
   - A practical guide to generating ER diagrams from Ruby on Rails `schema.rb` files using Liam ERD.
   - Covers CLI usage, Docker-based hot-reload setup, and automated S3 deployment with GitHub Actions.
 
+## Cloud Deployment
+
+- [Liam ERDで生成したER図をCloud Run on GCSで公開する](https://zenn.dev/sikeda107/articles/8da7d91277f9aa)
+  - August 2025 • zenn.dev • [translated](https://zenn-dev.translate.goog/sikeda107/articles/8da7d91277f9aa?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=ja&_x_tr_pto=wapp&_x_tr_hist=true)
+  - A step-by-step guide to deploying Liam ERD-generated diagrams on Google Cloud Platform
+  - Covers Cloud Storage setup, Cloud Run deployment with Nginx, and public URL configuration
+
+## Articles Featuring Liam ERD
+
+- [6 принципов архитектуры ПО для старта проекта](https://habr.com/ru/articles/888266/)
+  - March 2025 • habr.com • [translated](https://habr-com.translate.goog/ru/articles/888266/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=ru&_x_tr_pto=wapp)
+  - Uses Liam ERD as an example of self-descriptive code and architecture principles
+  - Shows how auto-generating interactive database documentation creates living architecture documentation
+- [Top 4 Free, Open Source Database Schema Diagram Tools to Visualize Database Easier in 2025](https://www.bytebase.com/blog/top-database-schema-diagram-tools/)
+  - May 2025 • bytebase.com
+  - Compares Liam ERD with DrawDB, ChartDB, and Azimutt as top open-source schema visualization tools
+  - Highlights Liam ERD's zero-setup approach for Rails, Prisma, and PostgreSQL schemas
+
 ## Contributing
 
 Have you written about Liam ERD? We'd love to add your content to this list! Please submit a PR with the following information:


### PR DESCRIPTION
## Summary
- Added Cloud Deployment section with a guide for deploying Liam ERD diagrams on Google Cloud Platform
- Added Articles Featuring Liam ERD section with articles that reference or compare Liam ERD
- Included Habr article about self-descriptive architecture principles that uses Liam ERD as an example
- Included Bytebase tool comparison article that compares Liam ERD with other schema diagram tools

## Preview
- https://liam-docs-git-add-community-urls-liambx.vercel.app/docs/community-resources


🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Cloud Deployment" section with guidance on deploying ER diagrams to Google Cloud Platform.
  * Added an "Articles Featuring Liam ERD" section highlighting articles on software architecture and tool comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->