### PR TITLE
🐛 Fix duplicate React key error in artifact tab

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
@@ -43,10 +43,14 @@ function formatDmlOperation(operation: DmlOperation): string {
   return sections.join('\n')
 }
 
-function formatUseCase(useCase: UseCase, index: number): string {
+function formatUseCase(
+  useCase: UseCase,
+  index: number,
+  reqIndex: number,
+): string {
   const sections: string[] = []
 
-  sections.push(`#### ${index + 1}. ${useCase.title}`)
+  sections.push(`#### ${reqIndex + 1}.${index + 1}. ${useCase.title}`)
   sections.push('')
   sections.push(useCase.description)
 
@@ -112,7 +116,7 @@ export function formatArtifactToMarkdown(artifact: Artifact): string {
         sections.push('')
 
         req.use_cases.forEach((useCase, ucIndex) => {
-          sections.push(formatUseCase(useCase, ucIndex))
+          sections.push(formatUseCase(useCase, ucIndex, reqIndex))
           sections.push('')
         })
       }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5391

## Why is this change needed?

Fixed an issue in the Artifacts tab where React’s duplicate key warning occurred. When use cases with the same number existed under different functional requirements, ReactMarkdown would generate identical keys, resulting in console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated use case headers in artifact output to use hierarchical numbering (e.g., “2.3 Title”), reflecting the parent functional requirement and its child use case.
  - Improves readability and scanning of artifacts with multiple requirements and use cases.
  - Applies to the Session Detail page’s Output > Artifact rendering.
  - No changes to content or structure—only header formatting is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## screenshots

for example, `1. ...` -> `7.1 ....` . 

This change wasn’t required to fix the error, but I applied it anyway.

| before | after |
|--------|--------|
| <img width="1057" height="750" alt="スクリーンショット 2025-08-15 14 43 21" src="https://github.com/user-attachments/assets/f3788d7f-eb05-4e9f-a9a4-b2a23e27fb4c" /> | <img width="1069" height="761" alt="スクリーンショット 2025-08-15 14 42 53" src="https://github.com/user-attachments/assets/d480668b-c66f-41e9-9e44-a1da01e70daf" /> | 




