### PR TITLE
🔧 Extract hardcoded strings to shared constants in Artifact component

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.stories.tsx
@@ -161,7 +161,7 @@ WHERE product_id = 'PROD-001'
   AND warehouse_id = 'WH-EAST';
 \`\`\`
 
-**Execution Logs:**
+**Execution History:**
 - 12/28/2024, 10:30:45 AM: ✅ Success - Updated 1 row(s) in 23ms
 - 12/28/2024, 09:15:22 AM: ✅ Success - Updated 1 row(s) in 18ms
 - 12/27/2024, 03:45:10 PM: ❌ Failed - Lock timeout exceeded after 5000ms
@@ -175,7 +175,7 @@ VALUES
 ('TXN-' || gen_random_uuid(), 'PROD-001', -50, 'SHIPMENT', CURRENT_TIMESTAMP);
 \`\`\`
 
-**Execution Logs:**
+**Execution History:**
 - 12/28/2024, 10:30:46 AM: ✅ Success - Inserted 1 row(s) in 15ms
 - 12/28/2024, 09:15:23 AM: ✅ Success - Inserted 1 row(s) in 12ms
 

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
@@ -9,7 +9,14 @@ import remarkGfm from 'remark-gfm'
 import { CopyButton } from '../shared/CopyButton'
 import styles from './Artifact.module.css'
 import { TableOfContents } from './TableOfContents/TableOfContents'
-import { generateHeadingId } from './utils'
+import {
+  EXECUTION_SECTION_TITLE,
+  FAILURE_ICON,
+  FAILURE_STATUS,
+  generateHeadingId,
+  SUCCESS_ICON,
+  SUCCESS_STATUS,
+} from './utils'
 
 type CodeProps = {
   className?: string
@@ -55,8 +62,8 @@ export const Artifact: FC<Props> = ({ doc }) => {
 
                   const text = extractText(children)
 
-                  // Check if this paragraph contains "Execution Logs:"
-                  if (text.includes('Execution Logs:')) {
+                  // Check if this paragraph contains execution section title
+                  if (text.includes(`${EXECUTION_SECTION_TITLE}:`)) {
                     return (
                       <p className={styles.executionLogsHeading} {...rest}>
                         {children}
@@ -89,12 +96,15 @@ export const Artifact: FC<Props> = ({ doc }) => {
                   const text = extractText(children)
 
                   // Check if this is an execution log entry
-                  const executionLogMatch = text.match(
-                    /^(.+?):\s*(✅ Success|❌ Failed)\s*-\s*(.+)$/,
+                  const successPattern = `${SUCCESS_ICON} ${SUCCESS_STATUS}`
+                  const failurePattern = `${FAILURE_ICON} ${FAILURE_STATUS}`
+                  const executionLogPattern = new RegExp(
+                    `^(.+?):\\s*(${successPattern}|${failurePattern})\\s*-\\s*(.+)$`,
                   )
+                  const executionLogMatch = text.match(executionLogPattern)
                   if (executionLogMatch) {
                     const [, timestamp, status, message] = executionLogMatch
-                    const isSuccess = status?.includes('✅ Success')
+                    const isSuccess = status?.includes(successPattern)
                     return (
                       <li className={styles.executionLogItem} {...rest}>
                         <span

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils.ts
@@ -1,3 +1,10 @@
+// Common constants for Artifact component
+export const EXECUTION_SECTION_TITLE = 'Execution History'
+export const SUCCESS_ICON = '✅'
+export const FAILURE_ICON = '❌'
+export const SUCCESS_STATUS = 'Success'
+export const FAILURE_STATUS = 'Failed'
+
 export const generateHeadingId = (text: string): string => {
   return text
     .toLowerCase()

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
@@ -1,4 +1,5 @@
 import type { Artifact, DmlOperation, UseCase } from '@liam-hq/artifact'
+import { EXECUTION_SECTION_TITLE, FAILURE_ICON, SUCCESS_ICON } from '../utils'
 
 function formatDmlOperation(operation: DmlOperation): string {
   const sections: string[] = []
@@ -19,11 +20,11 @@ function formatDmlOperation(operation: DmlOperation): string {
   // Execution logs
   if (operation.dml_execution_logs.length > 0) {
     sections.push('')
-    sections.push('**Execution History:**')
+    sections.push(`**${EXECUTION_SECTION_TITLE}:**`)
     sections.push('')
 
     operation.dml_execution_logs.forEach((log) => {
-      const statusIcon = log.success ? '✅' : '❌'
+      const statusIcon = log.success ? SUCCESS_ICON : FAILURE_ICON
       const executedAt = new Date(log.executed_at).toLocaleString('en-US', {
         year: 'numeric',
         month: '2-digit',


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
This change addresses feedback from PR #2817 review comments by extracting hardcoded strings to shared constants in the Artifact component. The specific improvements include:

- Centralizing duplicate string literals ("**Execution History:**", success/failure emojis) that appear across multiple files (formatArtifactToMarkdown.ts and Artifact.tsx)
- Improving code maintainability by ensuring consistency when these strings need to be updated
- Following DRY principles to reduce the risk of inconsistencies between components

### ref

- https://github.com/liam-hq/liam/pull/2817#discussion_r2250590305
- https://github.com/liam-hq/liam/pull/2817#discussion_r2250594269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated section headings from "Execution Logs" to "Execution History" for improved clarity.
  * Standardized the use of success and failure icons and status labels for execution history entries.

* **Refactor**
  * Centralized display strings and icons into constants for consistent labeling and formatting across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->