### PR TITLE
🐛 Fix autoprefixer warning in GlobalNav CSS

### DIFF
--- a/frontend/apps/app/components/CommonLayout/GlobalNav/GlobalNav.module.css
+++ b/frontend/apps/app/components/CommonLayout/GlobalNav/GlobalNav.module.css
@@ -32,7 +32,7 @@
 .logoSection {
   display: flex;
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
   gap: var(--spacing-1);
   padding: var(--spacing-1half, 0.375rem) var(--spacing-2, 0.5rem);
 }


### PR DESCRIPTION
## Issue

- resolve: Autoprefixer warning about 'start' value having mixed browser support
   - https://github.com/route06/liam-internal/issues/5348

warning:

```
(35:3) autoprefixer: start value has mixed support, consider using flex-start instead

Import trace for requested module:
./components/CommonLayout/GlobalNav/GlobalNav.module.css
./components/CommonLayout/GlobalNav/GlobalNav.tsx
./components/CommonLayout/GlobalNav/index.ts
./components/CommonLayout/CommonLayout.tsx
./components/CommonLayout/index.ts
./app/(app)/app/design_sessions/layout.tsx
```

## Why is this change needed?

The autoprefixer was throwing warnings about using `justify-content: start` because it has mixed browser support. Changed to `flex-start` for better cross-browser compatibility.

##  tested

server log does not include the warning now.

<img width="672" height="705" alt="スクリーンショット 2025-08-13 9 47 26" src="https://github.com/user-attachments/assets/7e9f3853-ffde-49a4-ac60-e9a25cbf6e96" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logo area alignment in the global navigation bar to reliably align content to the left, improving layout consistency across browsers and screen sizes. Users should see more predictable spacing and positioning of logo and adjacent items in the header, reducing occasional misalignment or jitter that could occur in certain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->