### PR TITLE
⚡(erd-core): Filter unchanged diff items in SchemaProvider

### DIFF
--- a/frontend/packages/erd-core/src/stores/schema/SchemaProvider.tsx
+++ b/frontend/packages/erd-core/src/stores/schema/SchemaProvider.tsx
@@ -23,13 +23,16 @@ export const SchemaProvider: FC<Props> = ({ children, current, previous }) => {
       tables: {},
     }
     const diffItems = buildSchemaDiff(previous ?? emptySchema, current)
+    const filteredDiffItems = diffItems.filter(
+      (item) => item.status !== 'unchanged',
+    )
     const merged = previous ? mergeSchemas(previous, current) : current
 
     return {
       current,
       previous,
       merged,
-      diffItems,
+      diffItems: filteredDiffItems,
     }
   }, [current, previous])
 


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
This change improves performance by filtering out unchanged items from the diffItems array in SchemaProvider. Since unchanged items don't affect the UI rendering, excluding them reduces unnecessary data processing and improves rendering performance, especially for schemas with many tables and columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema diff view now hides unchanged items, making it easier to focus on relevant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->