### PR TITLE
🐛 fix TableDetailDrawer to use merged schema when showDiff is enabled

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/TableDetailDrawer/TableDetailDrawer.tsx
@@ -1,5 +1,5 @@
 import { DrawerContent, DrawerPortal, DrawerRoot } from '@liam-hq/ui'
-import { type FC, type PropsWithChildren, useCallback } from 'react'
+import { type FC, type PropsWithChildren, useCallback, useMemo } from 'react'
 import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
 import { TableDetail } from '../../ERDContent/components/TableNode/TableDetail'
 import styles from './TableDetailDrawer.module.css'
@@ -32,10 +32,14 @@ export const TableDetailDrawerRoot: FC<PropsWithChildren> = ({ children }) => {
 }
 
 export const TableDetailDrawer: FC = () => {
-  const { current } = useSchemaOrThrow()
+  const { current, merged } = useSchemaOrThrow()
+  const { showDiff, activeTableName } = useUserEditingOrThrow()
 
-  const { activeTableName } = useUserEditingOrThrow()
-  const table = current.tables[activeTableName ?? '']
+  const schema = useMemo(() => {
+    return showDiff && merged ? merged : current
+  }, [showDiff, merged, current])
+
+  const table = schema.tables[activeTableName ?? '']
   const ariaDescribedBy =
     table?.comment == null
       ? {


### PR DESCRIPTION
## Issue

- resolve: Table detail drawer shows incorrect schema when diff mode is enabled

## Why is this change needed?
The TableDetailDrawer component was always using the current schema regardless of the showDiff state. When diff mode is enabled, it should display the merged schema to be consistent with the table nodes in the ERD view.

### Example
When comparing version1 to version2 where the `tasks` table had `user_id` and `volume_l` columns removed:
- ERD view: Shows both `user_id` and `volume_l` columns (correctly displaying the merged state)
- TableDetail drawer: Does not show these columns (incorrectly showing only version2)

In Diff view, we want to display the merged state of version1 and version2, so the TableDetail display needed to be fixed to match the ERD view.

| Before | After |
|--------|--------|
| <img width="1289" height="995" alt="スクリーンショット 2025-08-04 13 44 19" src="https://github.com/user-attachments/assets/d107dff0-8134-4a54-b38d-ea2872250bea" /> | <img width="1457" height="996" alt="スクリーンショット 2025-08-04 13 39 21" src="https://github.com/user-attachments/assets/68fce151-b1d5-4d7e-8b25-c9e2a79aca35" /> | 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The table details drawer now dynamically displays either the current or merged schema based on the user's editing mode, providing a more accurate view during schema editing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->