### PR TITLE
fix: correct BYTEA column handling for Supabase REST API double encoding

### DIFF
--- a/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.test.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.test.ts
@@ -136,16 +136,32 @@ describe('SupabaseCheckpointSaver', () => {
         updated_at: '2025-01-06T10:00:00.000Z',
       }
 
+      // Simulate Supabase returning hex format for BYTEA columns
+      const messageBlobData = JSON.stringify(
+        checkpoint.channel_values?.['messages'],
+      )
+      const stateBlobData = JSON.stringify(checkpoint.channel_values?.['state'])
+
+      // Simulate Supabase's double encoding: JSON -> Base64 -> Hex
+      const messageBase64 = Buffer.from(messageBlobData).toString('base64')
+      const stateBase64 = Buffer.from(stateBlobData).toString('base64')
+
       const blobsData = [
         {
           channel: 'messages',
           type: 'json',
-          blob: btoa(JSON.stringify(checkpoint.channel_values?.['messages'])),
+          // Convert to hex format like Supabase does (Base64 string -> Hex)
+          blob: `\\x${Array.from(Buffer.from(messageBase64))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('')}`,
         },
         {
           channel: 'state',
           type: 'json',
-          blob: btoa(JSON.stringify(checkpoint.channel_values?.['state'])),
+          // Convert to hex format like Supabase does (Base64 string -> Hex)
+          blob: `\\x${Array.from(Buffer.from(stateBase64))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('')}`,
         },
       ]
 

--- a/frontend/internal-packages/agent/src/checkpoint/byteaUtils.test.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/byteaUtils.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  base64ToUint8Array,
+  byteaToUint8Array,
+  hexToUint8Array,
+  uint8ArrayToBase64,
+  uint8ArrayToString,
+} from './byteaUtils'
+
+describe('byteaUtils', () => {
+  describe('uint8ArrayToBase64', () => {
+    it('should convert Uint8Array to base64 string', () => {
+      const input = new Uint8Array([72, 101, 108, 108, 111]) // "Hello"
+      const result = uint8ArrayToBase64(input)
+      expect(result).toBe('SGVsbG8=') // Base64 for "Hello"
+    })
+
+    it('should handle empty Uint8Array', () => {
+      const input = new Uint8Array([])
+      const result = uint8ArrayToBase64(input)
+      expect(result).toBe('')
+    })
+
+    it('should handle large binary data', () => {
+      const input = new Uint8Array(1000).fill(255)
+      const result = uint8ArrayToBase64(input)
+      expect(result).toBeTruthy()
+      // Verify it can be decoded back
+      const decoded = base64ToUint8Array(result)
+      expect(decoded).toEqual(input)
+    })
+  })
+
+  describe('hexToUint8Array', () => {
+    it('should convert hex string with \\x prefix to Uint8Array', () => {
+      const input = '\\x48656c6c6f' // "Hello" in hex
+      const result = hexToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+
+    it('should convert hex string without \\x prefix to Uint8Array', () => {
+      const input = '48656c6c6f' // "Hello" in hex without prefix
+      const result = hexToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+
+    it('should handle empty hex string', () => {
+      const input = '\\x'
+      const result = hexToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([]))
+    })
+
+    it('should handle hex with mixed case', () => {
+      const input = '\\x48656C6C6F' // Mixed case hex
+      const result = hexToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+  })
+
+  describe('base64ToUint8Array', () => {
+    it('should convert base64 string to Uint8Array', () => {
+      const input = 'SGVsbG8=' // Base64 for "Hello"
+      const result = base64ToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+
+    it('should handle empty base64 string', () => {
+      const input = ''
+      const result = base64ToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([]))
+    })
+
+    it('should handle base64 with padding', () => {
+      const input = 'SGVsbG8h' // Base64 for "Hello!"
+      const result = base64ToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111, 33]))
+    })
+  })
+
+  describe('byteaToUint8Array', () => {
+    it('should convert hex format from Supabase', () => {
+      const input = '\\x48656c6c6f' // Hex format from Supabase
+      const result = byteaToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+
+    it('should handle hex format with complex binary data', () => {
+      // Binary data including null bytes and special characters
+      const input = '\\x0001ff7f80'
+      const result = byteaToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([0, 1, 255, 127, 128]))
+    })
+
+    it('should handle hex format without prefix', () => {
+      // Some edge cases might not have the \x prefix
+      const input = '48656c6c6f'
+      const result = byteaToUint8Array(input)
+      expect(result).toEqual(new Uint8Array([72, 101, 108, 108, 111]))
+    })
+  })
+
+  describe('uint8ArrayToString', () => {
+    it('should convert Uint8Array to UTF-8 string', () => {
+      const input = new Uint8Array([72, 101, 108, 108, 111]) // "Hello"
+      const result = uint8ArrayToString(input)
+      expect(result).toBe('Hello')
+    })
+
+    it('should handle UTF-8 multi-byte characters', () => {
+      // "Hello World" with emoji in UTF-8
+      const input = new Uint8Array([
+        72,
+        101,
+        108,
+        108,
+        111,
+        32, // "Hello "
+        240,
+        159,
+        140,
+        141, // emoji bytes
+      ])
+      const result = uint8ArrayToString(input)
+      expect(result).toBe('Hello 🌍')
+    })
+
+    it('should handle empty Uint8Array', () => {
+      const input = new Uint8Array([])
+      const result = uint8ArrayToString(input)
+      expect(result).toBe('')
+    })
+  })
+
+  describe('round-trip conversions', () => {
+    it('should preserve data through base64 round-trip', () => {
+      const original = new Uint8Array([0, 1, 2, 127, 128, 255])
+      const base64 = uint8ArrayToBase64(original)
+      const restored = base64ToUint8Array(base64)
+      expect(restored).toEqual(original)
+    })
+
+    it('should preserve data through hex round-trip', () => {
+      const original = new Uint8Array([0, 1, 2, 127, 128, 255])
+      // Simulate what Supabase returns
+      const hex = `\\x${Array.from(original)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')}`
+      const restored = hexToUint8Array(hex)
+      expect(restored).toEqual(original)
+    })
+
+    it('should handle byteaToUint8Array with hex format correctly', () => {
+      const original = new Uint8Array([72, 101, 108, 108, 111])
+
+      // Test with hex format (Supabase returns this)
+      const hex = '\\x48656c6c6f'
+      const fromHex = byteaToUint8Array(hex)
+      expect(fromHex).toEqual(original)
+    })
+  })
+})

--- a/frontend/internal-packages/agent/src/checkpoint/byteaUtils.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/byteaUtils.ts
@@ -1,0 +1,74 @@
+/**
+ * Utility functions for BYTEA column handling in Supabase
+ *
+ * Supabase REST API requires Base64 encoding for BYTEA columns when writing,
+ * but always returns them as PostgreSQL hex format (e.g., '\x6465...').
+ */
+
+/**
+ * Convert Uint8Array to Base64 string for Supabase BYTEA columns
+ * Uses efficient methods based on environment (Node.js vs Browser)
+ */
+export const uint8ArrayToBase64 = (uint8Array: Uint8Array): string => {
+  // For Node.js environments - more efficient for large data
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(uint8Array).toString('base64')
+  }
+
+  // For browser environments - more efficient than the old method
+  const binaryString = Array.from(uint8Array)
+    .map((byte) => String.fromCharCode(byte))
+    .join('')
+  return btoa(binaryString)
+}
+
+/**
+ * Convert hex string from PostgreSQL BYTEA to Uint8Array
+ * Handles format: '\x48656c6c6f' -> [72, 101, 108, 108, 111]
+ */
+export const hexToUint8Array = (hex: string): Uint8Array => {
+  // Remove the '\x' prefix if present
+  const cleanHex = hex.startsWith('\\x') ? hex.slice(2) : hex
+
+  // Convert hex string to Uint8Array
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(cleanHex.substring(i, i + 2), 16)
+  }
+  return bytes
+}
+
+/**
+ * Convert Base64 string to Uint8Array
+ * Uses efficient methods based on environment
+ */
+export const base64ToUint8Array = (base64: string): Uint8Array => {
+  // For Node.js environments - more efficient
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(base64, 'base64'))
+  }
+
+  // For browser environments
+  const binaryString = atob(base64)
+  const bytes = new Uint8Array(binaryString.length)
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i)
+  }
+  return bytes
+}
+
+/**
+ * Convert hex string from Supabase BYTEA to Uint8Array
+ * Supabase always returns BYTEA columns in hex format (\x...)
+ */
+export const byteaToUint8Array = (data: string): Uint8Array => {
+  // Supabase BYTEA is always in hex format
+  return hexToUint8Array(data)
+}
+
+/**
+ * Convert Uint8Array to string
+ */
+export const uint8ArrayToString = (uint8Array: Uint8Array): string => {
+  return new TextDecoder().decode(uint8Array)
+}


### PR DESCRIPTION
## Issue

- resolve: N/A (bug fix)

## Why is this change needed?

The BYTEA column handling in SupabaseCheckpointSaver had a critical bug where data couldn't be correctly decoded from Supabase REST API responses.

**Root cause:**
- Supabase REST API returns BYTEA columns in PostgreSQL hex format (`\x...`)
- However, the data itself is base64-encoded when stored (double encoding)
- The original implementation tried to decode hex strings directly as base64, causing decoding failures

**Solution:**
- Added proper hex-to-Uint8Array conversion
- Implemented correct decoding flow: hex → base64 string → actual binary data
- Extracted utilities into a separate module for better maintainability

## Testing

- I have implemented the session resume feature at https://github.com/liam-hq/liam/pull/2982 and have confirmed that it is working fine.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed data encoding/decoding to ensure checkpoints, messages, and state are read/written reliably with Supabase.
  - Improved compatibility with hex-encoded binary fields from the Supabase REST API, preventing corrupted or missing data.

- Tests
  - Added comprehensive coverage for binary conversions (hex, base64, UTF‑8) to validate cross‑environment behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->