### PR TITLE
💄 style(command palette): show Toast feedback with useCopyLink

### DIFF
--- a/.changeset/dark-boats-follow.md
+++ b/.changeset/dark-boats-follow.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+💄 show Toast feedback with useCopyLink

--- a/.changeset/short-ties-wonder.md
+++ b/.changeset/short-ties-wonder.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+✨ support selecting Toast position with useCopy

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/hooks/useCopyLink.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/hooks/useCopyLink.ts
@@ -2,7 +2,13 @@ import { useCopy } from '@liam-hq/ui/hooks'
 import { useCallback } from 'react'
 
 export const useCopyLink = () => {
-  const { copy } = useCopy()
+  const { copy } = useCopy({
+    toast: {
+      success: 'Link copied!',
+      error: 'URL copy failed',
+      position: 'command-palette',
+    },
+  })
 
   const copyLink = useCallback(() => {
     const url = window.location.href

--- a/frontend/packages/ui/src/hooks/useCopy.ts
+++ b/frontend/packages/ui/src/hooks/useCopy.ts
@@ -1,11 +1,13 @@
 import { fromPromise } from 'neverthrow'
 import { useCallback, useState } from 'react'
+import type { ToastPosition } from '../components/Toast/types'
 import { useToast } from '../components/Toast/useToast'
 
 type UseCopyOptions = {
   toast?: {
     success: string
     error: string
+    position?: ToastPosition
   }
   resetDelay?: number
 }
@@ -18,7 +20,7 @@ type UseCopyReturn = {
 export const useCopy = (options: UseCopyOptions = {}): UseCopyReturn => {
   const { toast: toastMessages, resetDelay = 2000 } = options
   const [isCopied, setIsCopied] = useState(false)
-  const toast = useToast()
+  const toast = useToast(toastMessages?.position)
 
   const copy = useCallback(
     async (text: string) => {


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This change will enhance to show Toast feedback when user copies url by ⌘C.

https://github.com/user-attachments/assets/dcfc664d-c190-42bc-acf9-a28058923c51


preview: https://liam-app-git-style-copy-url-feedback-liambx.vercel.app/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Copy actions now display toast feedback with customizable placement, maintaining existing defaults.
  - Link copying in the Command Palette shows clear success (“Link copied!”) or error (“URL copy failed”) toasts, positioned within the palette.
- Chores
  - Prepared patch releases for UI and ERD Core packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->