### PR TITLE
📝 Add cross-repository reference guidance to create-internal-issue command

### DIFF
--- a/.claude/commands/create-internal-issue.md
+++ b/.claude/commands/create-internal-issue.md
@@ -46,3 +46,4 @@ $ARGUMENTS
   - Impact analysis (risks and benefits)
   - Technical considerations (implementation notes)
 - **Evidence documentation**: Include specific file paths, line numbers, and search results
+- **Cross-repository references**: When referencing PRs or issues from repositories other than route06/liam-internal (e.g., liam-hq/liam), use the full format `repository#number` (e.g., `liam-hq/liam#2991`) instead of just `#number` to ensure proper GitHub linking


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5369

## Why is this change needed?

When creating issues in the `route06/liam-internal` repository using the `/create-internal-issue` command, references to PRs/issues from other repositories (e.g., `liam-hq/liam`) using the `#number` format are incorrectly interpreted as references within the `liam-internal` repository.

This change adds a best practice to the command documentation to ensure proper cross-repository references using the full `repository#number` format (e.g., `liam-hq/liam#2991`), which creates correct GitHub links.