### PR TITLE
✨(public-share): Add minimal public share backend infrastructure

### DIFF
--- a/frontend/apps/app/features/public-share/actions.ts
+++ b/frontend/apps/app/features/public-share/actions.ts
@@ -1,0 +1,68 @@
+'use server'
+
+import { createClient, createPublicServerClient } from '@/libs/db/server'
+
+export async function checkPublicShareStatus(designSessionId: string) {
+  // Use public client for checking share status (no auth required)
+  const supabase = await createPublicServerClient()
+
+  const { error } = await supabase
+    .from('public_share_settings')
+    .select('design_session_id')
+    .eq('design_session_id', designSessionId)
+    .single()
+
+  return { isPublic: !error }
+}
+
+export async function enablePublicShare(designSessionId: string) {
+  const supabase = await createClient()
+
+  // Get current user
+  const { data: userData, error: authError } = await supabase.auth.getUser()
+  if (authError || !userData?.user) {
+    return { success: false, error: 'Authentication required' }
+  }
+
+  // First check if the user has access to this design session
+  const { data: session } = await supabase
+    .from('design_sessions')
+    .select('id')
+    .eq('id', designSessionId)
+    .single()
+
+  if (!session) {
+    return { success: false, error: 'Session not found' }
+  }
+
+  const { error } = await supabase
+    .from('public_share_settings')
+    .insert({ design_session_id: designSessionId })
+
+  if (error) {
+    return { success: false, error: error.message }
+  }
+
+  return { success: true, isPublic: true }
+}
+
+export async function disablePublicShare(designSessionId: string) {
+  const supabase = await createClient()
+
+  // Get current user
+  const { data: userData, error: authError } = await supabase.auth.getUser()
+  if (authError || !userData?.user) {
+    return { success: false, error: 'Authentication required' }
+  }
+
+  const { error } = await supabase
+    .from('public_share_settings')
+    .delete()
+    .eq('design_session_id', designSessionId)
+
+  if (error) {
+    return { success: false, error: error.message }
+  }
+
+  return { success: true, isPublic: false }
+}

--- a/frontend/apps/app/libs/db/server.ts
+++ b/frontend/apps/app/libs/db/server.ts
@@ -38,11 +38,6 @@ export async function createClient({
   )
 }
 
-/**
- * Create a public Supabase client for anonymous access
- * This is foundation code for Public Share feature Phase 1.1
- * Will be used in future phases for server-side anonymous access to public data
- */
 export async function createPublicServerClient() {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -27,7 +27,9 @@
     "frontend/packages/schema/src/schema/schema.ts",
     "frontend/packages/schema/src/schema/index.ts",
     // - Foundation code for Public Share feature (createPublicServerClient will be used in future phases)
-    "frontend/apps/app/libs/db/server.ts"
+    "frontend/apps/app/libs/db/server.ts",
+    // - Server Actions are not detected by knip due to 'use server' directive
+    "frontend/apps/app/features/public-share/actions.ts"
   ],
 
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5365

## Why is this change needed?
Implements the backend foundation for public share functionality using Server Actions instead of REST APIs. This approach avoids the useEffect anti-pattern and improves performance by fetching initial data during server-side rendering.

The implementation provides:
- Server Actions for checking and toggling public share status
- Initial state fetching in Server Components
- A clean hook interface using useTransition for optimistic updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces public sharing for design sessions, allowing you to enable or disable sharing and check whether a session is publicly accessible.
  - Clear feedback on success or errors (e.g., authentication required or session not found) when managing sharing status.

- Chores
  - Updated internal tooling configuration to better handle server-side actions, preventing false positives in unused code checks.

- Refactor
  - Internal cleanup of unused server utilities with no impact on user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->