### PR TITLE
✨(artifact): Fix formatArtifactToMarkdown output format for DML operations

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
@@ -12,8 +12,9 @@ describe('formatArtifactToMarkdown', () => {
           requirements: [
             {
               name: 'Aircraft Management',
-              description:
+              description: [
                 'The company owns multiple aircraft, each with an aircraft number, model, and seating capacity. The aircraft number must be unique, and seating capacity must be an integer greater than 0.',
+              ],
               type: 'functional',
               use_cases: [
                 {
@@ -86,8 +87,9 @@ ORDER BY f.scheduled_departure;`,
             },
             {
               name: 'Flight Information Management',
-              description:
+              description: [
                 'Flight information includes flight name, departure time, arrival time, origin, destination, aircraft number, captain ID, first officer ID, start time, and end time. Origin and destination cannot be the same, and scheduled times must satisfy departure time < arrival time.',
+              ],
               type: 'functional',
               use_cases: [
                 {
@@ -138,8 +140,9 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
             },
             {
               name: 'Pilot Management',
-              description:
+              description: [
                 'Each flight is operated by a captain and first officer, each with an ID, name, and phone number. Pilot IDs must be unique, and for flights, the captain ID and first officer ID cannot be the same person.',
+              ],
               type: 'functional',
               use_cases: [
                 {
@@ -175,8 +178,9 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
             },
             {
               name: 'Data Integrity and Validation',
-              description:
+              description: [
                 'Enforce referential integrity through foreign keys and implement various business rules through CHECK constraints. Protect related data with ON DELETE RESTRICT during deletions.',
+              ],
               type: 'functional',
               use_cases: [
                 {
@@ -205,14 +209,16 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
             },
             {
               name: 'Performance',
-              description:
+              description: [
                 'The system must be able to search 1000 flight records within 3 seconds and support concurrent access from 50 users.',
+              ],
               type: 'non_functional',
             },
             {
               name: 'Security',
-              description:
+              description: [
                 'Pilot personal information must be encrypted for storage and access logs must be recorded. Database access must be restricted to authenticated users only.',
+              ],
               type: 'non_functional',
             },
           ],
@@ -235,7 +241,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         ### 1. Aircraft Management
 
-        The company owns multiple aircraft, each with an aircraft number, model, and seating capacity. The aircraft number must be unique, and seating capacity must be an integer greater than 0.
+        - The company owns multiple aircraft, each with an aircraft number, model, and seating capacity. The aircraft number must be unique, and seating capacity must be an integer greater than 0.
 
 
         **Use Cases:**
@@ -299,7 +305,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         ### 2. Flight Information Management
 
-        Flight information includes flight name, departure time, arrival time, origin, destination, aircraft number, captain ID, first officer ID, start time, and end time. Origin and destination cannot be the same, and scheduled times must satisfy departure time < arrival time.
+        - Flight information includes flight name, departure time, arrival time, origin, destination, aircraft number, captain ID, first officer ID, start time, and end time. Origin and destination cannot be the same, and scheduled times must satisfy departure time < arrival time.
 
 
         **Use Cases:**
@@ -342,7 +348,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         ### 3. Pilot Management
 
-        Each flight is operated by a captain and first officer, each with an ID, name, and phone number. Pilot IDs must be unique, and for flights, the captain ID and first officer ID cannot be the same person.
+        - Each flight is operated by a captain and first officer, each with an ID, name, and phone number. Pilot IDs must be unique, and for flights, the captain ID and first officer ID cannot be the same person.
 
 
         **Use Cases:**
@@ -372,7 +378,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         ### 4. Data Integrity and Validation
 
-        Enforce referential integrity through foreign keys and implement various business rules through CHECK constraints. Protect related data with ON DELETE RESTRICT during deletions.
+        - Enforce referential integrity through foreign keys and implement various business rules through CHECK constraints. Protect related data with ON DELETE RESTRICT during deletions.
 
 
         **Use Cases:**
@@ -398,14 +404,14 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         ### 1. Performance
 
-        The system must be able to search 1000 flight records within 3 seconds and support concurrent access from 50 users.
+        - The system must be able to search 1000 flight records within 3 seconds and support concurrent access from 50 users.
 
 
         ---
 
         ### 2. Security
 
-        Pilot personal information must be encrypted for storage and access logs must be recorded. Database access must be restricted to authenticated users only.
+        - Pilot personal information must be encrypted for storage and access logs must be recorded. Database access must be restricted to authenticated users only.
         "
       `)
     })
@@ -417,7 +423,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Task CRUD',
-              description: 'Create, read, update, delete tasks',
+              description: ['Create, read, update, delete tasks'],
               type: 'functional',
               use_cases: [],
             },
@@ -438,7 +444,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Security',
-              description: 'All data must be encrypted',
+              description: ['All data must be encrypted'],
               type: 'non_functional',
             },
           ],
@@ -474,24 +480,24 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Feature A',
-              description: 'Description A',
+              description: ['Description A'],
               type: 'functional',
               use_cases: [],
             },
             {
               name: 'Feature B',
-              description: 'Description B',
+              description: ['Description B'],
               type: 'functional',
               use_cases: [],
             },
             {
               name: 'Requirement X',
-              description: 'Description X',
+              description: ['Description X'],
               type: 'non_functional',
             },
             {
               name: 'Requirement Y',
-              description: 'Description Y',
+              description: ['Description Y'],
               type: 'non_functional',
             },
           ],
@@ -513,13 +519,13 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'First',
-              description: 'First desc',
+              description: ['First desc'],
               type: 'functional',
               use_cases: [],
             },
             {
               name: 'Second',
-              description: 'Second desc',
+              description: ['Second desc'],
               type: 'functional',
               use_cases: [],
             },
@@ -550,7 +556,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -585,7 +591,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -619,7 +625,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -660,7 +666,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -700,7 +706,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -747,7 +753,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -780,7 +786,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -816,7 +822,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -852,7 +858,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -895,7 +901,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test description',
+              description: ['Test description'],
               type: 'functional',
               use_cases: [
                 {
@@ -923,7 +929,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'User Management',
-              description: 'User management features',
+              description: ['User management features'],
               type: 'functional',
               use_cases: [
                 {
@@ -961,7 +967,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Feature 1',
-              description: 'First feature',
+              description: ['First feature'],
               type: 'functional',
               use_cases: [
                 {
@@ -978,7 +984,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
             },
             {
               name: 'Feature 2',
-              description: 'Second feature',
+              description: ['Second feature'],
               type: 'functional',
               use_cases: [
                 {
@@ -1037,7 +1043,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Test Feature',
-              description: 'Test all operation types',
+              description: ['Test all operation types'],
               type: 'functional',
               use_cases: [
                 {
@@ -1069,7 +1075,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Long Feature',
-              description: longDescription,
+              description: [longDescription],
               type: 'functional',
               use_cases: [
                 {
@@ -1110,7 +1116,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
           requirements: [
             {
               name: 'Special & Characters',
-              description: 'Description with **bold** and _italic_ text',
+              description: ['Description with **bold** and _italic_ text'],
               type: 'functional',
               use_cases: [
                 {

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
@@ -1,0 +1,829 @@
+import type { Artifact, DmlOperation } from '@liam-hq/artifact'
+import { describe, expect, it } from 'vitest'
+import { formatArtifactToMarkdown } from '../formatArtifactToMarkdown'
+
+describe('formatArtifactToMarkdown', () => {
+  describe('main function', () => {
+    it('should format complete artifact with all sections', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Build an e-commerce platform',
+          requirements: [
+            {
+              name: 'User Management',
+              description: 'Users should be able to register and login',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'User Registration',
+                  description: 'New users can create an account',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'INSERT',
+                      sql: 'INSERT INTO users (email, password) VALUES ($1, $2)',
+                      description: 'Insert new user record',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-01-15T10:30:00Z',
+                          success: true,
+                          result_summary: '1 row inserted',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'Performance',
+              description: 'System should respond within 2 seconds',
+              type: 'non_functional',
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toMatchInlineSnapshot(`
+        "# Requirements Document
+
+        This document outlines system requirements and their associated data manipulation language (DML) operations.
+
+        ---
+
+        ## 📋 Business Requirements
+
+        Build an e-commerce platform
+
+        ## 🔧 Functional Requirements
+
+        ### 1. User Management
+
+        Users should be able to register and login
+
+
+        **Use Cases:**
+
+        #### 1.1. User Registration
+
+        New users can create an account
+
+        **Related DML Operations:**
+
+        **INSERT** - Insert new user record
+
+        \`\`\`sql
+        INSERT INTO users (email, password) VALUES ($1, $2)
+        \`\`\`
+
+        **Execution History:**
+
+        ✅ **01/15/2024, 07:30:00 PM**
+        > 1 row inserted
+
+
+
+        ## 📊 Non-Functional Requirements
+
+        ### 1. Performance
+
+        System should respond within 2 seconds
+        "
+      `)
+    })
+
+    it('should handle artifact with only functional requirements', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Task management system',
+          requirements: [
+            {
+              name: 'Task CRUD',
+              description: 'Create, read, update, delete tasks',
+              type: 'functional',
+              use_cases: [],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('## 🔧 Functional Requirements')
+      expect(result).not.toContain('## 📊 Non-Functional Requirements')
+    })
+
+    it('should handle artifact with only non-functional requirements', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'System optimization',
+          requirements: [
+            {
+              name: 'Security',
+              description: 'All data must be encrypted',
+              type: 'non_functional',
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).not.toContain('## 🔧 Functional Requirements')
+      expect(result).toContain('## 📊 Non-Functional Requirements')
+    })
+
+    it('should handle empty requirements array', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Empty project',
+          requirements: [],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('## 📋 Business Requirements')
+      expect(result).toContain('Empty project')
+      expect(result).not.toContain('## 🔧 Functional Requirements')
+      expect(result).not.toContain('## 📊 Non-Functional Requirements')
+    })
+
+    it('should format multiple requirements with proper numbering', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Multi-requirement system',
+          requirements: [
+            {
+              name: 'Feature A',
+              description: 'Description A',
+              type: 'functional',
+              use_cases: [],
+            },
+            {
+              name: 'Feature B',
+              description: 'Description B',
+              type: 'functional',
+              use_cases: [],
+            },
+            {
+              name: 'Requirement X',
+              description: 'Description X',
+              type: 'non_functional',
+            },
+            {
+              name: 'Requirement Y',
+              description: 'Description Y',
+              type: 'non_functional',
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toMatch(/### 1\. Feature A[\s\S]*### 2\. Feature B/)
+      expect(result).toMatch(
+        /### 1\. Requirement X[\s\S]*### 2\. Requirement Y/,
+      )
+    })
+
+    it('should add separators between functional requirements', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'First',
+              description: 'First desc',
+              type: 'functional',
+              use_cases: [],
+            },
+            {
+              name: 'Second',
+              description: 'Second desc',
+              type: 'functional',
+              use_cases: [],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+      const lines = result.split('\n')
+
+      const firstIndex = lines.findIndex((line) => line === '### 1. First')
+      const secondIndex = lines.findIndex((line) => line === '### 2. Second')
+      const separatorIndex = lines.findIndex(
+        (line, index) =>
+          index > firstIndex && index < secondIndex && line === '---',
+      )
+
+      expect(separatorIndex).toBeGreaterThan(firstIndex)
+      expect(separatorIndex).toBeLessThan(secondIndex)
+    })
+  })
+
+  describe('DML operation formatting', () => {
+    it('should format operation with description', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'UPDATE',
+                      sql: 'UPDATE users SET status = $1',
+                      description: 'Update user status',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('**UPDATE** - Update user status')
+      expect(result).toContain('```sql\nUPDATE users SET status = $1\n```')
+    })
+
+    it('should format operation without description', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'DELETE',
+                      sql: 'DELETE FROM users WHERE id = $1',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('**DELETE**')
+      expect(result).not.toContain('**DELETE** -')
+    })
+
+    it('should format successful execution logs', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'SELECT',
+                      sql: 'SELECT * FROM users',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-03-20T14:45:30Z',
+                          success: true,
+                          result_summary: '25 rows returned',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('**Execution History:**')
+      expect(result).toContain('✅ **03/20/2024, 11:45:30 PM**')
+      expect(result).toContain('> 25 rows returned')
+    })
+
+    it('should format failed execution logs', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'INSERT',
+                      sql: 'INSERT INTO users (email) VALUES ($1)',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-03-20T14:45:30Z',
+                          success: false,
+                          result_summary: 'Unique constraint violation',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('❌ **03/20/2024, 11:45:30 PM**')
+      expect(result).toContain('> Unique constraint violation')
+    })
+
+    it('should format multiple execution logs', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'INSERT',
+                      sql: 'INSERT INTO orders (user_id, total) VALUES ($1, $2)',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-03-20T10:00:00Z',
+                          success: false,
+                          result_summary: 'Connection timeout',
+                        },
+                        {
+                          executed_at: '2024-03-20T10:01:00Z',
+                          success: true,
+                          result_summary: '1 row inserted',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('❌ **03/20/2024, 07:00:00 PM**')
+      expect(result).toContain('> Connection timeout')
+      expect(result).toContain('✅ **03/20/2024, 07:01:00 PM**')
+      expect(result).toContain('> 1 row inserted')
+    })
+
+    it('should not show execution section when no logs exist', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'SELECT',
+                      sql: 'SELECT * FROM products',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).not.toContain('**Execution History:**')
+    })
+
+    it('should trim SQL whitespace', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Test Use Case',
+                  description: 'Use case description',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'SELECT',
+                      sql: '  \n  SELECT * FROM users  \n  ',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('```sql\nSELECT * FROM users\n```')
+      expect(result).not.toContain('  SELECT')
+    })
+  })
+
+  describe('use case formatting', () => {
+    it('should format use case with single DML operation', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Single Operation Use Case',
+                  description: 'This use case has one operation',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'INSERT',
+                      sql: 'INSERT INTO logs (message) VALUES ($1)',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('#### 1.1. Single Operation Use Case')
+      expect(result).toContain('This use case has one operation')
+      expect(result).toContain('**Related DML Operations:**')
+      expect(result).not.toContain('##### Operation 1')
+    })
+
+    it('should format use case with multiple DML operations', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Multi Operation Use Case',
+                  description: 'This use case has multiple operations',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'INSERT',
+                      sql: 'INSERT INTO orders (user_id) VALUES ($1)',
+                      dml_execution_logs: [],
+                    },
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'UPDATE',
+                      sql: 'UPDATE inventory SET quantity = quantity - 1',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('##### Operation 1')
+      expect(result).toContain('##### Operation 2')
+      expect(result).toContain('---')
+      expect(result).toContain('INSERT INTO orders')
+      expect(result).toContain('UPDATE inventory')
+    })
+
+    it('should format use case without DML operations', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test description',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'No Operations Use Case',
+                  description: 'This use case has no operations yet',
+                  dml_operations: [],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('#### 1.1. No Operations Use Case')
+      expect(result).toContain('This use case has no operations yet')
+      expect(result).not.toContain('**Related DML Operations:**')
+    })
+
+    it('should format multiple use cases with proper numbering', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test',
+          requirements: [
+            {
+              name: 'User Management',
+              description: 'User management features',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'User Registration',
+                  description: 'Register new users',
+                  dml_operations: [],
+                },
+                {
+                  title: 'User Login',
+                  description: 'Authenticate users',
+                  dml_operations: [],
+                },
+                {
+                  title: 'Password Reset',
+                  description: 'Reset user password',
+                  dml_operations: [],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('#### 1.1. User Registration')
+      expect(result).toContain('#### 1.2. User Login')
+      expect(result).toContain('#### 1.3. Password Reset')
+    })
+
+    it('should handle complex nested structure', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Complex system',
+          requirements: [
+            {
+              name: 'Feature 1',
+              description: 'First feature',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'UC 1.1',
+                  description: 'First use case',
+                  dml_operations: [],
+                },
+                {
+                  title: 'UC 1.2',
+                  description: 'Second use case',
+                  dml_operations: [],
+                },
+              ],
+            },
+            {
+              name: 'Feature 2',
+              description: 'Second feature',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'UC 2.1',
+                  description: 'Third use case',
+                  dml_operations: [],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('### 1. Feature 1')
+      expect(result).toContain('#### 1.1. UC 1.1')
+      expect(result).toContain('#### 1.2. UC 1.2')
+      expect(result).toContain('### 2. Feature 2')
+      expect(result).toContain('#### 2.1. UC 2.1')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle all operation types', () => {
+      const operations: DmlOperation[] = [
+        {
+          useCaseId: 'uc-1',
+          operation_type: 'INSERT',
+          sql: 'INSERT INTO test',
+          dml_execution_logs: [],
+        },
+        {
+          useCaseId: 'uc-2',
+          operation_type: 'UPDATE',
+          sql: 'UPDATE test',
+          dml_execution_logs: [],
+        },
+        {
+          useCaseId: 'uc-3',
+          operation_type: 'DELETE',
+          sql: 'DELETE FROM test',
+          dml_execution_logs: [],
+        },
+        {
+          useCaseId: 'uc-4',
+          operation_type: 'SELECT',
+          sql: 'SELECT * FROM test',
+          dml_execution_logs: [],
+        },
+      ]
+
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Test all operations',
+          requirements: [
+            {
+              name: 'Test Feature',
+              description: 'Test all operation types',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'All Operations',
+                  description: 'Test all DML operation types',
+                  dml_operations: operations,
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('**INSERT**')
+      expect(result).toContain('**UPDATE**')
+      expect(result).toContain('**DELETE**')
+      expect(result).toContain('**SELECT**')
+    })
+
+    it('should handle very long text content gracefully', () => {
+      const longDescription = 'A'.repeat(500)
+      const longSQL = `SELECT ${'column,'.repeat(50)} FROM table`
+
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: longDescription,
+          requirements: [
+            {
+              name: 'Long Feature',
+              description: longDescription,
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Long Use Case',
+                  description: longDescription,
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'SELECT',
+                      sql: longSQL,
+                      description: longDescription,
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-01-01T00:00:00Z',
+                          success: true,
+                          result_summary: longDescription,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain(longDescription)
+      expect(result).toContain(longSQL)
+    })
+
+    it('should preserve markdown-safe characters in content', () => {
+      const artifact: Artifact = {
+        requirement_analysis: {
+          business_requirement: 'Special chars: * _ ` # [ ] ( ) ! < >',
+          requirements: [
+            {
+              name: 'Special & Characters',
+              description: 'Description with **bold** and _italic_ text',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Use Case [with brackets]',
+                  description: 'Description with `code` and <tags>',
+                  dml_operations: [
+                    {
+                      useCaseId: 'uc-1',
+                      operation_type: 'SELECT',
+                      sql: 'SELECT * FROM users WHERE name = "John\'s"',
+                      description: 'Query with quotes & special chars',
+                      dml_execution_logs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }
+
+      const result = formatArtifactToMarkdown(artifact)
+
+      expect(result).toContain('Special chars: * _ ` # [ ] ( ) ! < >')
+      expect(result).toContain('Special & Characters')
+      expect(result).toContain('**bold** and _italic_')
+      expect(result).toContain('Use Case [with brackets]')
+      expect(result).toContain('`code` and <tags>')
+      expect(result).toContain('"John\'s"')
+    })
+  })
+})

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
@@ -7,27 +7,195 @@ describe('formatArtifactToMarkdown', () => {
     it('should format complete artifact with all sections', () => {
       const artifact: Artifact = {
         requirement_analysis: {
-          business_requirement: 'Build an e-commerce platform',
+          business_requirement:
+            'Define database requirements for consistently managing airline-owned aircraft, operated flights, and pilots (captains and first officers) involved in operations, while maintaining scheduled and actual times for flights. This enables consistent tracking of aircraft used and personnel assigned for each flight.',
           requirements: [
             {
-              name: 'User Management',
-              description: 'Users should be able to register and login',
+              name: 'Aircraft Management',
+              description:
+                'The company owns multiple aircraft, each with an aircraft number, model, and seating capacity. The aircraft number must be unique, and seating capacity must be an integer greater than 0.',
               type: 'functional',
               use_cases: [
                 {
-                  title: 'User Registration',
-                  description: 'New users can create an account',
+                  title: 'Aircraft Registration and Update',
+                  description:
+                    'The operations manager opens the aircraft management screen, selects "New Registration", and enters the aircraft number, model, and seating capacity. Upon clicking the register button, the system verifies required field entry, confirms aircraft number uniqueness, checks that seating capacity is a positive number, then records it in the aircraft registry.',
                   dml_operations: [
                     {
-                      useCaseId: 'uc-1',
+                      useCaseId: 'dbeab333-1119-4392-8f9c-f8f0a21c1dc2',
                       operation_type: 'INSERT',
-                      sql: 'INSERT INTO users (email, password) VALUES ($1, $2)',
-                      description: 'Insert new user record',
+                      sql: `BEGIN;
+INSERT INTO airplanes (airplane_number, model, capacity) VALUES
+  ('JA100A', 'ATR42-600', 48),
+  ('JA200B', 'Bombardier CRJ900', 90),
+  ('JA330C', 'Flying Car Alpha', 5);
+COMMIT;`,
+                      description:
+                        'New aircraft registration test including normal cases and edge cases (capacity 1/0, model names with special characters and non-ASCII).',
                       dml_execution_logs: [
                         {
-                          executed_at: '2024-01-15T10:30:00Z',
+                          executed_at: '2024-06-01T08:00:00Z',
+                          success: true,
+                          result_summary: '3 rows inserted',
+                        },
+                      ],
+                    },
+                    {
+                      useCaseId: 'dbeab333-1119-4392-8f9c-f8f0a21c1dc2',
+                      operation_type: 'UPDATE',
+                      sql: `UPDATE airplanes SET model = 'ATR42-700', capacity = 50 WHERE airplane_number = 'JA100A';`,
+                      description:
+                        'Aircraft model name and seat count update (normal update scenario for existing data).',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-06-01T08:05:00Z',
+                          success: true,
+                          result_summary: '1 row updated',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  title: 'View Flights by Aircraft',
+                  description:
+                    'The operations manager specifies an aircraft number on the search screen and searches with period and route conditions. The system extracts flights associated with the specified aircraft within the period and displays a list of flight names, departure times, arrival times, segments, assigned captain and first officer.',
+                  dml_operations: [
+                    {
+                      useCaseId: 'd698dd19-82ea-48a7-bafe-b84ed1b3743d',
+                      operation_type: 'SELECT',
+                      sql: `SELECT f.flight_name, f.scheduled_departure, f.scheduled_arrival, f.origin, f.destination
+FROM flights f
+WHERE f.airplane_number = 'JA100A'
+  AND f.scheduled_departure >= '2024-06-01 00:00:00+09'
+  AND f.scheduled_arrival <= '2024-06-02 23:59:59+09'
+ORDER BY f.scheduled_departure;`,
+                      description:
+                        'Retrieve flight list within period for specified aircraft (JA100A). Verify date boundaries and flight names.',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-06-02T10:00:00Z',
+                          success: true,
+                          result_summary: '2 rows returned',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'Flight Information Management',
+              description:
+                'Flight information includes flight name, departure time, arrival time, origin, destination, aircraft number, captain ID, first officer ID, start time, and end time. Origin and destination cannot be the same, and scheduled times must satisfy departure time < arrival time.',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Flight Schedule Creation',
+                  description:
+                    'The schedule coordinator enters flight name, departure time, arrival time, origin, and destination on the flight creation screen, then selects aircraft number and pilot IDs. The system validates the input values before saving.',
+                  dml_operations: [
+                    {
+                      useCaseId: 'ca0dd9b5-f923-4f08-afb8-c441ad57fd0a',
+                      operation_type: 'INSERT',
+                      sql: `INSERT INTO flights (id, flight_name, origin, destination, scheduled_departure, scheduled_arrival, airplane_number, captain_id, first_officer_id)
+VALUES ('fc70279f-04d3-41ea-97e9-3a1bb7ee358f', 'JAL101', 'Tokyo', 'Osaka', '2024-06-01 08:00:00+09', '2024-06-01 09:10:00+09', 'JA100A', 'P0001', 'P0002');`,
+                      description:
+                        'Representative flight creation (Tokyo to Osaka route)',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-05-30T14:00:00Z',
                           success: true,
                           result_summary: '1 row inserted',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  title: 'Recording Actual Flight Times',
+                  description:
+                    'After operation, the operations coordinator opens the target flight details screen and enters the start time (actual departure) and end time (actual arrival) then saves.',
+                  dml_operations: [
+                    {
+                      useCaseId: '469fe899-d91e-4a2e-8ad4-756d5192185f',
+                      operation_type: 'UPDATE',
+                      sql: `UPDATE flights SET actual_start = '2024-06-01 08:05:00+09', actual_end = '2024-06-01 09:12:00+09'
+WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
+                      description:
+                        'Record actual departure and arrival times simultaneously (normal case including delays).',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-06-01T09:15:00Z',
+                          success: true,
+                          result_summary: '1 row updated',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'Pilot Management',
+              description:
+                'Each flight is operated by a captain and first officer, each with an ID, name, and phone number. Pilot IDs must be unique, and for flights, the captain ID and first officer ID cannot be the same person.',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Pilot (Captain/First Officer) Registration',
+                  description:
+                    'HR or operations manager selects "New Registration" from the pilot roster screen and enters pilot ID, name, and phone number then saves.',
+                  dml_operations: [
+                    {
+                      useCaseId: 'aad974e0-de84-4e49-b1c3-998a3d7a9905',
+                      operation_type: 'INSERT',
+                      sql: `INSERT INTO pilots (pilot_id, name, phone) VALUES
+  ('P0001', 'Taro Sato', '+81-90-1234-5678'),
+  ('P0002', 'Hanako Yamada', '+81-90-2345-6789');`,
+                      description:
+                        'Multiple pilot registration (diverse name and phone number formats)',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-05-25T10:00:00Z',
+                          success: false,
+                          result_summary:
+                            'ERROR: duplicate key value violates unique constraint "pk_pilots"',
+                        },
+                        {
+                          executed_at: '2024-05-25T10:05:00Z',
+                          success: true,
+                          result_summary: '2 rows inserted',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'Data Integrity and Validation',
+              description:
+                'Enforce referential integrity through foreign keys and implement various business rules through CHECK constraints. Protect related data with ON DELETE RESTRICT during deletions.',
+              type: 'functional',
+              use_cases: [
+                {
+                  title: 'Referential Integrity Verification',
+                  description:
+                    'Verify that the system properly returns errors when attempting to delete aircraft with existing flights or pilots assigned to flights.',
+                  dml_operations: [
+                    {
+                      useCaseId: 'dbeab333-1119-4392-8f9c-f8f0a21c1dc2',
+                      operation_type: 'DELETE',
+                      sql: `DELETE FROM airplanes WHERE airplane_number = 'JA330C';`,
+                      description:
+                        'Delete aircraft with remaining flights (expecting referential integrity error: ON DELETE RESTRICT).',
+                      dml_execution_logs: [
+                        {
+                          executed_at: '2024-06-03T11:00:00Z',
+                          success: false,
+                          result_summary:
+                            'ERROR: update or delete on table "airplanes" violates foreign key constraint "fk_flights_airplane"',
                         },
                       ],
                     },
@@ -37,7 +205,14 @@ describe('formatArtifactToMarkdown', () => {
             },
             {
               name: 'Performance',
-              description: 'System should respond within 2 seconds',
+              description:
+                'The system must be able to search 1000 flight records within 3 seconds and support concurrent access from 50 users.',
+              type: 'non_functional',
+            },
+            {
+              name: 'Security',
+              description:
+                'Pilot personal information must be encrypted for storage and access logs must be recorded. Database access must be restricted to authenticated users only.',
               type: 'non_functional',
             },
           ],
@@ -45,7 +220,6 @@ describe('formatArtifactToMarkdown', () => {
       }
 
       const result = formatArtifactToMarkdown(artifact)
-
       expect(result).toMatchInlineSnapshot(`
         "# Requirements Document
 
@@ -55,33 +229,184 @@ describe('formatArtifactToMarkdown', () => {
 
         ## 📋 Business Requirements
 
-        Build an e-commerce platform
+        Define database requirements for consistently managing airline-owned aircraft, operated flights, and pilots (captains and first officers) involved in operations, while maintaining scheduled and actual times for flights. This enables consistent tracking of aircraft used and personnel assigned for each flight.
 
         ## 🔧 Functional Requirements
 
-        ### 1. User Management
+        ### 1. Aircraft Management
 
-        Users should be able to register and login
+        The company owns multiple aircraft, each with an aircraft number, model, and seating capacity. The aircraft number must be unique, and seating capacity must be an integer greater than 0.
 
 
         **Use Cases:**
 
-        #### 1.1. User Registration
+        #### 1.1. Aircraft Registration and Update
 
-        New users can create an account
+        The operations manager opens the aircraft management screen, selects "New Registration", and enters the aircraft number, model, and seating capacity. Upon clicking the register button, the system verifies required field entry, confirms aircraft number uniqueness, checks that seating capacity is a positive number, then records it in the aircraft registry.
 
         **Related DML Operations:**
 
-        **INSERT** - Insert new user record
+        ##### Operation 1
+
+        **INSERT** - New aircraft registration test including normal cases and edge cases (capacity 1/0, model names with special characters and non-ASCII).
 
         \`\`\`sql
-        INSERT INTO users (email, password) VALUES ($1, $2)
+        BEGIN;
+        INSERT INTO airplanes (airplane_number, model, capacity) VALUES
+          ('JA100A', 'ATR42-600', 48),
+          ('JA200B', 'Bombardier CRJ900', 90),
+          ('JA330C', 'Flying Car Alpha', 5);
+        COMMIT;
         \`\`\`
 
         **Execution History:**
 
-        ✅ **01/15/2024, 07:30:00 PM**
+        ✅ **06/01/2024, 05:00:00 PM**
+        > 3 rows inserted
+
+        ---
+
+        ##### Operation 2
+
+        **UPDATE** - Aircraft model name and seat count update (normal update scenario for existing data).
+
+        \`\`\`sql
+        UPDATE airplanes SET model = 'ATR42-700', capacity = 50 WHERE airplane_number = 'JA100A';
+        \`\`\`
+
+        **Execution History:**
+
+        ✅ **06/01/2024, 05:05:00 PM**
+        > 1 row updated
+
+
+        #### 1.2. View Flights by Aircraft
+
+        The operations manager specifies an aircraft number on the search screen and searches with period and route conditions. The system extracts flights associated with the specified aircraft within the period and displays a list of flight names, departure times, arrival times, segments, assigned captain and first officer.
+
+        **Related DML Operations:**
+
+        **SELECT** - Retrieve flight list within period for specified aircraft (JA100A). Verify date boundaries and flight names.
+
+        \`\`\`sql
+        SELECT f.flight_name, f.scheduled_departure, f.scheduled_arrival, f.origin, f.destination
+        FROM flights f
+        WHERE f.airplane_number = 'JA100A'
+          AND f.scheduled_departure >= '2024-06-01 00:00:00+09'
+          AND f.scheduled_arrival <= '2024-06-02 23:59:59+09'
+        ORDER BY f.scheduled_departure;
+        \`\`\`
+
+        **Execution History:**
+
+        ✅ **06/02/2024, 07:00:00 PM**
+        > 2 rows returned
+
+
+        ---
+
+        ### 2. Flight Information Management
+
+        Flight information includes flight name, departure time, arrival time, origin, destination, aircraft number, captain ID, first officer ID, start time, and end time. Origin and destination cannot be the same, and scheduled times must satisfy departure time < arrival time.
+
+
+        **Use Cases:**
+
+        #### 2.1. Flight Schedule Creation
+
+        The schedule coordinator enters flight name, departure time, arrival time, origin, and destination on the flight creation screen, then selects aircraft number and pilot IDs. The system validates the input values before saving.
+
+        **Related DML Operations:**
+
+        **INSERT** - Representative flight creation (Tokyo to Osaka route)
+
+        \`\`\`sql
+        INSERT INTO flights (id, flight_name, origin, destination, scheduled_departure, scheduled_arrival, airplane_number, captain_id, first_officer_id)
+        VALUES ('fc70279f-04d3-41ea-97e9-3a1bb7ee358f', 'JAL101', 'Tokyo', 'Osaka', '2024-06-01 08:00:00+09', '2024-06-01 09:10:00+09', 'JA100A', 'P0001', 'P0002');
+        \`\`\`
+
+        **Execution History:**
+
+        ✅ **05/30/2024, 11:00:00 PM**
         > 1 row inserted
+
+
+        #### 2.2. Recording Actual Flight Times
+
+        After operation, the operations coordinator opens the target flight details screen and enters the start time (actual departure) and end time (actual arrival) then saves.
+
+        **Related DML Operations:**
+
+        **UPDATE** - Record actual departure and arrival times simultaneously (normal case including delays).
+
+        \`\`\`sql
+        UPDATE flights SET actual_start = '2024-06-01 08:05:00+09', actual_end = '2024-06-01 09:12:00+09'
+        WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';
+        \`\`\`
+
+        **Execution History:**
+
+        ✅ **06/01/2024, 06:15:00 PM**
+        > 1 row updated
+
+
+        ---
+
+        ### 3. Pilot Management
+
+        Each flight is operated by a captain and first officer, each with an ID, name, and phone number. Pilot IDs must be unique, and for flights, the captain ID and first officer ID cannot be the same person.
+
+
+        **Use Cases:**
+
+        #### 3.1. Pilot (Captain/First Officer) Registration
+
+        HR or operations manager selects "New Registration" from the pilot roster screen and enters pilot ID, name, and phone number then saves.
+
+        **Related DML Operations:**
+
+        **INSERT** - Multiple pilot registration (diverse name and phone number formats)
+
+        \`\`\`sql
+        INSERT INTO pilots (pilot_id, name, phone) VALUES
+          ('P0001', 'Taro Sato', '+81-90-1234-5678'),
+          ('P0002', 'Hanako Yamada', '+81-90-2345-6789');
+        \`\`\`
+
+        **Execution History:**
+
+        ❌ **05/25/2024, 07:00:00 PM**
+        > ERROR: duplicate key value violates unique constraint "pk_pilots"
+
+        ✅ **05/25/2024, 07:05:00 PM**
+        > 2 rows inserted
+
+
+        ---
+
+        ### 4. Data Integrity and Validation
+
+        Enforce referential integrity through foreign keys and implement various business rules through CHECK constraints. Protect related data with ON DELETE RESTRICT during deletions.
+
+
+        **Use Cases:**
+
+        #### 4.1. Referential Integrity Verification
+
+        Verify that the system properly returns errors when attempting to delete aircraft with existing flights or pilots assigned to flights.
+
+        **Related DML Operations:**
+
+        **DELETE** - Delete aircraft with remaining flights (expecting referential integrity error: ON DELETE RESTRICT).
+
+        \`\`\`sql
+        DELETE FROM airplanes WHERE airplane_number = 'JA330C';
+        \`\`\`
+
+        **Execution History:**
+
+        ❌ **06/03/2024, 08:00:00 PM**
+        > ERROR: update or delete on table "airplanes" violates foreign key constraint "fk_flights_airplane"
 
 
 
@@ -89,7 +414,14 @@ describe('formatArtifactToMarkdown', () => {
 
         ### 1. Performance
 
-        System should respond within 2 seconds
+        The system must be able to search 1000 flight records within 3 seconds and support concurrent access from 50 users.
+
+
+        ---
+
+        ### 2. Security
+
+        Pilot personal information must be encrypted for storage and access logs must be recorded. Database access must be restricted to authenticated users only.
         "
       `)
     })

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
@@ -244,11 +244,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         The operations manager opens the aircraft management screen, selects "New Registration", and enters the aircraft number, model, and seating capacity. Upon clicking the register button, the system verifies required field entry, confirms aircraft number uniqueness, checks that seating capacity is a positive number, then records it in the aircraft registry.
 
-        **Related DML Operations:**
-
-        ##### Operation 1
-
-        **INSERT** - New aircraft registration test including normal cases and edge cases (capacity 1/0, model names with special characters and non-ASCII).
+        ##### **INSERT** - New aircraft registration test including normal cases and edge cases (capacity 1/0, model names with special characters and non-ASCII).
 
         \`\`\`sql
         BEGIN;
@@ -266,9 +262,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         ---
 
-        ##### Operation 2
-
-        **UPDATE** - Aircraft model name and seat count update (normal update scenario for existing data).
+        ##### **UPDATE** - Aircraft model name and seat count update (normal update scenario for existing data).
 
         \`\`\`sql
         UPDATE airplanes SET model = 'ATR42-700', capacity = 50 WHERE airplane_number = 'JA100A';
@@ -284,9 +278,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         The operations manager specifies an aircraft number on the search screen and searches with period and route conditions. The system extracts flights associated with the specified aircraft within the period and displays a list of flight names, departure times, arrival times, segments, assigned captain and first officer.
 
-        **Related DML Operations:**
-
-        **SELECT** - Retrieve flight list within period for specified aircraft (JA100A). Verify date boundaries and flight names.
+        ##### **SELECT** - Retrieve flight list within period for specified aircraft (JA100A). Verify date boundaries and flight names.
 
         \`\`\`sql
         SELECT f.flight_name, f.scheduled_departure, f.scheduled_arrival, f.origin, f.destination
@@ -316,9 +308,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         The schedule coordinator enters flight name, departure time, arrival time, origin, and destination on the flight creation screen, then selects aircraft number and pilot IDs. The system validates the input values before saving.
 
-        **Related DML Operations:**
-
-        **INSERT** - Representative flight creation (Tokyo to Osaka route)
+        ##### **INSERT** - Representative flight creation (Tokyo to Osaka route)
 
         \`\`\`sql
         INSERT INTO flights (id, flight_name, origin, destination, scheduled_departure, scheduled_arrival, airplane_number, captain_id, first_officer_id)
@@ -335,9 +325,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         After operation, the operations coordinator opens the target flight details screen and enters the start time (actual departure) and end time (actual arrival) then saves.
 
-        **Related DML Operations:**
-
-        **UPDATE** - Record actual departure and arrival times simultaneously (normal case including delays).
+        ##### **UPDATE** - Record actual departure and arrival times simultaneously (normal case including delays).
 
         \`\`\`sql
         UPDATE flights SET actual_start = '2024-06-01 08:05:00+09', actual_end = '2024-06-01 09:12:00+09'
@@ -363,9 +351,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         HR or operations manager selects "New Registration" from the pilot roster screen and enters pilot ID, name, and phone number then saves.
 
-        **Related DML Operations:**
-
-        **INSERT** - Multiple pilot registration (diverse name and phone number formats)
+        ##### **INSERT** - Multiple pilot registration (diverse name and phone number formats)
 
         \`\`\`sql
         INSERT INTO pilots (pilot_id, name, phone) VALUES
@@ -395,9 +381,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         Verify that the system properly returns errors when attempting to delete aircraft with existing flights or pilots assigned to flights.
 
-        **Related DML Operations:**
-
-        **DELETE** - Delete aircraft with remaining flights (expecting referential integrity error: ON DELETE RESTRICT).
+        ##### **DELETE** - Delete aircraft with remaining flights (expecting referential integrity error: ON DELETE RESTRICT).
 
         \`\`\`sql
         DELETE FROM airplanes WHERE airplane_number = 'JA330C';
@@ -857,7 +841,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
       expect(result).toContain('#### 1.1. Single Operation Use Case')
       expect(result).toContain('This use case has one operation')
-      expect(result).toContain('**Related DML Operations:**')
+      expect(result).toContain('##### **INSERT**')
       expect(result).not.toContain('##### Operation 1')
     })
 
@@ -897,8 +881,8 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
       const result = formatArtifactToMarkdown(artifact)
 
-      expect(result).toContain('##### Operation 1')
-      expect(result).toContain('##### Operation 2')
+      expect(result).toContain('##### **INSERT**')
+      expect(result).toContain('##### **UPDATE**')
       expect(result).toContain('---')
       expect(result).toContain('INSERT INTO orders')
       expect(result).toContain('UPDATE inventory')

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
@@ -263,7 +263,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ✅ **06/01/2024, 05:00:00 PM**
+        ✅ **06/01/2024, 08:00:00 AM**
         > 3 rows inserted
 
         ---
@@ -276,7 +276,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ✅ **06/01/2024, 05:05:00 PM**
+        ✅ **06/01/2024, 08:05:00 AM**
         > 1 row updated
 
 
@@ -297,7 +297,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ✅ **06/02/2024, 07:00:00 PM**
+        ✅ **06/02/2024, 10:00:00 AM**
         > 2 rows returned
 
 
@@ -323,7 +323,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ✅ **05/30/2024, 11:00:00 PM**
+        ✅ **05/30/2024, 02:00:00 PM**
         > 1 row inserted
 
 
@@ -340,7 +340,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ✅ **06/01/2024, 06:15:00 PM**
+        ✅ **06/01/2024, 09:15:00 AM**
         > 1 row updated
 
 
@@ -367,10 +367,10 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ❌ **05/25/2024, 07:00:00 PM**
+        ❌ **05/25/2024, 10:00:00 AM**
         > ERROR: duplicate key value violates unique constraint "pk_pilots"
 
-        ✅ **05/25/2024, 07:05:00 PM**
+        ✅ **05/25/2024, 10:05:00 AM**
         > 2 rows inserted
 
 
@@ -395,7 +395,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
         **Execution History:**
 
-        ❌ **06/03/2024, 08:00:00 PM**
+        ❌ **06/03/2024, 11:00:00 AM**
         > ERROR: update or delete on table "airplanes" violates foreign key constraint "fk_flights_airplane"
 
 
@@ -655,7 +655,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
       const result = formatArtifactToMarkdown(artifact)
 
       expect(result).toContain('**Execution History:**')
-      expect(result).toContain('✅ **03/20/2024, 11:45:30 PM**')
+      expect(result).toContain('✅ **03/20/2024, 02:45:30 PM**')
       expect(result).toContain('> 25 rows returned')
     })
 
@@ -695,7 +695,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
       const result = formatArtifactToMarkdown(artifact)
 
-      expect(result).toContain('❌ **03/20/2024, 11:45:30 PM**')
+      expect(result).toContain('❌ **03/20/2024, 02:45:30 PM**')
       expect(result).toContain('> Unique constraint violation')
     })
 
@@ -740,9 +740,9 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
 
       const result = formatArtifactToMarkdown(artifact)
 
-      expect(result).toContain('❌ **03/20/2024, 07:00:00 PM**')
+      expect(result).toContain('❌ **03/20/2024, 10:00:00 AM**')
       expect(result).toContain('> Connection timeout')
-      expect(result).toContain('✅ **03/20/2024, 07:01:00 PM**')
+      expect(result).toContain('✅ **03/20/2024, 10:01:00 AM**')
       expect(result).toContain('> 1 row inserted')
     })
 

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
@@ -47,6 +47,7 @@ function formatUseCase(
             hour: '2-digit',
             minute: '2-digit',
             second: '2-digit',
+            timeZone: 'UTC',
           })
 
           sections.push(`${statusIcon} **${executedAt}**`)

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/formatArtifactToMarkdown.ts
@@ -1,47 +1,5 @@
-import type { Artifact, DmlOperation, UseCase } from '@liam-hq/artifact'
+import type { Artifact, UseCase } from '@liam-hq/artifact'
 import { EXECUTION_SECTION_TITLE, FAILURE_ICON, SUCCESS_ICON } from '../utils'
-
-function formatDmlOperation(operation: DmlOperation): string {
-  const sections: string[] = []
-
-  // Operation type and description
-  if (operation.description) {
-    sections.push(`**${operation.operation_type}** - ${operation.description}`)
-  } else {
-    sections.push(`**${operation.operation_type}**`)
-  }
-  sections.push('')
-
-  // SQL code block
-  sections.push('```sql')
-  sections.push(operation.sql.trim())
-  sections.push('```')
-
-  // Execution logs
-  if (operation.dml_execution_logs.length > 0) {
-    sections.push('')
-    sections.push(`**${EXECUTION_SECTION_TITLE}:**`)
-    sections.push('')
-
-    operation.dml_execution_logs.forEach((log) => {
-      const statusIcon = log.success ? SUCCESS_ICON : FAILURE_ICON
-      const executedAt = new Date(log.executed_at).toLocaleString('en-US', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-      })
-
-      sections.push(`${statusIcon} **${executedAt}**`)
-      sections.push(`> ${log.result_summary}`)
-      sections.push('')
-    })
-  }
-
-  return sections.join('\n')
-}
 
 function formatUseCase(
   useCase: UseCase,
@@ -56,15 +14,46 @@ function formatUseCase(
 
   if (useCase.dml_operations.length > 0) {
     sections.push('')
-    sections.push('**Related DML Operations:**')
-    sections.push('')
 
+    // Format all operations directly as headings
     useCase.dml_operations.forEach((operation, opIndex) => {
-      if (useCase.dml_operations.length > 1) {
-        sections.push(`##### Operation ${opIndex + 1}`)
-        sections.push('')
+      // Format as heading with operation type and description
+      if (operation.description) {
+        sections.push(
+          `##### **${operation.operation_type}** - ${operation.description}`,
+        )
+      } else {
+        sections.push(`##### **${operation.operation_type}**`)
       }
-      sections.push(formatDmlOperation(operation))
+      sections.push('')
+
+      // SQL code block
+      sections.push('```sql')
+      sections.push(operation.sql.trim())
+      sections.push('```')
+
+      // Execution logs
+      if (operation.dml_execution_logs.length > 0) {
+        sections.push('')
+        sections.push(`**${EXECUTION_SECTION_TITLE}:**`)
+        sections.push('')
+
+        operation.dml_execution_logs.forEach((log) => {
+          const statusIcon = log.success ? SUCCESS_ICON : FAILURE_ICON
+          const executedAt = new Date(log.executed_at).toLocaleString('en-US', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          })
+
+          sections.push(`${statusIcon} **${executedAt}**`)
+          sections.push(`> ${log.result_summary}`)
+          sections.push('')
+        })
+      }
 
       if (opIndex < useCase.dml_operations.length - 1) {
         sections.push('---')


### PR DESCRIPTION
## Issue

- resolve: #3049

## Why is this change needed?

The formatArtifactToMarkdown utility was generating incorrect output format for DML operations. The function was wrapping operations in unnecessary headers and numbering that made the output less readable and not aligned with the expected format.

## Summary

- Updated `formatArtifactToMarkdown` implementation to format DML operations directly as level 5 headings
- Removed the separate `formatDmlOperation` function that is no longer needed
- Each operation is now formatted as `##### **OPERATION_TYPE** - Description` for better hierarchy
- Removed "Related DML Operations:" header and "Operation N" numbering for cleaner output
- Added comprehensive tests with realistic airline system example data
- Updated test expectations to match the new simplified format

## Test plan

- [x] All existing tests pass
- [x] Added comprehensive test with realistic data (airline system example)
- [x] Tests cover single and multiple DML operations
- [x] Tests verify correct formatting of execution logs (success/failure)
- [x] Snapshot tests updated to match new format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined DML operation display with direct operation headings, immediate SQL blocks, and per-operation execution history.
  - Standardized execution timestamps to UTC and added success/failure icons.
  - Improved section behavior: correct numbering, and omission of empty functional/non-functional sections.

- Tests
  - Added comprehensive suite validating full artifact rendering, edge cases, SQL whitespace trimming, special characters, and execution log scenarios to ensure consistent Markdown output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->