### PR TITLE
fix(agent): consolidate DML operations into usecase structure

### DIFF
--- a/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/nodes/prepareDmlNode.ts
@@ -126,9 +126,19 @@ export async function prepareDmlNode(
     })
     .join('\n\n')
 
+  const updatedUsecases = state.generatedUsecases.map((usecase) => {
+    const usecaseDmlOperations = result.dmlOperations.filter(
+      (op) => op.useCaseId === usecase.id,
+    )
+    return {
+      ...usecase,
+      dmlOperations: usecaseDmlOperations,
+    }
+  })
+
   return {
     ...state,
     dmlStatements,
-    dmlOperations: result.dmlOperations,
+    generatedUsecases: updatedUsecases,
   }
 }

--- a/frontend/internal-packages/agent/src/chat/workflow/shared/createAnnotations.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/shared/createAnnotations.ts
@@ -1,5 +1,4 @@
 import { Annotation, MessagesAnnotation } from '@langchain/langgraph'
-import type { DmlOperation } from '@liam-hq/artifact'
 import type { Schema } from '@liam-hq/schema'
 import type { Usecase } from '../../../langchain/agents/qaGenerateUsecaseAgent/agent'
 
@@ -29,7 +28,6 @@ export const createAnnotations = () => {
 
     ddlStatements: Annotation<string | undefined>,
     dmlStatements: Annotation<string | undefined>,
-    dmlOperations: Annotation<DmlOperation[] | undefined>,
 
     // DDL execution retry mechanism
     shouldRetryWithDesignSchema: Annotation<boolean | undefined>,

--- a/frontend/internal-packages/agent/src/chat/workflow/types.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/types.ts
@@ -1,5 +1,4 @@
 import type { BaseMessage } from '@langchain/core/messages'
-import type { DmlOperation } from '@liam-hq/artifact'
 import type { Schema } from '@liam-hq/schema'
 import type { Usecase } from '../../langchain/agents/qaGenerateUsecaseAgent/agent'
 import type { Repositories } from '../../repositories'
@@ -20,7 +19,6 @@ export type WorkflowState = {
 
   ddlStatements?: string | undefined
   dmlStatements?: string | undefined
-  dmlOperations?: DmlOperation[] | undefined
 
   // DML execution results
   dmlExecutionSuccessful?: boolean | undefined

--- a/frontend/internal-packages/agent/src/chat/workflow/utils/transformWorkflowStateToArtifact.ts
+++ b/frontend/internal-packages/agent/src/chat/workflow/utils/transformWorkflowStateToArtifact.ts
@@ -19,35 +19,6 @@ const wrapDescription = (
 }
 
 /**
- * Map workflow-level DML operations to individual use cases
- */
-const mapDmlOperationsToUsecases = (
-  usecases: Usecase[],
-  workflowDmlOperations: WorkflowState['dmlOperations'],
-): Usecase[] => {
-  if (!workflowDmlOperations || workflowDmlOperations.length === 0) {
-    return usecases
-  }
-
-  return usecases.map((usecase) => {
-    const usecaseDmlOperations = workflowDmlOperations
-      .filter((dmlOp) => dmlOp.useCaseId === usecase.id)
-      .map((dmlOp) => ({
-        useCaseId: dmlOp.useCaseId,
-        operation_type: dmlOp.operation_type,
-        sql: dmlOp.sql,
-        description: dmlOp.description,
-        dml_execution_logs: dmlOp.dml_execution_logs ?? [],
-      }))
-
-    return {
-      ...usecase,
-      dmlOperations: usecaseDmlOperations,
-    }
-  })
-}
-
-/**
  * Convert analyzed requirements to artifact requirements
  */
 const convertAnalyzedRequirementsToArtifact = (
@@ -160,11 +131,7 @@ export const transformWorkflowStateToArtifact = (
     : []
 
   if (state.generatedUsecases && state.generatedUsecases.length > 0) {
-    const usecasesWithDmlOperations = mapDmlOperationsToUsecases(
-      state.generatedUsecases,
-      state.dmlOperations,
-    )
-    mergeUseCasesIntoRequirements(requirements, usecasesWithDmlOperations)
+    mergeUseCasesIntoRequirements(requirements, state.generatedUsecases)
   }
 
   return {


### PR DESCRIPTION
## Summary
This PR fixes the issue where DML execution results were not being reflected in artifacts due to a data structure mismatch.

## Problem
- DML operations were stored in `state.dmlOperations` but execution expected them in `usecase.dmlOperations`
- This caused DML operations to never execute, as `usecase.dmlOperations` was always empty
- Data was duplicated between two locations

## Solution
Consolidated DML operations to be stored directly in `state.generatedUsecases[].dmlOperations`:
- `prepareDmlNode` now stores DML operations directly in each usecase
- `validateSchemaNode` reads from usecases without needing mapping
- Removed `state.dmlOperations` field entirely
- Eliminated all backward compatibility code

## Changes
1. **Core consolidation** - Store DML operations in usecases
2. **Remove backward compatibility** - Clean up redundant code and data structures  
3. **Test improvements** - Focus tests on observable behavior rather than implementation details

## Impact
- ✅ DML operations now execute correctly
- ✅ Execution results properly flow to artifacts
- ✅ Cleaner, simpler data structure
- ✅ All tests passing

## Testing

The following error is now occurring because we are now querying PGLite. Assuming this issue has been resolved, we will address it in the next PR.

```
✅ [INFO] 2025-08-20T02:23:21.360Z AI response: Generated 16 use cases for testing and validation
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
SQL parsing failed, falling back to simple split: Ma[F[(F[((c2 + 12) >> 2)] >> 2)]] is not a function
```

Fixes #3066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-usecase DML execution tracking: execution logs, timestamps, summaries, and success flags are now reported per usecase.

- Refactor
  - DML results and state are consolidated under each usecase for clearer processing and artifact generation.
  - Validation now runs DML when per-usecase DML exists and reports outcomes per usecase.
  - Reduced exposed internal DML fields from public annotations/state.

- Tests
  - Added/updated tests verifying DML assignment to usecases and per-usecase execution reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->