### PR TITLE
✨ Add PostgreSQL enum deparser support with CREATE TYPE AS ENUM

### DIFF
--- a/frontend/packages/schema/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/utils.ts
@@ -1,4 +1,10 @@
-import type { Column, Constraint, Index, Table } from '../../schema/index.js'
+import type {
+  Column,
+  Constraint,
+  Enum,
+  Index,
+  Table,
+} from '../../schema/index.js'
 
 /**
  * Generate column definition as DDL string
@@ -390,4 +396,23 @@ export function generateDropCheckConstraintStatement(
   return `ALTER TABLE ${escapeIdentifier(
     tableName,
   )} DROP CONSTRAINT IF EXISTS ${escapeIdentifier(constraintName)};`
+}
+
+/**
+ * Generate CREATE TYPE AS ENUM statement for an enum
+ */
+export function generateCreateEnumStatement(enumObj: Enum): string {
+  const enumName = escapeIdentifier(enumObj.name)
+  const enumValues = enumObj.values
+    .map((value) => `'${escapeString(value)}'`)
+    .join(', ')
+
+  let ddl = `CREATE TYPE ${enumName} AS ENUM (${enumValues});`
+
+  // Add enum comment if exists
+  if (enumObj.comment) {
+    ddl += `\n\nCOMMENT ON TYPE ${enumName} IS '${escapeString(enumObj.comment)}';`
+  }
+
+  return ddl
 }

--- a/frontend/packages/schema/src/schema/factories.ts
+++ b/frontend/packages/schema/src/schema/factories.ts
@@ -1,6 +1,8 @@
 import type {
   CheckConstraint,
   Column,
+  Enum,
+  Enums,
   ForeignKeyConstraint,
   Index,
   PrimaryKeyConstraint,
@@ -83,6 +85,13 @@ export const aCheckConstraint = (
   ...override,
 })
 
+export const anEnum = (override?: Partial<Enum>): Enum => ({
+  name: 'status',
+  values: ['active', 'inactive'],
+  comment: null,
+  ...override,
+})
+
 const tables = (override?: Tables): Tables => {
   return (
     override ?? {
@@ -91,7 +100,11 @@ const tables = (override?: Tables): Tables => {
   )
 }
 
+const enums = (override?: Enums): Enums => {
+  return override ?? {}
+}
+
 export const aSchema = (override?: Partial<Schema>): Schema => ({
   tables: tables(override?.tables),
-  enums: override?.enums ?? {},
+  enums: enums(override?.enums),
 })

--- a/frontend/packages/schema/src/schema/index.ts
+++ b/frontend/packages/schema/src/schema/index.ts
@@ -2,6 +2,7 @@ export {
   aCheckConstraint,
   aColumn,
   aForeignKeyConstraint,
+  anEnum,
   anIndex,
   aPrimaryKeyConstraint,
   aSchema,


### PR DESCRIPTION
## Issue

- ref : https://github.com/route06/liam-internal/issues/5244

TODO
- Add enumSchema to schema.ts ✅
    - https://github.com/liam-hq/liam/pull/2930
- Support PostgreSQL enum definitions ✅
    - https://github.com/liam-hq/liam/pull/2937
- 🔄 Currently working on: Make postgresqlSchemaDeparser handle enum support
    - We are currently here 👈
- Include enums in schemaDesignTool.ts

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

  Adds PostgreSQL enum deparser support for generating CREATE TYPE AS ENUM statements from schema definitions.

## Testing

I have confirmed that test passes.
frontend/packages/schema/src/deparser/postgresql/schemaDeparser.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating PostgreSQL enum type creation statements in schema exports.
  * Enum types are now created before tables when generating SQL DDL.

* **Bug Fixes**
  * Ensured proper handling and escaping of enum values, including single-value enums and those with quotes.

* **Tests**
  * Introduced comprehensive tests for enum type generation, including comments, multiple enums, and reference order.

* **Chores**
  * Added factory helpers for creating enum objects in tests and exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->