### PR TITLE
Fix PostgreSQL CHECK constraint parsing and deparsing issues

### DIFF
--- a/frontend/packages/schema/src/parser/sql/postgresql/converter.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/converter.ts
@@ -169,27 +169,43 @@ const constraintToCheckConstraint = (
     return err(new UnexpectedTokenWarningError('Invalid check constraint'))
   }
 
-  let openParenthesesCount = 0
-  const startLocation = rawSql.indexOf('(', constraint.location)
-  let endLocation: number | undefined = undefined
-  for (let i = startLocation; i < rawSql.length; i++) {
-    if (rawSql[i] === '(') {
-      openParenthesesCount++
-    } else if (rawSql[i] === ')') {
-      openParenthesesCount--
-      if (openParenthesesCount === 0) {
-        endLocation = i
-        break
+  // Find balanced parentheses for the CHECK constraint condition
+  const findBalancedParentheses = (
+    sql: string,
+    startIndex: number,
+  ): { start: number; end: number } | null => {
+    let openParenIndex = -1
+    let depth = 0
+
+    // Find the first opening parenthesis
+    for (let i = startIndex; i < sql.length; i++) {
+      if (sql[i] === '(') {
+        if (openParenIndex === -1) {
+          openParenIndex = i
+        }
+        depth++
+      } else if (sql[i] === ')') {
+        depth--
+        if (depth === 0 && openParenIndex !== -1) {
+          return { start: openParenIndex, end: i }
+        }
       }
     }
+    return null
   }
 
-  if (startLocation === undefined || endLocation === undefined) {
-    return err(new UnexpectedTokenWarningError('Invalid check constraint'))
+  const parentheses = findBalancedParentheses(rawSql, constraint.location)
+
+  if (!parentheses) {
+    return err(
+      new UnexpectedTokenWarningError(
+        'Invalid check constraint: no balanced parentheses found',
+      ),
+    )
   }
 
   // Extract the condition inside the parentheses (without the CHECK prefix)
-  const condition = rawSql.slice(startLocation + 1, endLocation)
+  const condition = rawSql.slice(parentheses.start + 1, parentheses.end)
 
   // Generate a better name for anonymous constraints
   let constraintName = constraint.conname
@@ -198,11 +214,15 @@ const constraintToCheckConstraint = (
       constraintName = `${columnName}_check`
     } else {
       // For table-level constraints, try to extract a meaningful name from the condition
+      // Handle case where condition might be empty or invalid
       const simplifiedCondition = condition
+        .trim()
         .replace(/\s+/g, '_')
         .replace(/[^a-zA-Z0-9_]/g, '')
         .substring(0, 20)
-      constraintName = `check_${simplifiedCondition}`
+      constraintName = simplifiedCondition
+        ? `check_${simplifiedCondition}`
+        : 'check_constraint'
     }
   }
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5376
- ref: https://github.com/route06/liam-internal/issues/5312

## Why is this change needed?

This PR addresses two critical issues with PostgreSQL CHECK constraint handling in the schema parser and deparser:

### Issue 1: Anonymous CHECK constraints not properly parsed
- Currently, anonymous CHECK constraints like `age INT CHECK (age >= 0)` receive generic names like `CHECK_age`
- This makes constraint management and schema understanding more difficult

### Issue 2: CHECK constraints double-wrapped in deparser output
- The parser was storing `CHECK (condition)` in the `detail` field
- The deparser was then wrapping it again: `CHECK (CHECK (condition))`
- This resulted in invalid SQL syntax: `ALTER TABLE ... ADD CONSTRAINT ... CHECK (CHECK (age >= 0))`

## Examples

### Before (Invalid SQL)
```sql
-- Anonymous constraint got generic name
ALTER TABLE products ADD CONSTRAINT CHECK_price CHECK (CHECK (price > 0));
-- Invalid SQL: double CHECK wrapping ❌
```

### After (Valid SQL)
```sql
-- Anonymous constraint gets meaningful name
ALTER TABLE products ADD CONSTRAINT price_check CHECK (price > 0);
-- Valid SQL: proper CHECK syntax ✅

-- Table-level constraints work correctly
ALTER TABLE design_sessions ADD CONSTRAINT design_sessions_project_or_org_check 
CHECK ((("project_id" IS NOT NULL) OR ("organization_id" IS NOT NULL)));
```

## Testing

```
-- Create new schema
CREATE SCHEMA IF NOT EXISTS sample_checks;

-- Table 1: With inline unnamed CHECK constraint on column definition
CREATE TABLE IF NOT EXISTS sample_checks.persons (
    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
    name TEXT NOT NULL,
    age INT CHECK (age >= 0),  -- Unnamed CHECK constraint directly on column
    email TEXT UNIQUE,
    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
);

-- Table 2: With named CHECK constraint defined separately in CREATE TABLE
CREATE TABLE IF NOT EXISTS sample_checks.design_sessions (
    id UUID DEFAULT gen_random_uuid() NOT NULL,
    project_id UUID,
    organization_id UUID NOT NULL,
    created_by_user_id UUID NOT NULL,
    parent_design_session_id UUID,
    name TEXT NOT NULL,
    created_at TIMESTAMP(3) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
    CONSTRAINT design_sessions_project_or_org_check CHECK ((project_id IS NOT NULL) OR (organization_id IS NOT NULL))
);
```
### Before

SQL(Check section) | after parse | after deparse
-- | -- | --
age INT CHECK (age >= 0) | "constraints": {        "CHECK_age": {          "name": "CHECK_age",          "type": "CHECK",          "detail": "age >= 0"        }, | ❌Error<br><br>"error":"Parse error: syntax error at or near "CHECK""<br><br>ALTER TABLE "persons" ADD CONSTRAINT "CHECK_age" CHECK (CHECK (age >= 0));
CONSTRAINT design_sessions_project_or_org_check CHECK ((project_id IS NOT NULL) OR (organization_id IS NOT NULL)) | "constraints": {        "design_sessions_project_or_org_check": {          "name": "design_sessions_project_or_org_check",          "type": "CHECK",          "detail": "(project_id IS NOT NULL) OR (organization_id IS NOT NULL)"        }      } | ❌Error<br><br>"error":"Parse error: syntax error at or near "CHECK""<br><br>ALTER TABLE "design_sessions" ADD CONSTRAINT "design_sessions_project_or_org_check" CHECK (CHECK ((project_id IS NOT NULL) OR (organization_id IS NOT NULL)));

### After
SQL(Check section) | after parse | after deparse
-- | -- | --
age INT CHECK (age >= 0) | "constraints": {        "age_check": {          "name": "age_check",          "type": "CHECK",          "detail": "age >= 0"        }, | ✅<br><br>ALTER TABLE "persons" ADD CONSTRAINT "age_check" CHECK (age >= 0);
CONSTRAINT design_sessions_project_or_org_check CHECK ((project_id IS NOT NULL) OR (organization_id IS NOT NULL)) | "constraints": {        "design_sessions_project_or_org_check": {          "name": "design_sessions_project_or_org_check",          "type": "CHECK",          "detail": "(project_id IS NOT NULL) OR (organization_id IS NOT NULL)"        }      } | ✅<br><br>ALTER TABLE "design_sessions" ADD CONSTRAINT "design_sessions_project_or_org_check" CHECK ((project_id IS NOT NULL) OR (organization_id IS NOT NULL));





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved PostgreSQL CHECK constraint parsing: deterministic, descriptive constraint names and cleaner predicate-only details; clearer error message when a constraint is malformed.

* **Tests**
  * Added comprehensive tests covering anonymous, column-level, table-level, and multi-condition CHECK constraints, including parseability and exact SQL snapshot assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->