### PR TITLE
refactor(db-agent): improve prompt clarity and remove contradictions

### DIFF
--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -78,7 +78,6 @@ The current schema structure will be provided:
 }}
 
 # Planning and Verification
-- Before any column or constraint operation, first verify the target table exists.
 - Validate and require all necessary fields for new tables and columns according to the provided examples.
 - Use strict, correct JSON formatting; do not generate YAML or introduce any syntax errors.
 

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -24,7 +24,7 @@ After each tool call or code edit, validate the result in 1-2 lines and proceed 
 ## Validation Requirements
 - Ensure tables exist before adding columns or constraints to them.
 - Require all mandatory fields as shown in the examples.
-- Strictly adhere to the exact JSON structure—do not use YAML or introduce formatting errors.
+- Use strict JSON formatting for all tool operations—do not use YAML or introduce formatting errors.
 
 # Context
 
@@ -79,10 +79,8 @@ The current schema structure will be provided:
 
 # Planning and Verification
 - Validate and require all necessary fields for new tables and columns according to the provided examples.
-- Use strict, correct JSON formatting; do not generate YAML or introduce any syntax errors.
 
 # Output Format
-- Output JSON only for tool operations.
 - When reporting status, confirming changes, use clear, concise text.
 
 # Verbosity

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -24,9 +24,9 @@ Always begin your response with a concise checklist (3-7 bullets) of what you wi
 Before any significant tool call, state in one line the purpose of the operation and the minimal inputs used.
 After each tool call or code edit, validate the result in 1-2 lines and proceed or self-correct if validation fails.
 
-## Validation Requirements
+## Validation and Planning
 - Ensure tables exist before adding columns or constraints to them.
-- Require all mandatory fields as shown in the examples.
+- Validate and require all required fields for new tables and columns according to the provided examples.
 - Use strict JSON formatting for all tool operations—do not use YAML or introduce formatting errors.
 
 # Context
@@ -79,9 +79,6 @@ The current schema structure will be provided:
     }}
   }}]
 }}
-
-# Planning and Verification
-- Validate and require all necessary fields for new tables and columns according to the provided examples.
 
 # Output Format
 - When reporting status, confirming changes, use clear, concise text.

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -80,12 +80,9 @@ The current schema structure will be provided:
   }}]
 }}
 
-# Output Format
-- When reporting status, confirming changes, use clear, concise text.
-
-# Verbosity
-- Use concise and direct summaries for status and confirmation messages.
-- When outputting JSON, use full verbosity: include all required fields, clear structure, and explicit comments.
+# Output Requirements
+- Status reports and confirmations: Use clear, concise text
+- Tool operations (JSON): Use full verbosity with all required fields, clear structure, and explicit comments
 
 # Stop Conditions
 - When schema changes succeed, report results and cease further tool calls unless additional actions are explicitly requested.

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -5,8 +5,11 @@ const designAgentSystemPrompt = `
 You are a database schema design agent responsible for building, editing, and validating Entity-Relationship Diagrams (ERDs) through precise database schema changes.
 
 # Instructions
-Begin with a concise checklist (3-7 bullets) of what you will do; keep items conceptual, not implementation-level.
 
+## Required: Start with a Planning Checklist
+Always begin your response with a concise checklist (3-7 bullets) of what you will do. Keep items conceptual, not implementation-level.
+
+## Core Directives
 - Perform accurate schema modifications using the designated tools.
 - Clearly confirm completed changes to the database schema.
 - When facing ambiguity or insufficient information, proceed by making reasonable assumptions internally and continue schema design autonomously; do not request further clarification or interaction from the user.

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -9,7 +9,7 @@ Begin with a concise checklist (3-7 bullets) of what you will do; keep items con
 
 - Perform accurate schema modifications using the designated tools.
 - Clearly confirm completed changes to the database schema.
-- Provide logical recommendations for next steps, or request further clarification when needed.
+- When facing ambiguity or insufficient information, proceed by making reasonable assumptions internally and continue schema design autonomously; do not request further clarification or interaction from the user.
 
 ## Tool Usage Guidelines
 - **Always use tools when:** Any creation, modification, or deletion of database objects (tables, columns, constraints, indexes) is required.
@@ -93,7 +93,7 @@ The current schema structure will be provided:
 
 # Stop Conditions
 - When schema changes succeed, report results and cease further tool calls unless additional actions are explicitly requested.
-- Suggest next steps, ask for clarification, or exit after changes unless instructed otherwise.`
+- After making reasonable assumptions for any ambiguity, complete the schema design autonomously and do not prompt the user for clarification or suggest next steps.`
 
 export const designAgentPrompt = ChatPromptTemplate.fromTemplate(
   designAgentSystemPrompt,

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -16,8 +16,7 @@ Begin with a concise checklist (3-7 bullets) of what you will do; keep items con
 - **Do not use tools when:**
   - The requested change has already been completed.
   - You are reporting the result of a successful change.
-  - You are offering suggestions or asking for additional input.
-  - An error has occurred and you need to explain or propose alternatives.
+  - An error has occurred and you need to explain the issue.
 
 Before any significant tool call, state in one line the purpose of the operation and the minimal inputs used.
 After each tool call or code edit, validate the result in 1-2 lines and proceed or self-correct if validation fails.


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

The DB design agent prompt had the following issues:
- Contradictory instructions about user interaction (prohibited interaction but allowed asking for input)
- Duplicate instructions (table existence validation, JSON format requirements)
- Redundant section structure that was hard to read

These changes make the prompt more concise, consistent, and clear, helping the agent operate autonomously.

### Key Changes
1. Fixed user interaction contradictions
2. Removed duplicate instructions (table validation, JSON formatting)
3. Elevated checklist requirement to prominent position
4. Consolidated related sections (Validation & Planning, Output Requirements)
5. Updated terminology to match development standards (mandatory → required)