### PR TITLE
feat: add logout functionality with toast notifications

### DIFF
--- a/frontend/apps/app/components/CommonLayout/AppBar/AppBar.tsx
+++ b/frontend/apps/app/components/CommonLayout/AppBar/AppBar.tsx
@@ -1,10 +1,10 @@
 import type { FC } from 'react'
-import { AvatarWithImage } from '@/components'
 import { ChevronRight } from '@/icons'
 import styles from './AppBar.module.css'
 import { BranchDropdownMenu } from './BranchDropdownMenu'
 import { ProjectsDropdownMenu } from './ProjectsDropdownMenu'
 import { getAuthUser } from './services/getAuthUser'
+import { UserDropdown } from './UserDropdown'
 
 type Props = {
   currentProjectId?: string
@@ -37,9 +37,7 @@ export const AppBar: FC<Props> = async ({
         )}
       </div>
       <div className={styles.rightSection}>
-        {avatarUrl && (
-          <AvatarWithImage src={avatarUrl} alt="User profile" size="sm" />
-        )}
+        {avatarUrl && <UserDropdown avatarUrl={avatarUrl} />}
       </div>
     </div>
   )

--- a/frontend/apps/app/components/CommonLayout/AppBar/UserDropdown.tsx
+++ b/frontend/apps/app/components/CommonLayout/AppBar/UserDropdown.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useToast } from '@liam-hq/ui'
+import { type FC, useCallback } from 'react'
+import {
+  AvatarWithImage,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+} from '@/components'
+import { ArrowRight } from '@/icons'
+import { createClient } from '@/libs/db/client'
+
+type Props = {
+  avatarUrl: string
+}
+
+export const UserDropdown: FC<Props> = ({ avatarUrl }) => {
+  const toast = useToast()
+
+  const handleLogout = useCallback(async () => {
+    // Show loading toast immediately
+    toast({
+      title: 'Logging out...',
+      description: 'Please wait while we log you out.',
+      status: 'info',
+    })
+
+    // Perform logout on client side
+    const supabase = createClient()
+    const { error } = await supabase.auth.signOut()
+
+    if (!error) {
+      // Redirect with success parameter
+      window.location.href = '/app/login?logout=success'
+    } else {
+      toast({
+        title: 'Logout failed',
+        description: error.message || 'An error occurred during logout.',
+        status: 'error',
+      })
+    }
+  }, [toast])
+
+  return (
+    <DropdownMenuRoot>
+      <DropdownMenuTrigger asChild>
+        <AvatarWithImage src={avatarUrl} alt="User profile" size="sm" />
+      </DropdownMenuTrigger>
+      <DropdownMenuPortal>
+        <DropdownMenuContent align="end" sideOffset={5}>
+          <DropdownMenuItem leftIcon={<ArrowRight />} onClick={handleLogout}>
+            Logout
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenuPortal>
+    </DropdownMenuRoot>
+  )
+}

--- a/frontend/apps/app/components/LoginPage/LoginPage.tsx
+++ b/frontend/apps/app/components/LoginPage/LoginPage.tsx
@@ -2,6 +2,7 @@ import { LiamLogoMark } from '@liam-hq/ui'
 import { cookies } from 'next/headers'
 import { EmailForm } from './EmailForm'
 import styles from './LoginPage.module.css'
+import { LogoutToast } from './LogoutToast'
 import { SignInGithubButton } from './SignInGithubButton'
 
 export async function LoginPage() {
@@ -16,6 +17,7 @@ export async function LoginPage() {
 
   return (
     <div className={styles.container}>
+      <LogoutToast />
       <div className={styles.cardContainer}>
         <div className={styles.card}>
           <div className={styles.titleWrapper}>

--- a/frontend/apps/app/components/LoginPage/LogoutToast.tsx
+++ b/frontend/apps/app/components/LoginPage/LogoutToast.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useToast } from '@liam-hq/ui'
+import { useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+
+export function LogoutToast() {
+  const toast = useToast()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const logoutStatus = searchParams.get('logout')
+    if (logoutStatus === 'success') {
+      toast({
+        title: 'Logged out successfully',
+        description: 'You have been logged out.',
+        status: 'success',
+      })
+
+      // Clean up the URL to remove the logout parameter
+      const newUrl = window.location.pathname
+      window.history.replaceState({}, '', newUrl)
+    }
+  }, [searchParams, toast])
+
+  return null
+}


### PR DESCRIPTION
## Issue

- resolve: #

## Why is this change needed?

This PR adds logout functionality to the application with proper user feedback through toast notifications. Previously, there was no clear way for users to log out, and no feedback was provided when logging out.

## Summary

- Add UserDropdown component with avatar click interaction  
- Implement client-side logout to prevent authentication errors
- Show logout success toast on login page after redirect
- Clean and intuitive user experience

## Implementation Details

1. **UserDropdown Component**: Created a new dropdown component that appears when clicking the user avatar
2. **Client-side Logout**: Implemented logout using Supabase client to avoid server-side authentication errors during re-renders
3. **Toast Notifications**: 
   - Shows "Logging out..." toast during logout process
   - Displays "Logged out successfully" toast on login page after redirect
   - Uses URL parameters to pass logout status to login page

## Test Plan

- [x] Click on user avatar in the app bar
- [x] Verify dropdown menu appears with logout option
- [x] Click logout button
- [x] Verify "Logging out..." toast appears
- [x] Verify redirect to login page
- [x] Verify "Logged out successfully" toast appears on login page
- [x] Verify URL is cleaned up after toast display

🤖 Generated with [Claude Code](https://claude.ai/code)