### PR TITLE
🐛(erd-core): Fix column change status logic in ERD visualization

### DIFF
--- a/frontend/packages/db-structure/src/diff/index.ts
+++ b/frontend/packages/db-structure/src/diff/index.ts
@@ -10,5 +10,6 @@ export type {
 export {
   columnRelatedDiffItemSchema,
   schemaDiffItemsSchema,
+  tableDiffItemSchema,
   tableRelatedDiffItemSchema,
 } from './types.js'

--- a/frontend/packages/db-structure/src/diff/types.ts
+++ b/frontend/packages/db-structure/src/diff/types.ts
@@ -40,7 +40,7 @@ const baseSchemaDiffItemSchema = object({
   tableId: string(),
 })
 
-const tableDiffItemSchema = object({
+export const tableDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('table'),
   data: tableSchema,

--- a/frontend/packages/db-structure/src/index.ts
+++ b/frontend/packages/db-structure/src/index.ts
@@ -15,6 +15,7 @@ export {
   buildSchemaDiff,
   columnRelatedDiffItemSchema,
   schemaDiffItemsSchema,
+  tableDiffItemSchema,
   tableRelatedDiffItemSchema,
 } from './diff/index.js'
 export { applyPatchOperations, operationsSchema } from './operation/index.js'


### PR DESCRIPTION
## Issue

- resolve: #N/A

## Why is this change needed?
The column change status logic in the ERD visualization had issues with properly determining the change status of columns. 

### Problem
When comparing version1 to version2, the tasks table had:
- Added columns: location, owner_id, capacity_l
- Removed columns: user_id, volume_l

However, all columns were incorrectly marked as "modified" and highlighted in yellow, instead of showing the correct status for each column (added/removed/unchanged).

### Solution
This fix ensures that:
1. Table-level changes (added/removed) are prioritized over column changes
2. Column filtering correctly checks only the specified columnId
3. Each column gets its correct individual status instead of all being marked as modified

| Before | After |
|--------|--------|
| <img width="1304" height="995" alt="スクリーンショット 2025-08-04 14 12 43" src="https://github.com/user-attachments/assets/6933d2d6-55e1-46b1-be34-4888c7c5edc3" /> | <img width="1303" height="996" alt="スクリーンショット 2025-08-04 14 07 28" src="https://github.com/user-attachments/assets/ba9e1d83-4776-4221-85a4-a3f9e47adfba" /> | 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for detecting and handling table-level schema changes in the application.

* **Refactor**
  * Improved the logic for determining change status of table columns, with better prioritization of table-level changes and more accurate aggregation of column change statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->