### PR TITLE
trial(command palette): update toast feedback ui

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -5,6 +5,7 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
 import { useSchemaOrThrow } from '@/stores'
 import { TableNode } from '../../../ERDContent/components'
+import { CommandPaletteCommandOptions } from '../CommandPaletteOptions'
 import { CommandPaletteSearchInput } from '../CommandPaletteSearchInput'
 import type { CommandPaletteInputMode } from '../types'
 import styles from './CommandPaletteContent.module.css'
@@ -100,12 +101,9 @@ export const CommandPaletteContent: FC<Props> = ({ closeDialog }) => {
               ))}
             </Command.Group>
           )}
-          {
-            (inputMode.type === 'default' || inputMode.type === 'command') &&
-              null
-            // TODO(command options): uncomment the following line to release command options
-            // <CommandPaletteCommandOptions />
-          }
+          {(inputMode.type === 'default' || inputMode.type === 'command') && (
+            <CommandPaletteCommandOptions />
+          )}
         </Command.List>
         <div
           className={styles.previewContainer}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteOptions/CommandOptions.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteOptions/CommandOptions.tsx
@@ -7,6 +7,7 @@ import {
   TidyUpIcon,
 } from '@liam-hq/ui'
 import { Command } from 'cmdk'
+import { useQueryState } from 'nuqs'
 import type { FC } from 'react'
 import { useUserEditingOrThrow } from '@/stores'
 import { useCommandPalette } from '../CommandPaletteProvider'
@@ -19,6 +20,8 @@ export const CommandPaletteCommandOptions: FC = () => {
   const { zoomToFit, tidyUp } = useFitScreen()
   const { setShowMode } = useUserEditingOrThrow()
 
+  const [closeAfterCopy] = useQueryState('close', { defaultValue: '' })
+
   const result = useCommandPalette()
   const setOpen = result.isOk() ? result.value.setOpen : () => {}
 
@@ -29,7 +32,9 @@ export const CommandPaletteCommandOptions: FC = () => {
         value="copy link"
         onSelect={() => {
           copyLink()
-          setOpen(false)
+          if (closeAfterCopy === 'true') {
+            setOpen(false)
+          }
         }}
       >
         <Copy className={styles.itemIcon} />

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/hooks/useCopyLink.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/hooks/useCopyLink.ts
@@ -1,12 +1,15 @@
 import { useCopy } from '@liam-hq/ui/hooks'
+import { useQueryState } from 'nuqs'
 import { useCallback } from 'react'
 
 export const useCopyLink = () => {
+  const [toastPosition] = useQueryState('toast', { defaultValue: '' })
+
   const { copy } = useCopy({
     toast: {
       success: 'Link copied!',
       error: 'URL copy failed',
-      position: 'command-palette',
+      position: toastPosition === 'header' ? 'header' : 'command-palette',
     },
   })
 


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Command Palette now displays available command options in default/command modes.
  * Copy Link behavior is configurable: add close=true to the URL to auto-close the Command Palette after copying; otherwise it stays open.
  * Toast notification position is configurable: add toast=header to the URL to show the toast in the header; default remains within the Command Palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->