### PR TITLE
🔧 Fix Server Actions CORS error with custom domain in production

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -22,7 +22,7 @@ const nextConfig: NextConfig = {
     serverActions: {
       allowedOrigins:
         process.env.VERCEL_ENV === 'production'
-          ? ['https://liambx.com', 'https://liam-erd-web.vercel.app']
+          ? ['liambx.com', 'liam-erd-web.vercel.app']
           : undefined,
     },
   },


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5427

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
In production, Server Actions are failing with the error:
x-forwarded-host header with value liam-erd-web.vercel.app does not match origin header with value liambx.com from a forwarded Server Actions request. Aborting the action.

This occurs because:
1. Users access the site via the custom domain `liambx.com`
2. Vercel's infrastructure internally processes requests through `liam-erd-web.vercel.app`
3. Next.js Server Actions perform security validation by comparing the `x-forwarded-host` and `origin` headers
4. The mismatch between these headers causes the validation to fail

This change adds `allowedOrigins` configuration for production environment only, allowing Server Actions to accept requests from both domains while keeping development environment unchanged.


## Testing

Since it cannot be verified in the preview environment, I would like to check it in the production environment after merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restricted server-side actions to trusted production domains, enforcing cross-origin access rules while leaving development environments unrestricted.
  * Impact: Requests from unrecognized domains may be blocked in production, improving security and reliability for supported domains and preventing unintended cross-site interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->