### PR TITLE
fix: force PMAnalysisAgent to use tools

### DIFF
--- a/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
+++ b/frontend/internal-packages/agent/src/langchain/agents/pmAnalysisAgent/agent.ts
@@ -41,6 +41,7 @@ export class PMAnalysisAgent {
       [{ type: 'web_search_preview' }, saveRequirementsToArtifactTool],
       {
         parallel_tool_calls: false,
+        tool_choice: 'required',
       },
     )
 


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

The PMAnalysisAgent should always use one of its configured tools (web_search_preview or saveRequirementsToArtifact) rather than responding directly. This change adds the `tool_choice: 'required'` parameter to enforce tool usage, ensuring the agent follows the intended workflow.

## Summary
- Added `tool_choice: 'required'` parameter to the PMAnalysisAgent's bindTools configuration
- This ensures the agent always selects and uses one of the provided tools instead of generating direct responses

## Test plan
- [ ] Verify PMAnalysisAgent always uses tools when invoked
- [ ] Confirm no direct text responses are generated by the agent
- [ ] Test that both web_search_preview and saveRequirementsToArtifact tools can still be properly selected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of PM Analysis by ensuring required tools are invoked when generating results, reducing skipped tool usage and incomplete responses.
  * Delivers more consistent, accurate outputs with fewer edge-case failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->