### PR TITLE
✨(agent): Enhance tool call logging to show complete arguments in INFO mode

### DIFF
--- a/frontend/internal-packages/agent/scripts/shared/streamingUtils.ts
+++ b/frontend/internal-packages/agent/scripts/shared/streamingUtils.ts
@@ -64,7 +64,22 @@ const getMessageContent = (lastMessage: unknown): string | undefined => {
       ? lastMessage['kwargs']['content']
       : undefined)
 
-  return typeof content === 'string' ? content : undefined
+  // Handle both string and array formats
+  if (typeof content === 'string') {
+    return content
+  }
+
+  // Handle array format (e.g., [{ type: 'text', text: '...', annotations: [] }])
+  if (Array.isArray(content) && content.length > 0) {
+    const firstItem = content[0]
+    if (isObject(firstItem) && hasProperty(firstItem, 'text')) {
+      return typeof firstItem['text'] === 'string'
+        ? firstItem['text']
+        : undefined
+    }
+  }
+
+  return undefined
 }
 
 // Helper function to extract tool calls from AI message


### PR DESCRIPTION
## Issue

- resolve: #enhance-agent-logging

## Why is this change needed?

Previously, INFO level logs only showed tool names without their arguments, making it difficult to understand what the AI agent was actually doing. This was particularly problematic for tools like `saveRequirementsToArtifactTool` where the arguments contain important business logic details.

Additionally, AI responses that came in array format (from LangChain) were not being displayed in INFO mode, causing important information to be lost.

### Changes made:
1. **Enhanced tool call logging**: Modified `processToolCalls` to return both tool names and arguments, displaying complete tool arguments as formatted JSON
2. **Fixed array-format content handling**: Updated `getMessageContent` to handle both string and array formats for AI messages, ensuring all AI responses are logged correctly

### Benefits:
- Improved observability without requiring DEBUG mode
- Complete visibility into AI agent's decision-making process
- Easier debugging and monitoring of the Deep Modeling workflow
- All tool arguments and AI responses now visible in INFO level logs