### PR TITLE
feat: Setup PGlite WASM files for design sessions

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -99,6 +99,7 @@ const nextConfig: NextConfig = {
   },
   outputFileTracingIncludes: {
     '/erd/p/\\[\\.\\.\\.slug\\]': ['./prism.wasm'],
+    '/app/design_sessions/new': ['./pglite.wasm', './pglite.data'],
   },
   env: {
     NEXT_PUBLIC_GIT_HASH: gitCommitHash,

--- a/frontend/apps/app/package.json
+++ b/frontend/apps/app/package.json
@@ -75,7 +75,7 @@
     "lint:biome": "biome check .",
     "lint:eslint": "eslint .",
     "lint:tsc": "tsc --noEmit",
-    "postinstall": "cp ../../packages/schema/node_modules/@ruby/prism/src/prism.wasm prism.wasm",
+    "postinstall": "cp ../../packages/schema/node_modules/@ruby/prism/src/prism.wasm prism.wasm && cp node_modules/@electric-sql/pglite/dist/pglite.wasm pglite.wasm && cp node_modules/@electric-sql/pglite/dist/pglite.data pglite.data",
     "start": "next start",
     "test": "vitest --watch=false",
     "test:vitest": "pnpm vitest"


### PR DESCRIPTION
## Issue

- resolve: (If applicable, add issue number here)

## Why is this change needed?

Setup PGlite WASM files for the design sessions feature at `/app/design_sessions/new` route.

## Summary

- Added postinstall script to copy PGlite WASM and data files to the app directory
- Configured Next.js `outputFileTracingIncludes` to include PGlite files for the design sessions route
- Followed the same pattern as the existing `prism.wasm` setup

## Test plan

- [ ] Run `pnpm install` in `frontend/apps/app` to verify PGlite files are copied
- [ ] Verify `pglite.wasm` and `pglite.data` files exist in the app directory
- [ ] Build the app and verify the files are included in the output for `/app/design_sessions/new`

🤖 Generated with [Claude Code](https://claude.ai/code)