### PR TITLE
Add allowed_bots configuration to Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -52,6 +52,7 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 60
+          allowed_bots: "liam-claude-code-action-bot[bot]"
           additional_permissions: |
             actions: read
           custom_instructions: |


### PR DESCRIPTION
## Issue

- ref: https://github.com/route06/liam-internal/issues/4987

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

With version 0.0.55, Claude Code Action now supports an allowed_bots input to explicitly authorize trusted bots, such as dependabot, renovate, or github-actions, to trigger Claude.

- https://github.com/anthropics/claude-code-action/releases/tag/v0.0.55
- https://github.com/anthropics/claude-code-action/pull/117

Claude Code Action is now able to respond to requests from bots.

Usage Examples
```
# Allow specific trusted bots (recommended)
- uses: anthropics/claude-code-action@main
  with:
    allowed_bots: "dependabot,renovate"

# Allow all bots (use with caution in trusted environments)
- uses: anthropics/claude-code-action@main
  with:
    allowed_bots: "*"

# No bots allowed (default, most secure)
- uses: anthropics/claude-code-action@main
  # No allowed_bots parameter needed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation workflow to explicitly allow approved bot accounts to run code actions, improving reliability and control of automated PR creation and maintenance.
  * Enhances CI governance without altering application behavior.
  * No user-facing changes; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->