### PR TITLE
 🔧 Fix PGlite webpack compatibility with serverExternalPackages

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -30,6 +30,7 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  serverExternalPackages: ['@electric-sql/pglite'],
   webpack: (config) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (Array.isArray(config.externals)) {


### PR DESCRIPTION


## Issue

- resolve: https://github.com/route06/liam-internal/issues/5345
- follow-up: https://github.com/liam-hq/liam/pull/2970

## Why is this change needed?

Fix PGlite webpack compatibility issue by adding serverExternalPackages configuration to exclude @electric-sql/pglite from webpack bundling. This resolves createRequire errors that were preventing real PostgreSQL execution in Next.js server environment, allowing design sessions to use actual SQL validation instead of mock responses.

## tested

- https://liam-app-git-fix-5345-error-4-liambx.vercel.app/app/design_sessions/5d3f09bb-5709-4f46-9d40-790096993f92?deepModeling=false
- 
<img width="1310" height="691" alt="スクリーンショット 2025-08-13 9 40 37" src="https://github.com/user-attachments/assets/529eb526-8be0-4a11-b480-61ed93209e32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of server-side queries by always executing against the real database engine and eliminating placeholder results.
  * Enhanced error handling to surface clearer, more accurate errors during query initialization and execution.

* **Chores**
  * Updated server configuration to treat the database engine package as external, reducing server bundle complexity and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->