### PR TITLE
✨(erd-core): Add diff highlighting for table column properties

### DIFF
--- a/frontend/packages/db-structure/src/diff/index.ts
+++ b/frontend/packages/db-structure/src/diff/index.ts
@@ -8,7 +8,9 @@ export type {
   TableRelatedDiffItem,
 } from './types.js'
 export {
+  columnDiffItemSchema,
   columnRelatedDiffItemSchema,
+  columnTypeDiffItemSchema,
   schemaDiffItemsSchema,
   tableCommentDiffItemSchema,
   tableDiffItemSchema,

--- a/frontend/packages/db-structure/src/diff/index.ts
+++ b/frontend/packages/db-structure/src/diff/index.ts
@@ -8,9 +8,13 @@ export type {
   TableRelatedDiffItem,
 } from './types.js'
 export {
+  columnCommentDiffItemSchema,
+  columnDefaultDiffItemSchema,
   columnDiffItemSchema,
+  columnNotNullDiffItemSchema,
   columnRelatedDiffItemSchema,
   columnTypeDiffItemSchema,
+  constraintDiffItemSchema,
   schemaDiffItemsSchema,
   tableCommentDiffItemSchema,
   tableDiffItemSchema,

--- a/frontend/packages/db-structure/src/diff/types.ts
+++ b/frontend/packages/db-structure/src/diff/types.ts
@@ -88,7 +88,7 @@ export const columnTypeDiffItemSchema = object({
 })
 export type ColumnTypeDiffItem = InferOutput<typeof columnTypeDiffItemSchema>
 
-const columnCommentDiffItemSchema = object({
+export const columnCommentDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('column-comment'),
   data: commentSchema,
@@ -98,7 +98,7 @@ export type ColumnCommentDiffItem = InferOutput<
   typeof columnCommentDiffItemSchema
 >
 
-const columnDefaultDiffItemSchema = object({
+export const columnDefaultDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('column-default'),
   data: columnDefaultSchema,
@@ -116,7 +116,7 @@ const columnCheckDiffItemSchema = object({
 })
 export type ColumnCheckDiffItem = InferOutput<typeof columnCheckDiffItemSchema>
 
-const columnNotNullDiffItemSchema = object({
+export const columnNotNullDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('column-not-null'),
   data: columnNotNullSchema,
@@ -168,7 +168,7 @@ const indexTypeDiffItemSchema = object({
 })
 export type IndexTypeDiffItem = InferOutput<typeof indexTypeDiffItemSchema>
 
-const constraintDiffItemSchema = object({
+export const constraintDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('constraint'),
   data: constraintSchema,

--- a/frontend/packages/db-structure/src/diff/types.ts
+++ b/frontend/packages/db-structure/src/diff/types.ts
@@ -64,7 +64,7 @@ export type TableCommentDiffItem = InferOutput<
   typeof tableCommentDiffItemSchema
 >
 
-const columnDiffItemSchema = object({
+export const columnDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('column'),
   data: columnSchema,
@@ -80,7 +80,7 @@ const columnNameDiffItemSchema = object({
 })
 export type ColumnNameDiffItem = InferOutput<typeof columnNameDiffItemSchema>
 
-const columnTypeDiffItemSchema = object({
+export const columnTypeDiffItemSchema = object({
   ...baseSchemaDiffItemSchema.entries,
   kind: literal('column-type'),
   data: columnTypeSchema,

--- a/frontend/packages/db-structure/src/index.ts
+++ b/frontend/packages/db-structure/src/index.ts
@@ -13,7 +13,9 @@ export type {
 } from './diff/index.js'
 export {
   buildSchemaDiff,
+  columnDiffItemSchema,
   columnRelatedDiffItemSchema,
+  columnTypeDiffItemSchema,
   schemaDiffItemsSchema,
   tableCommentDiffItemSchema,
   tableDiffItemSchema,

--- a/frontend/packages/db-structure/src/index.ts
+++ b/frontend/packages/db-structure/src/index.ts
@@ -13,9 +13,13 @@ export type {
 } from './diff/index.js'
 export {
   buildSchemaDiff,
+  columnCommentDiffItemSchema,
+  columnDefaultDiffItemSchema,
   columnDiffItemSchema,
+  columnNotNullDiffItemSchema,
   columnRelatedDiffItemSchema,
   columnTypeDiffItemSchema,
+  constraintDiffItemSchema,
   schemaDiffItemsSchema,
   tableCommentDiffItemSchema,
   tableDiffItemSchema,

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
@@ -11,22 +11,3 @@
   font-weight: 400;
   line-height: normal;
 }
-
-.comment {
-  color: var(--color-white-alpha-70);
-  font-size: var(--font-size-2);
-  font-style: normal;
-  line-height: 150%;
-}
-
-.primaryKeyIcon {
-  width: 0.75rem;
-  height: 0.75rem;
-  color: var(--primary-accent);
-}
-
-.diamondIcon {
-  width: 0.75rem;
-  height: 0.75rem;
-  color: var(--overlay-70);
-}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -3,22 +3,17 @@ import {
   type Constraints,
   isPrimaryKey,
 } from '@liam-hq/db-structure'
-import {
-  DiamondFillIcon,
-  DiamondIcon,
-  GridTableDd,
-  GridTableDt,
-  GridTableItem,
-  GridTableRoot,
-  GridTableRow,
-  KeyRound,
-} from '@liam-hq/ui'
+import { GridTableRoot } from '@liam-hq/ui'
 import clsx from 'clsx'
 import { type FC, useMemo } from 'react'
 import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
 import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
 import styles from './ColumnsItem.module.css'
+import { Comment } from './Comment'
+import { Default } from './Default'
 import { getChangeStatus } from './getChangeStatus'
+import { NotNull } from './NotNull'
+import { PrimaryKey } from './PrimaryKey'
 import { Type } from './Type'
 
 type Props = {
@@ -45,38 +40,14 @@ export const ColumnsItem: FC<Props> = ({ tableId, column, constraints }) => {
   return (
     <div className={clsx(styles.wrapper, diffStyle)}>
       <h3 className={styles.heading}>{column.name}</h3>
-      {column.comment && <p className={styles.comment}>{column.comment}</p>}
+      {column.comment && <Comment tableId={tableId} column={column} />}
       <GridTableRoot>
         <Type tableId={tableId} column={column} />
-        {column.default !== null && (
-          <GridTableItem>
-            <GridTableDt>Default</GridTableDt>
-            <GridTableDd>{column.default}</GridTableDd>
-          </GridTableItem>
-        )}
+        <Default tableId={tableId} column={column} />
         {isPrimaryKey(column.name, constraints) && (
-          <GridTableItem>
-            <GridTableRow>
-              <KeyRound className={styles.primaryKeyIcon} />
-              Primary Key
-            </GridTableRow>
-          </GridTableItem>
+          <PrimaryKey tableId={tableId} columnName={column.name} />
         )}
-        {column.notNull ? (
-          <GridTableItem>
-            <GridTableRow>
-              <DiamondFillIcon className={styles.diamondIcon} />
-              Not-null
-            </GridTableRow>
-          </GridTableItem>
-        ) : (
-          <GridTableItem>
-            <GridTableRow>
-              <DiamondIcon className={styles.diamondIcon} />
-              Nullable
-            </GridTableRow>
-          </GridTableItem>
-        )}
+        <NotNull tableId={tableId} column={column} />
       </GridTableRoot>
     </div>
   )

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -19,6 +19,7 @@ import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
 import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
 import styles from './ColumnsItem.module.css'
 import { getChangeStatus } from './getChangeStatus'
+import { Type } from './Type'
 
 type Props = {
   tableId: string
@@ -46,10 +47,7 @@ export const ColumnsItem: FC<Props> = ({ tableId, column, constraints }) => {
       <h3 className={styles.heading}>{column.name}</h3>
       {column.comment && <p className={styles.comment}>{column.comment}</p>}
       <GridTableRoot>
-        <GridTableItem>
-          <GridTableDt>Type</GridTableDt>
-          <GridTableDd>{column.type}</GridTableDd>
-        </GridTableItem>
+        <Type tableId={tableId} column={column} />
         {column.default !== null && (
           <GridTableItem>
             <GridTableDt>Default</GridTableDt>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/Comment.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/Comment.module.css
@@ -1,0 +1,6 @@
+.comment {
+  color: var(--color-white-alpha-70);
+  font-size: var(--font-size-2);
+  font-style: normal;
+  line-height: 150%;
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/Comment.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/Comment.tsx
@@ -1,0 +1,30 @@
+import type { Column } from '@liam-hq/db-structure'
+import clsx from 'clsx'
+import { type FC, useMemo } from 'react'
+import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
+import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
+import styles from './Comment.module.css'
+import { getChangeStatus } from './getChangeStatus'
+
+type Props = {
+  tableId: string
+  column: Column
+}
+
+export const Comment: FC<Props> = ({ tableId, column }) => {
+  const { diffItems } = useSchemaOrThrow()
+  const { showDiff } = useUserEditingOrThrow()
+
+  const changeStatus = useMemo(() => {
+    if (!showDiff) return undefined
+    return getChangeStatus({
+      tableId,
+      diffItems: diffItems ?? [],
+      columnId: column.name,
+    })
+  }, [showDiff, tableId, diffItems])
+
+  const diffStyle = useDiffStyle(showDiff, changeStatus)
+
+  return <p className={clsx(styles.comment, diffStyle)}>{column.comment}</p>
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/getChangeStatus.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/getChangeStatus.ts
@@ -1,0 +1,27 @@
+import {
+  type ChangeStatus,
+  columnCommentDiffItemSchema,
+  type SchemaDiffItem,
+} from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+type Params = {
+  tableId: string
+  columnId: string
+  diffItems: SchemaDiffItem[]
+}
+
+export function getChangeStatus({
+  tableId,
+  columnId,
+  diffItems,
+}: Params): ChangeStatus {
+  const filteredDiffItems = diffItems.filter((d) => d.tableId === tableId)
+
+  const columnCommentDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnCommentDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  return columnCommentDiffItem?.status ?? 'unchanged'
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/index.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Comment/index.ts
@@ -1,0 +1,1 @@
+export * from './Comment'

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Default/Default.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Default/Default.tsx
@@ -1,0 +1,36 @@
+import type { Column } from '@liam-hq/db-structure'
+import { GridTableDd, GridTableDt, GridTableItem } from '@liam-hq/ui'
+import { type FC, useMemo } from 'react'
+import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
+import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
+import { getChangeStatus } from './getChangeStatus'
+
+type Props = {
+  tableId: string
+  column: Column
+}
+
+export const Default: FC<Props> = ({ tableId, column }) => {
+  const { diffItems } = useSchemaOrThrow()
+  const { showDiff } = useUserEditingOrThrow()
+
+  const changeStatus = useMemo(() => {
+    if (!showDiff) return undefined
+    return getChangeStatus({
+      tableId,
+      columnId: column.name,
+      diffItems: diffItems ?? [],
+    })
+  }, [showDiff, tableId, diffItems, column.name])
+
+  const diffStyle = useDiffStyle(showDiff, changeStatus)
+
+  if (column.default === null) return null
+
+  return (
+    <GridTableItem className={diffStyle}>
+      <GridTableDt>Default</GridTableDt>
+      <GridTableDd>{column.default}</GridTableDd>
+    </GridTableItem>
+  )
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Default/getChangeStatus.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Default/getChangeStatus.ts
@@ -1,0 +1,50 @@
+import {
+  type ChangeStatus,
+  columnDefaultDiffItemSchema,
+  columnDiffItemSchema,
+  type SchemaDiffItem,
+  tableDiffItemSchema,
+} from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+type Params = {
+  tableId: string
+  columnId: string
+  diffItems: SchemaDiffItem[]
+}
+
+export function getChangeStatus({
+  tableId,
+  columnId,
+  diffItems,
+}: Params): ChangeStatus {
+  const filteredDiffItems = diffItems.filter((d) => d.tableId === tableId)
+
+  // Priority 1: Check for table-level changes (added/removed)
+  const tableRelatedDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(tableDiffItemSchema, item)
+    return parsed.success
+  })
+
+  if (tableRelatedDiffItem) {
+    return tableRelatedDiffItem.status
+  }
+
+  // Priority 2: Check for column-level changes (added/removed)
+  const columnDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  if (columnDiffItem) {
+    return columnDiffItem.status
+  }
+
+  // Priority 3: Check for column default changes
+  const columnDefaultDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnDefaultDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  return columnDefaultDiffItem?.status ?? 'unchanged'
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Default/index.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Default/index.ts
@@ -1,0 +1,1 @@
+export { Default } from './Default'

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/NotNull.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/NotNull.module.css
@@ -1,0 +1,5 @@
+.diamondIcon {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--overlay-70);
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/NotNull.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/NotNull.tsx
@@ -1,0 +1,51 @@
+import type { Column } from '@liam-hq/db-structure'
+import {
+  DiamondFillIcon,
+  DiamondIcon,
+  GridTableItem,
+  GridTableRow,
+} from '@liam-hq/ui'
+import { type FC, useMemo } from 'react'
+import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
+import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
+import { getChangeStatus } from './getChangeStatus'
+import styles from './NotNull.module.css'
+
+type Props = {
+  tableId: string
+  column: Column
+}
+
+export const NotNull: FC<Props> = ({ tableId, column }) => {
+  const { diffItems } = useSchemaOrThrow()
+  const { showDiff } = useUserEditingOrThrow()
+
+  const changeStatus = useMemo(() => {
+    if (!showDiff) return undefined
+    return getChangeStatus({
+      tableId,
+      columnId: column.name,
+      diffItems: diffItems ?? [],
+    })
+  }, [showDiff, tableId, diffItems, column.name])
+
+  const diffStyle = useDiffStyle(showDiff, changeStatus)
+
+  return (
+    <GridTableItem className={diffStyle}>
+      <GridTableRow>
+        {column.notNull ? (
+          <>
+            <DiamondFillIcon className={styles.diamondIcon} />
+            Not-null
+          </>
+        ) : (
+          <>
+            <DiamondIcon className={styles.diamondIcon} />
+            Nullable
+          </>
+        )}
+      </GridTableRow>
+    </GridTableItem>
+  )
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/getChangeStatus.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/getChangeStatus.ts
@@ -1,0 +1,50 @@
+import {
+  type ChangeStatus,
+  columnDiffItemSchema,
+  columnNotNullDiffItemSchema,
+  type SchemaDiffItem,
+  tableDiffItemSchema,
+} from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+type Params = {
+  tableId: string
+  columnId: string
+  diffItems: SchemaDiffItem[]
+}
+
+export function getChangeStatus({
+  tableId,
+  columnId,
+  diffItems,
+}: Params): ChangeStatus {
+  const filteredDiffItems = diffItems.filter((d) => d.tableId === tableId)
+
+  // Priority 1: Check for table-level changes (added/removed)
+  const tableRelatedDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(tableDiffItemSchema, item)
+    return parsed.success
+  })
+
+  if (tableRelatedDiffItem) {
+    return tableRelatedDiffItem.status
+  }
+
+  // Priority 2: Check for column-level changes (added/removed)
+  const columnDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  if (columnDiffItem) {
+    return columnDiffItem.status
+  }
+
+  // Priority 3: Check for column not-null changes
+  const columnNotNullDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnNotNullDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  return columnNotNullDiffItem?.status ?? 'unchanged'
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/index.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/NotNull/index.ts
@@ -1,0 +1,1 @@
+export { NotNull } from './NotNull'

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/PrimaryKey.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/PrimaryKey.module.css
@@ -1,0 +1,5 @@
+.primaryKeyIcon {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--primary-accent);
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/PrimaryKey.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/PrimaryKey.tsx
@@ -1,0 +1,36 @@
+import { GridTableItem, GridTableRow, KeyRound } from '@liam-hq/ui'
+import { type FC, useMemo } from 'react'
+import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
+import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
+import { getChangeStatus } from './getChangeStatus'
+import styles from './PrimaryKey.module.css'
+
+type Props = {
+  tableId: string
+  columnName: string
+}
+
+export const PrimaryKey: FC<Props> = ({ tableId, columnName }) => {
+  const { diffItems } = useSchemaOrThrow()
+  const { showDiff } = useUserEditingOrThrow()
+
+  const changeStatus = useMemo(() => {
+    if (!showDiff) return undefined
+    return getChangeStatus({
+      tableId,
+      columnId: columnName,
+      diffItems: diffItems ?? [],
+    })
+  }, [showDiff, tableId, diffItems, columnName])
+
+  const diffStyle = useDiffStyle(showDiff, changeStatus)
+
+  return (
+    <GridTableItem className={diffStyle}>
+      <GridTableRow>
+        <KeyRound className={styles.primaryKeyIcon} />
+        Primary Key
+      </GridTableRow>
+    </GridTableItem>
+  )
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/getChangeStatus.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/getChangeStatus.ts
@@ -1,0 +1,53 @@
+import {
+  type ChangeStatus,
+  columnDiffItemSchema,
+  constraintDiffItemSchema,
+  type SchemaDiffItem,
+  tableDiffItemSchema,
+} from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+type Params = {
+  tableId: string
+  columnId: string
+  diffItems: SchemaDiffItem[]
+}
+
+export function getChangeStatus({
+  tableId,
+  columnId,
+  diffItems,
+}: Params): ChangeStatus {
+  const filteredDiffItems = diffItems.filter((d) => d.tableId === tableId)
+
+  // Priority 1: Check for table-level changes (added/removed)
+  const tableRelatedDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(tableDiffItemSchema, item)
+    return parsed.success
+  })
+
+  if (tableRelatedDiffItem) {
+    return tableRelatedDiffItem.status
+  }
+
+  // Priority 2: Check for column-level changes (added/removed)
+  const columnDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  if (columnDiffItem) {
+    return columnDiffItem.status
+  }
+
+  // Priority 3: Check for primary key constraint changes
+  const constraintDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(constraintDiffItemSchema, item)
+    if (parsed.success && parsed.output.data.type === 'PRIMARY KEY') {
+      return parsed.output.data.columnNames.includes(columnId)
+    }
+    return false
+  })
+
+  return constraintDiffItem?.status ?? 'unchanged'
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/index.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/PrimaryKey/index.ts
@@ -1,0 +1,1 @@
+export { PrimaryKey } from './PrimaryKey'

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Type/Type.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Type/Type.tsx
@@ -1,0 +1,34 @@
+import type { Column } from '@liam-hq/db-structure'
+import { GridTableDd, GridTableDt, GridTableItem } from '@liam-hq/ui'
+import { type FC, useMemo } from 'react'
+import { useDiffStyle } from '@/features/diff/hooks/useDiffStyle'
+import { useSchemaOrThrow, useUserEditingOrThrow } from '@/stores'
+import { getChangeStatus } from './getChangeStatus'
+
+type Props = {
+  tableId: string
+  column: Column
+}
+
+export const Type: FC<Props> = ({ tableId, column }) => {
+  const { diffItems } = useSchemaOrThrow()
+  const { showDiff } = useUserEditingOrThrow()
+
+  const changeStatus = useMemo(() => {
+    if (!showDiff) return undefined
+    return getChangeStatus({
+      tableId,
+      diffItems: diffItems ?? [],
+      columnId: column.name,
+    })
+  }, [showDiff, tableId, diffItems])
+
+  const diffStyle = useDiffStyle(showDiff, changeStatus)
+
+  return (
+    <GridTableItem className={diffStyle}>
+      <GridTableDt>Type</GridTableDt>
+      <GridTableDd>{column.type}</GridTableDd>
+    </GridTableItem>
+  )
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Type/getChangeStatus.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Type/getChangeStatus.ts
@@ -1,0 +1,51 @@
+import {
+  type ChangeStatus,
+  columnDiffItemSchema,
+  columnTypeDiffItemSchema,
+  type SchemaDiffItem,
+  tableDiffItemSchema,
+} from '@liam-hq/db-structure'
+import { safeParse } from 'valibot'
+
+type Params = {
+  tableId: string
+  columnId: string
+  diffItems: SchemaDiffItem[]
+}
+
+export function getChangeStatus({
+  tableId,
+  columnId,
+  diffItems,
+}: Params): ChangeStatus {
+  const filteredDiffItems = diffItems.filter((d) => d.tableId === tableId)
+
+  // Priority 1: Check for table-level changes (added/removed)
+  // If the table itself has been added or removed, return that status immediately
+  const tableRelatedDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(tableDiffItemSchema, item)
+    return parsed.success
+  })
+
+  if (tableRelatedDiffItem) {
+    return tableRelatedDiffItem.status
+  }
+
+  // Priority 2: Check for column-level changes (added/removed)
+  // If the column itself has been added or removed, return that status immediately
+  const columnDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  if (columnDiffItem) {
+    return columnDiffItem.status
+  }
+
+  const columnTypeDiffItem = filteredDiffItems.find((item) => {
+    const parsed = safeParse(columnTypeDiffItemSchema, item)
+    return parsed.success && parsed.output.columnId === columnId
+  })
+
+  return columnTypeDiffItem?.status ?? 'unchanged'
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Type/index.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/Type/index.ts
@@ -1,0 +1,1 @@
+export * from './Type'


### PR DESCRIPTION
## Issue

- resolve: #1337

## Why is this change needed?

This PR adds diff highlighting support for table column properties in the ERD visualization to improve the visibility of schema changes. Users can now easily see what properties have been added, removed, or modified for each column.

### Changes included:
- Extract column property components (Type, Default, NotNull, PrimaryKey, Comment) into separate components
- Add diff highlighting logic for each property type with proper change detection
- Export diff types from db-structure package for use in erd-core
- Implement visual indicators for added/removed/modified properties using consistent styling

### Visual improvements:
- Added properties show green background
- Removed properties show red background with strikethrough
- Modified properties show yellow background
- Consistent diff styling across all column properties