### PR TITLE
Implement cumulative DDL generation for AI prompt in ExportDropdown

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/ExportDropdown.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/ExportDropdown.tsx
@@ -52,7 +52,7 @@ const generateAIPrompt = (
 
 ${artifactDoc}
 
-## Schema Evolution (DDL Changes)
+## Schema Migrations
 \`\`\`sql
 ${ddlContent}\`\`\`
 

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/ExportDropdown.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/ExportDropdown.tsx
@@ -42,7 +42,6 @@ const generateCumulativeDDL = (operations: Operation[]): string => {
 }
 
 const generateAIPrompt = (
-  _schema: Schema,
   artifactDoc: string,
   cumulativeOperations: Operation[],
 ): string => {
@@ -76,7 +75,7 @@ export const ExportDropdown: FC<Props> = ({
   const handleCopyAIPrompt = async () => {
     if (!artifactDoc) return
 
-    const prompt = generateAIPrompt(schema, artifactDoc, cumulativeOperations)
+    const prompt = generateAIPrompt(artifactDoc, cumulativeOperations)
     const clipboardResult = await fromPromise(
       navigator.clipboard.writeText(prompt),
       (error) =>

--- a/frontend/packages/db-structure/src/index.ts
+++ b/frontend/packages/db-structure/src/index.ts
@@ -17,7 +17,11 @@ export {
   schemaDiffItemsSchema,
   tableRelatedDiffItemSchema,
 } from './diff/index.js'
-export { applyPatchOperations, operationsSchema } from './operation/index.js'
+export {
+  applyPatchOperations,
+  type Operation,
+  operationsSchema,
+} from './operation/index.js'
 export type { ProcessError } from './parser.js'
 export {
   aColumn,

--- a/frontend/packages/db-structure/src/operation/index.ts
+++ b/frontend/packages/db-structure/src/operation/index.ts
@@ -1,2 +1,2 @@
 export { applyPatchOperations } from './applyPatchOperations.js'
-export { operationsSchema } from './schema/index.js'
+export { type Operation, operationsSchema } from './schema/index.js'


### PR DESCRIPTION
## Issue

- resolve: Fix copy DDL functionality in ExportDropdown to generate cumulative DDL differences instead of full schema

## Why is this change needed?

The current AI prompt feature in ExportDropdown generates the entire schema DDL, which can be overwhelming and less useful for understanding incremental changes. This PR implements cumulative DDL generation that shows only the changes made up to the selected version, providing more targeted and useful AI prompts for schema evolution understanding.

## Changes Made

- **Export Operation type**: Added Operation type export from db-structure package to make it available for components
- **Enhanced ExportDropdown**: Added `cumulativeOperations` prop and `generateCumulativeDDL` function to convert Operation arrays to DDL statements
- **Updated AI prompt generation**: Modified `generateAIPrompt` to use cumulative DDL instead of full schema
- **Header component updates**: Added cumulative operations calculation based on selected version
- **Conditional menu display**: AI prompt menu now only appears when both artifact documentation and operations exist

## Technical Details

The implementation works by:
1. Calculating cumulative operations from initial schema to selected version
2. Converting each Operation to DDL using `postgresqlOperationDeparser`
3. Combining DDL statements to show schema evolution
4. Providing targeted AI prompts with incremental changes only

## Testing

- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ Linting passes
- ✅ Functionality tested with version selection

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced export options to include cumulative schema migration operations up to the selected version.
  * The AI prompt now summarizes schema migrations instead of the full SQL schema.
  * The "Prompt for AI Agent" export option is only shown when relevant data is available.

* **Refactor**
  * Improved prompt generation logic for AI export to better reflect migration history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->