### PR TITLE
feat(agent): implement LangGraph checkpointer to replace manual history conversion

### DIFF
--- a/frontend/apps/app/app/api/chat/route.ts
+++ b/frontend/apps/app/app/api/chat/route.ts
@@ -112,31 +112,12 @@ export async function POST(request: Request) {
   // If no version exists yet (initial state), use 0 as the version number
   const latestVersionNumber = latestVersion?.number ?? 0
 
-  const { data: timelineItems, error: timelineItemsError } = await supabase
-    .from('timeline_items')
-    .select('type, content')
-    .eq('design_session_id', designSessionId)
-    .order('created_at', { ascending: true })
-
-  if (timelineItemsError) {
-    return NextResponse.json(
-      { error: 'Failed to fetch timeline items' },
-      { status: 500 },
-    )
-  }
-
-  const history: [string, string][] = timelineItems.map((item) => [
-    item.type === 'user' ? 'Human' : 'AI',
-    item.content,
-  ])
-
   const result = await repositories.schema
     .getSchema(designSessionId)
     .andThen((data) => {
       const params: AgentWorkflowParams = {
         userInput: validationResult.output.userInput,
         schemaData: data.schema,
-        history,
         organizationId,
         buildingSchemaId: buildingSchema.id,
         latestVersionNumber: latestVersionNumber,

--- a/frontend/internal-packages/agent/scripts/shared/scriptUtils.ts
+++ b/frontend/internal-packages/agent/scripts/shared/scriptUtils.ts
@@ -427,7 +427,6 @@ export const createWorkflowState = (
   const workflowParams: AgentWorkflowParams = {
     userInput,
     schemaData: sampleSchema,
-    history: [] satisfies [string, string][], // Empty history for initial run
     organizationId: organization.id,
     buildingSchemaId: buildingSchema.id,
     latestVersionNumber: buildingSchema.latest_version_number,

--- a/frontend/internal-packages/agent/src/chat/workflow/README.md
+++ b/frontend/internal-packages/agent/src/chat/workflow/README.md
@@ -187,7 +187,6 @@ const result = await deepModeling(
   {
     userInput:
       "Create a schema for a fitness tracking app with users, workout plans, exercise logs, and progress charts.",
-    history: [],
     schemaData: mySchemaData,
     organizationId: "my-organization-id",
     buildingSchemaId: "my-building-schema-id",

--- a/frontend/internal-packages/agent/src/db-agent/invokeDbAgent.ts
+++ b/frontend/internal-packages/agent/src/db-agent/invokeDbAgent.ts
@@ -19,7 +19,10 @@ export const invokeDbAgent = (
   },
 ): AgentWorkflowResult => {
   const { recursionLimit = DEFAULT_RECURSION_LIMIT } = params
-  const compiled = createDbAgentGraph()
+  // Pass checkpointer from repositories to enable state persistence
+  const compiled = createDbAgentGraph(
+    config.configurable.repositories.schema.checkpointer,
+  )
 
   // Setup workflow state with message conversion and timeline sync
   return setupWorkflowState(params, config).andThen((setup) =>

--- a/frontend/internal-packages/agent/src/deepModeling.ts
+++ b/frontend/internal-packages/agent/src/deepModeling.ts
@@ -17,7 +17,10 @@ export const deepModeling = (
   },
 ): AgentWorkflowResult => {
   const { recursionLimit = DEFAULT_RECURSION_LIMIT } = params
-  const compiled = createGraph()
+  // Pass checkpointer from repositories to enable state persistence
+  const compiled = createGraph(
+    config.configurable.repositories.schema.checkpointer,
+  )
 
   // Setup workflow state with message conversion and timeline sync
   return setupWorkflowState(params, config).andThen((setupResult) => {

--- a/frontend/internal-packages/agent/src/shared/workflowSetup.ts
+++ b/frontend/internal-packages/agent/src/shared/workflowSetup.ts
@@ -1,4 +1,4 @@
-import { AIMessage, HumanMessage } from '@langchain/core/messages'
+import { HumanMessage } from '@langchain/core/messages'
 import { RunCollectorCallbackHandler } from '@langchain/core/tracers/run_collector'
 import type { CompiledStateGraph } from '@langchain/langgraph'
 import { err, errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
@@ -47,7 +47,6 @@ export const setupWorkflowState = (
   const {
     userInput,
     schemaData,
-    history,
     organizationId,
     buildingSchemaId,
     latestVersionNumber = 0,
@@ -57,20 +56,10 @@ export const setupWorkflowState = (
 
   const { repositories, thread_id } = config.configurable
 
-  // TODO(MH4GF): Remove this history-to-messages conversion once checkpointer is implemented
-  // When thread_id checkpoint functionality is working, message history will be
-  // automatically restored from the checkpoint storage, making this manual conversion unnecessary
-  // Convert history to BaseMessage objects (synchronous)
-  const messages = history.map(([role, content]) => {
-    return role === 'assistant'
-      ? new AIMessage(content)
-      : new HumanMessage(content)
-  })
-
   const workflowRunId = uuidv4()
 
   const userMessage = new HumanMessage(userInput)
-  const allMessages = [...messages, userMessage]
+  const allMessages = [userMessage]
 
   const createWorkflowRun = ResultAsync.fromPromise(
     repositories.schema.createWorkflowRun({

--- a/frontend/internal-packages/agent/src/types.ts
+++ b/frontend/internal-packages/agent/src/types.ts
@@ -8,7 +8,6 @@ import type { WorkflowState } from './chat/workflow/types'
 export type AgentWorkflowParams = {
   userInput: string
   schemaData: Schema
-  history: [string, string][]
   organizationId: string
   buildingSchemaId: string
   latestVersionNumber: number


### PR DESCRIPTION
## Issue

- ref: https://github.com/route06/liam-internal/issues/5135

## Why is this change needed?

This change removes the manual history-to-messages conversion in favor of LangGraph's built-in checkpointer functionality, which automatically restores message history based on thread_id. This aligns with LangGraph's standard patterns and simplifies the codebase.

## Summary

- ✅ Pass checkpointer from repositories to `createGraph()` and `createDbAgentGraph()`
- ✅ Remove `history` parameter from `AgentWorkflowParams` type 
- ✅ Remove manual conversion logic in `setupWorkflowState`
- ✅ Update all call sites to remove history parameter
- ✅ Remove unnecessary timeline items query from chat route

## Implementation Details

The checkpointer is now passed to the graph creation functions, enabling automatic state persistence and restoration. With thread_id properly configured, LangGraph handles message history internally through its checkpoint system.

### Key Changes:
1. `deepModeling.ts` and `invokeDbAgent.ts` now pass the checkpointer to graph creation
2. `workflowSetup.ts` no longer performs manual history-to-messages conversion
3. `AgentWorkflowParams` type simplified by removing the history field
4. Chat route cleaned up to remove unused timeline items query

## Test plan

- [x] TypeScript compilation passes
- [x] All linting rules pass
- [x] Existing tests continue to pass
- [ ] Manual testing: Verify conversation history is maintained across invocations
- [ ] Manual testing: Confirm thread_id correctly maps to design sessions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved stability of agent workflows with persisted state during processing.
- Changes
  - Chat no longer uses prior conversation history; each prompt is processed independently.
- Documentation
  - Updated usage examples to remove the history parameter from chat/agent workflows.
- Refactor
  - Simplified message handling to start from the current user input only, reducing legacy history logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->