### PR TITLE
chore(coderabbit): remove drafts option from reviews configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,7 +22,6 @@ reviews:
   suggested_reviewers: true
   poem: true
   abort_on_close: true
-  drafts: true
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Issue

-ref: https://github.com/route06/liam-internal/issues/5393

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I mistakenly added `drafts: true` to the “review” item, so I deleted it.

<img width="777" height="672" alt="ss 3759" src="https://github.com/user-attachments/assets/1606e248-9044-48d8-96db-fe8b0be9559d" />


