### PR TITLE
fix(coderabbit): correct auto_review configuration nesting

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,10 +3,6 @@ tone_instructions: ""
 early_access: true
 enable_free_tier: true
 
-auto_review:
-  enabled: true
-  drafts: true
-
 reviews:
   high_level_summary: true
   high_level_summary_placeholder: "@coderabbitai summary"
@@ -22,6 +18,9 @@ reviews:
   suggested_reviewers: true
   poem: true
   abort_on_close: true
+  auto_review:
+    enabled: true
+    drafts: true
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Issue
- resolve: https://github.com/route06/liam-internal/issues/5393


## Summary
- Fix CodeRabbit configuration structure by moving `auto_review` to be properly nested under the `reviews` section


before
```
auto_review:
  enabled: true
  drafts: true

reviews:
  drafts: true
```

after
```
reviews:
  drafts: true

  auto_review:
    enabled: true
    drafts: true
```

docs
https://docs.coderabbit.ai/reference/yaml-template

## Why is this change needed?
The `auto_review` configuration was incorrectly placed as a top-level option instead of being nested under the `reviews` section, which could cause configuration parsing issues.

## Changes
- Move `auto_review.enabled` and `auto_review.drafts` to be under `reviews.auto_review`

🤖 Generated with [Claude Code](https://claude.ai/code)

## Testing

When I created this pull request, coderabbit was running, so it looked good.

<img width="925" height="723" alt="ss 3766" src="https://github.com/user-attachments/assets/57d39f0f-f201-46aa-9c22-af9e2375c549" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized code review configuration by moving auto review settings into the reviews section, retaining existing options (enabled, drafts).
  * Ensures configuration consistency without altering functionality.

* **Notes**
  * No user-facing changes or feature impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->