### PR TITLE
💄 ui(toast): update Toast style, be singleton and appearing from the bottom

### DIFF
--- a/.changeset/busy-worms-double.md
+++ b/.changeset/busy-worms-double.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+💄 update Toast style, be singleton and appearing from the bottom

--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -26,7 +26,6 @@
     "clsx": "2.1.1",
     "destyle.css": "4.0.1",
     "lucide-react": "0.511.0",
-    "nanoid": "5.1.5",
     "neverthrow": "8.2.0",
     "react": "19.1.0",
     "react-resizable-panels": "3.0.3",

--- a/frontend/packages/ui/src/components/Toast/Toast.module.css
+++ b/frontend/packages/ui/src/components/Toast/Toast.module.css
@@ -44,7 +44,7 @@
 
 @keyframes slideIn {
   from {
-    transform: translateX(100%);
+    transform: translateY(100%);
   }
 
   to {

--- a/frontend/packages/ui/src/components/Toast/Toast.tsx
+++ b/frontend/packages/ui/src/components/Toast/Toast.tsx
@@ -2,7 +2,6 @@
 
 import * as RadixToast from '@radix-ui/react-toast'
 import clsx from 'clsx'
-import { nanoid } from 'nanoid'
 import {
   createContext,
   type FC,
@@ -11,7 +10,7 @@ import {
   useState,
 } from 'react'
 import styles from './Toast.module.css'
-import type { ToastFn, ToastId, ToastItem, ToastOptions } from './types'
+import type { ToastFn, ToastItem, ToastOptions } from './types'
 
 type Props = ToastOptions & {
   isOpen: boolean
@@ -50,33 +49,20 @@ export const Toast: FC<Props> = ({
 export const ToastContext = createContext<ToastFn>(() => '')
 
 export const ToastProvider = ({ children }: PropsWithChildren) => {
-  const [toastItems, setToastItems] = useState<ToastItem[]>([])
-  const handleOpenChange = useCallback((id: ToastId) => {
-    return () => {
-      setToastItems((prev) =>
-        prev.map((item) =>
-          item.id === id ? { ...item, isOpen: !item.isOpen } : item,
-        ),
-      )
-    }
+  const [toastItem, setToastItem] = useState<ToastItem | null>(null)
+  const closeToastItem = useCallback(() => {
+    setToastItem((prev) => (prev === null ? null : { ...prev, isOpen: false }))
   }, [])
-  const toast = useCallback((options: ToastOptions): ToastId => {
-    const id = nanoid()
-    setToastItems((prev) => [...prev, { ...options, id, isOpen: true }])
-    return id
+  const createToastItem = useCallback((options: ToastOptions) => {
+    closeToastItem()
+    window.setTimeout(() => setToastItem({ ...options, isOpen: true }), 100)
   }, [])
 
   return (
     <RadixToast.Provider>
-      <ToastContext.Provider value={toast}>
+      <ToastContext.Provider value={createToastItem}>
         {children}
-        {toastItems.map((value) => (
-          <Toast
-            key={value.id}
-            {...value}
-            onOpenChange={handleOpenChange(value.id)}
-          />
-        ))}
+        {toastItem && <Toast {...toastItem} onOpenChange={closeToastItem} />}
         <RadixToast.Viewport className={styles.viewport} />
       </ToastContext.Provider>
     </RadixToast.Provider>

--- a/frontend/packages/ui/src/components/Toast/types.ts
+++ b/frontend/packages/ui/src/components/Toast/types.ts
@@ -1,5 +1,3 @@
-export type ToastId = string
-
 type ToastStatus = 'success' | 'error' | 'warning' | 'info'
 
 export type ToastOptions = {
@@ -8,6 +6,6 @@ export type ToastOptions = {
   status: ToastStatus
 }
 
-export type ToastItem = ToastOptions & { id: ToastId; isOpen: boolean }
+export type ToastItem = ToastOptions & { isOpen: boolean }
 
-export type ToastFn = (options: ToastOptions) => ToastId
+export type ToastFn = (options: ToastOptions) => void

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,9 +1028,6 @@ importers:
       lucide-react:
         specifier: 0.511.0
         version: 0.511.0(react@19.1.0)
-      nanoid:
-        specifier: 5.1.5
-        version: 5.1.5
       neverthrow:
         specifier: 8.2.0
         version: 8.2.0
@@ -19599,7 +19596,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.11.0)
+      retry-axios: 2.6.0(axios@1.11.0(debug@4.4.1))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -22354,7 +22351,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.11.0):
+  retry-axios@2.6.0(axios@1.11.0(debug@4.4.1)):
     dependencies:
       axios: 1.11.0(debug@4.4.1)
 


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This PR updates Toast style to be a singleton and appearing from the bottom than from the right.

**before**

https://github.com/user-attachments/assets/c607d802-d108-4a96-87b6-c7e3fe193879

**after**

https://github.com/user-attachments/assets/1b02481c-5780-465a-b99b-ae4a735bed00




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Toast notification to display as a singleton, ensuring only one toast appears at a time.
  * Toast notifications now slide in from the bottom of the screen for improved visibility.

* **Style**
  * Refined the Toast animation for a smoother vertical slide-in effect.

* **Chores**
  * Removed an unused dependency from the UI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->