### PR TITLE
 🐛 Fix artifact description display formatting

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css
@@ -295,7 +295,7 @@
 
 /* Horizontal Rules */
 .body :global(hr) {
-  height: 0.25em;
+  height: 1px;
   padding: 0;
   margin: 24px 0;
   background-color: var(--global-border);

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
@@ -103,6 +103,7 @@ export function formatArtifactToMarkdown(artifact: Artifact): string {
       sections.push(`### ${reqIndex + 1}. ${req.name}`)
       sections.push('')
       sections.push(req.description)
+      sections.push('')
 
       if (req.type === 'functional' && req.use_cases.length > 0) {
         sections.push('')
@@ -135,6 +136,7 @@ export function formatArtifactToMarkdown(artifact: Artifact): string {
       sections.push(`### ${reqIndex + 1}. ${req.name}`)
       sections.push('')
       sections.push(req.description)
+      sections.push('')
 
       if (reqIndex < nonFunctionalReqs.length - 1) {
         sections.push('')


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
Fixed an issue where artifact descriptions were displayed with header styling (bold text). Added proper spacing after descriptions and adjusted horizontal rule thickness for consistent visual appearance.

|  | Before | After |
|---|---|---|
| Screenshot | <img width="2152" height="1986" alt="Screenshot 2025-08-04 16 31 56" src="https://github.com/user-attachments/assets/8c10f923-f637-4198-a073-42a13717c021" /> | <img width="2158" height="2066" alt="Screenshot 2025-08-04 17 10 40" src="https://github.com/user-attachments/assets/01283f6c-e2a4-44f2-aa27-dbfa6e0759a6" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated horizontal rule styling for improved consistency in the artifact display.

* **Bug Fixes**
  * Improved spacing in generated markdown by adding blank lines after requirement descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->