### PR TITLE
🐛 Fix path module error in session creation

### DIFF
--- a/frontend/apps/app/features/sessions/components/shared/services/sessionCreationHelpers.ts
+++ b/frontend/apps/app/features/sessions/components/shared/services/sessionCreationHelpers.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import path from 'node:path'
 import { createSupabaseRepositories } from '@liam-hq/agent'
 import type { SupabaseClientType } from '@liam-hq/db'
 import type { Schema } from '@liam-hq/schema'
@@ -129,7 +128,7 @@ export const parseSchemaContent = async (
   format: SchemaFormat,
 ): Promise<Schema | CreateSessionState> => {
   try {
-    setPrismWasmUrl(path.resolve(process.cwd(), 'prism.wasm'))
+    setPrismWasmUrl(`${process.cwd()}/prism.wasm`)
     const { value: parsedSchema, errors } = await parse(content, format)
 
     if (errors && errors.length > 0) {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/5345

## Why is this change needed?

After PR #2941 migrated from trigger.dev to Vercel Functions, the session creation process started failing with `{"error":"The \"path\" argument must be of type string or an instance of Buffer or URL. ..."}` errors. This was caused by the Node.js `path` module being used in edge runtime environment where it's not available.

The fix removes the dependency on Node.js `path.resolve()` and replaces it with a simple string template literal to maintain compatibility with Vercel Functions edge runtime.