### PR TITLE
**hidden release** ✨ feat(command palette): support input mode "Command" 

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -5,7 +5,6 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
 import { useSchemaOrThrow } from '@/stores'
 import { TableNode } from '../../../ERDContent/components'
-import { CommandPaletteCommandOptions } from '../CommandPaletteOptions'
 import { CommandPaletteSearchInput } from '../CommandPaletteSearchInput'
 import type { CommandPaletteInputMode } from '../types'
 import styles from './CommandPaletteContent.module.css'
@@ -101,9 +100,12 @@ export const CommandPaletteContent: FC<Props> = ({ closeDialog }) => {
               ))}
             </Command.Group>
           )}
-          {(inputMode.type === 'default' || inputMode.type === 'command') && (
-            <CommandPaletteCommandOptions />
-          )}
+          {
+            (inputMode.type === 'default' || inputMode.type === 'command') &&
+              null
+            // TODO(command options): uncomment the following line to release command options
+            // <CommandPaletteCommandOptions />
+          }
         </Command.List>
         <div
           className={styles.previewContainer}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -5,6 +5,7 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
 import { useSchemaOrThrow } from '@/stores'
 import { TableNode } from '../../../ERDContent/components'
+import { CommandPaletteCommandOptions } from '../CommandPaletteOptions'
 import { CommandPaletteSearchInput } from '../CommandPaletteSearchInput'
 import type { CommandPaletteInputMode } from '../types'
 import styles from './CommandPaletteContent.module.css'
@@ -99,6 +100,9 @@ export const CommandPaletteContent: FC<Props> = ({ closeDialog }) => {
                 </Command.Item>
               ))}
             </Command.Group>
+          )}
+          {(inputMode.type === 'default' || inputMode.type === 'command') && (
+            <CommandPaletteCommandOptions />
           )}
         </Command.List>
         <div

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.module.css
@@ -1,12 +1,16 @@
 .container {
   display: flex;
   flex-grow: 1;
-  position: relative;
   align-items: center;
 }
 
+.inputContainer {
+  display: flex;
+  margin-left: var(--spacing-2);
+}
+
 .input {
-  padding: var(--spacing-2) 0 var(--spacing-2) var(--spacing-6);
+  padding: var(--spacing-2) 0;
   width: 100%;
   border-radius: var(--border-radius-smbase);
 }
@@ -15,8 +19,13 @@
   outline: none;
 }
 
+.modePrefix {
+  flex-shrink: 0;
+  margin-right: var(--spacing-1);
+  padding: var(--spacing-2) 0;
+}
+
 .searchIcon {
-  position: absolute;
   width: 16px;
   height: 16px;
   color: var(--overlay-60);

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Command } from 'cmdk'
+import type { PropsWithChildren } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CommandPaletteSearchInput } from './CommandPaletteSearchInput'
+
+const mockSetMode = vi.fn()
+
+const wrapper = (props: PropsWithChildren) => (
+  <Command>{props.children}</Command>
+)
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('in case input mode is "default"', () => {
+  describe('when the user pressed > key', () => {
+    it('should switch to "command" mode when value is empty', async () => {
+      const user = userEvent.setup()
+      render(
+        <CommandPaletteSearchInput
+          mode={{ type: 'default' }}
+          setMode={mockSetMode}
+        />,
+        { wrapper },
+      )
+      screen.getByRole('combobox').focus()
+
+      await user.keyboard('>')
+
+      expect(mockSetMode).toHaveBeenCalledWith({ type: 'command' })
+    })
+  })
+
+  it('should not switch input mode when value is not empty', async () => {
+    const user = userEvent.setup()
+    render(
+      <CommandPaletteSearchInput
+        mode={{ type: 'default' }}
+        setMode={mockSetMode}
+      />,
+      { wrapper },
+    )
+    screen.getByRole('combobox').focus()
+
+    // make the input not empty
+    await user.keyboard('hello')
+
+    await user.keyboard('>')
+
+    expect(mockSetMode).not.toHaveBeenCalled()
+  })
+})
+
+describe('in case input mode is "command"', () => {
+  describe('when the user pressed Backspace key', () => {
+    it('should switch to "default" mode when value is empty', async () => {
+      const user = userEvent.setup()
+      render(
+        <CommandPaletteSearchInput
+          mode={{ type: 'command' }}
+          setMode={mockSetMode}
+        />,
+        { wrapper },
+      )
+      screen.getByRole('combobox').focus()
+
+      await user.keyboard('{backspace}')
+
+      expect(mockSetMode).toHaveBeenCalledWith({ type: 'default' })
+    })
+  })
+
+  it('should not switch input mode when value is not empty', async () => {
+    const user = userEvent.setup()
+    render(
+      <CommandPaletteSearchInput
+        mode={{ type: 'command' }}
+        setMode={mockSetMode}
+      />,
+      { wrapper },
+    )
+    screen.getByRole('combobox').focus()
+
+    // make the input not empty
+    await user.keyboard('hello')
+
+    await user.keyboard('{backspace}')
+
+    expect(mockSetMode).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -15,7 +15,8 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-describe('in case input mode is "default"', () => {
+// TODO(command options): remove .skip to release command options
+describe.skip('in case input mode is "default"', () => {
   describe('when the user pressed > key', () => {
     it('should switch to "command" mode when value is empty', async () => {
       const user = userEvent.setup()
@@ -54,7 +55,8 @@ describe('in case input mode is "default"', () => {
   })
 })
 
-describe('in case input mode is "command"', () => {
+// TODO(command options): remove .skip to release command options
+describe.skip('in case input mode is "command"', () => {
   describe('when the user pressed Backspace key', () => {
     it('should switch to "default" mode when value is empty', async () => {
       const user = userEvent.setup()

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -26,11 +26,14 @@ export const CommandPaletteSearchInput: FC<Props> = ({
   return (
     <div className={styles.container}>
       <Search className={styles.searchIcon} />
-      <Command.Input
-        {...inputProps}
-        className={styles.input}
-        placeholder="Search"
-      />
+      <div className={styles.inputContainer}>
+        {modePrefix && <span className={styles.modePrefix}>{modePrefix}</span>}
+        <Command.Input
+          {...inputProps}
+          className={styles.input}
+          placeholder="Search"
+        />
+      </div>
     </div>
   )
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -35,11 +35,12 @@ export const CommandPaletteSearchInput: FC<Props> = ({
     const down = (event: KeyboardEvent) => {
       if (mode.type === 'default') {
         // switch to "command" mode if value is empty and `>` is pressed
-        if (event.key === '>' && value === '') {
-          event.preventDefault()
-          setMode({ type: 'command' })
-          return
-        }
+        // TODO(command options): uncomment the following lines to release command options
+        // if (event.key === '>' && value === '') {
+        //   event.preventDefault()
+        //   setMode({ type: 'command' })
+        //   return
+        // }
 
         return
       }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -1,6 +1,6 @@
 import { Search } from '@liam-hq/ui'
 import { Command } from 'cmdk'
-import type { ComponentProps, FC } from 'react'
+import { type ComponentProps, type FC, useMemo } from 'react'
 import type { CommandPaletteInputMode } from '../types'
 import styles from './CommandPaletteSearchInput.module.css'
 
@@ -14,6 +14,15 @@ export const CommandPaletteSearchInput: FC<Props> = ({
   setMode,
   ...inputProps
 }) => {
+  const modePrefix = useMemo(() => {
+    switch (mode.type) {
+      case 'default':
+        return null
+      case 'command':
+        return '>'
+    }
+  }, [mode])
+
   return (
     <div className={styles.container}>
       <Search className={styles.searchIcon} />

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -1,6 +1,12 @@
 import { Search } from '@liam-hq/ui'
 import { Command } from 'cmdk'
-import { type ComponentProps, type FC, useMemo } from 'react'
+import {
+  type ComponentProps,
+  type FC,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import type { CommandPaletteInputMode } from '../types'
 import styles from './CommandPaletteSearchInput.module.css'
 
@@ -14,6 +20,8 @@ export const CommandPaletteSearchInput: FC<Props> = ({
   setMode,
   ...inputProps
 }) => {
+  const [value, setValue] = useState('')
+
   const modePrefix = useMemo(() => {
     switch (mode.type) {
       case 'default':
@@ -23,6 +31,35 @@ export const CommandPaletteSearchInput: FC<Props> = ({
     }
   }, [mode])
 
+  useEffect(() => {
+    const down = (event: KeyboardEvent) => {
+      if (mode.type === 'default') {
+        // switch to "command" mode if value is empty and `>` is pressed
+        if (event.key === '>' && value === '') {
+          event.preventDefault()
+          setMode({ type: 'command' })
+          return
+        }
+
+        return
+      }
+
+      if (mode.type === 'command') {
+        // switch to "default" mode if value is empty and delete key is pressed
+        if (event.key === 'Backspace' && value === '') {
+          event.preventDefault()
+          setMode({ type: 'default' })
+          return
+        }
+
+        return
+      }
+    }
+
+    document.addEventListener('keydown', down)
+    return () => document.removeEventListener('keydown', down)
+  }, [value, mode])
+
   return (
     <div className={styles.container}>
       <Search className={styles.searchIcon} />
@@ -30,6 +67,8 @@ export const CommandPaletteSearchInput: FC<Props> = ({
         {modePrefix && <span className={styles.modePrefix}>{modePrefix}</span>}
         <Command.Input
           {...inputProps}
+          value={value}
+          onValueChange={setValue}
           className={styles.input}
           placeholder="Search"
         />

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
@@ -1,4 +1,3 @@
-export type CommandPaletteInputMode = { type: 'default' }
+export type CommandPaletteInputMode = { type: 'default' } | { type: 'command' }
 // upcoming input mode
-// | { type: 'command' }
 // | { type: 'column'; tableName: string }


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I introduce "command" input mode.
- type `>` to switch "default" to "command"
- type Backspace to switch "command" to "default"

preview https://liam-ol53xvjxl-liambx.vercel.app

You can see only command options with typing ">" key

https://github.com/user-attachments/assets/70803453-dcc9-48b3-9975-54cc58e44e4c

I eventually hide these changes https://github.com/liam-hq/liam/pull/3046/commits/7aaed1ab54423fc755b703da4449fc43bf4806d1.
I'm going to release this in public after some UX updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Command Palette input now shows a “>” indicator in command mode.
  - Pressing Backspace with an empty input exits command mode.
  - Internal hook added for future command options (no user-visible change yet).

- Style
  - Refreshed Command Palette input layout with improved spacing and inline elements for clearer visuals.

- Tests
  - Added tests (currently skipped) covering keyboard-based mode switching in the Command Palette input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->