### PR TITLE
feat: Add public view UI components and cache optimization

### DIFF
--- a/frontend/apps/app/app/app/public/design_sessions/[id]/page.tsx
+++ b/frontend/apps/app/app/app/public/design_sessions/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation'
+import * as v from 'valibot'
+import type { PageProps } from '@/app/types'
+import { PublicSessionDetailPage } from '@/components/PublicSessionDetailPage'
+
+const paramsSchema = v.object({
+  id: v.string(),
+})
+
+// Cache configuration for public pages
+export const revalidate = 60 // Revalidate every 60 seconds
+
+export default async function Page({ params }: PageProps) {
+  const parsedParams = v.safeParse(paramsSchema, await params)
+  if (!parsedParams.success) {
+    notFound()
+  }
+
+  const designSessionId = parsedParams.output.id
+
+  return <PublicSessionDetailPage designSessionId={designSessionId} />
+}

--- a/frontend/apps/app/components/PublicLayout/PublicAppBar/PublicAppBar.module.css
+++ b/frontend/apps/app/components/PublicLayout/PublicAppBar/PublicAppBar.module.css
@@ -1,0 +1,39 @@
+.wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 52px;
+  padding: var(--spacing-3) var(--spacing-3half) var(--spacing-3)
+    var(--spacing-2);
+  background-color: var(--global-muted-background);
+  border-radius: var(--border-radius-base);
+  border-bottom: 1px solid var(--pane-border);
+}
+
+.leftSection {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex: 1;
+}
+
+.publicBadge {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1half);
+  padding: var(--spacing-1) var(--spacing-2);
+  background-color: var(--pane-background);
+  border: 1px solid var(--pane-border);
+  border-radius: var(--border-radius-base);
+  color: var(--text-secondary);
+}
+
+.icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.publicText {
+  font-size: var(--font-size-2);
+}

--- a/frontend/apps/app/components/PublicLayout/PublicAppBar/PublicAppBar.tsx
+++ b/frontend/apps/app/components/PublicLayout/PublicAppBar/PublicAppBar.tsx
@@ -1,0 +1,15 @@
+import type { FC } from 'react'
+import styles from './PublicAppBar.module.css'
+
+export const PublicAppBar: FC = () => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.leftSection}>
+        <div className={styles.publicBadge}>
+          <span className={styles.icon}>🌐</span>
+          <span className={styles.publicText}>Public</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/PublicLayout/PublicAppBar/index.ts
+++ b/frontend/apps/app/components/PublicLayout/PublicAppBar/index.ts
@@ -1,0 +1,1 @@
+export { PublicAppBar } from './PublicAppBar'

--- a/frontend/apps/app/components/PublicLayout/PublicGlobalNav/PublicGlobalNav.module.css
+++ b/frontend/apps/app/components/PublicLayout/PublicGlobalNav/PublicGlobalNav.module.css
@@ -1,0 +1,58 @@
+.globalNavContainer {
+  position: relative;
+  min-width: 3.25rem;
+}
+
+.globalNav {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3.25rem;
+  height: 100%;
+  background-color: var(--pane-background);
+  border-right: 1px solid var(--pane-border);
+  transition: width 0.1s var(--default-timing-function);
+  overflow: hidden;
+  z-index: 100;
+  box-shadow: none;
+}
+
+.globalNav:hover {
+  width: 11rem;
+  box-shadow: 4px 0 16px rgba(0, 0, 0, 0.2);
+}
+
+.logoContainer {
+  padding: var(--spacing-2);
+}
+
+.logoSection {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--spacing-1);
+  padding: var(--spacing-1half, 0.375rem) var(--spacing-2, 0.5rem);
+}
+
+.iconContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+.labelArea {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.liamMigrationLogo {
+  width: 4.23125rem;
+  height: 0.7875rem;
+}

--- a/frontend/apps/app/components/PublicLayout/PublicGlobalNav/PublicGlobalNav.tsx
+++ b/frontend/apps/app/components/PublicLayout/PublicGlobalNav/PublicGlobalNav.tsx
@@ -1,0 +1,22 @@
+import type { FC } from 'react'
+import { LiamDbLogo, LiamLogoMark } from '@/logos'
+import styles from './PublicGlobalNav.module.css'
+
+export const PublicGlobalNav: FC = () => {
+  return (
+    <div className={styles.globalNavContainer}>
+      <nav className={styles.globalNav}>
+        <div className={styles.logoContainer}>
+          <div className={styles.logoSection}>
+            <div className={styles.iconContainer}>
+              <LiamLogoMark />
+            </div>
+            <div className={styles.labelArea}>
+              <LiamDbLogo className={styles.liamMigrationLogo} />
+            </div>
+          </div>
+        </div>
+      </nav>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/PublicLayout/PublicGlobalNav/index.ts
+++ b/frontend/apps/app/components/PublicLayout/PublicGlobalNav/index.ts
@@ -1,0 +1,1 @@
+export { PublicGlobalNav } from './PublicGlobalNav'

--- a/frontend/apps/app/components/PublicLayout/PublicLayout.module.css
+++ b/frontend/apps/app/components/PublicLayout/PublicLayout.module.css
@@ -1,0 +1,23 @@
+.layout {
+  display: flex;
+  height: 100vh;
+  background-color: var(--global-background);
+  color: var(--global-foreground);
+}
+
+.mainContent {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  overflow: hidden;
+  height: 100%;
+}
+
+.content {
+  flex-grow: 1;
+  padding: 0;
+  overflow: auto;
+  height: calc(100% - 52px); /* Subtract AppBar height */
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/apps/app/components/PublicLayout/PublicLayout.tsx
+++ b/frontend/apps/app/components/PublicLayout/PublicLayout.tsx
@@ -1,0 +1,20 @@
+import type { FC, ReactNode } from 'react'
+import { PublicAppBar } from './PublicAppBar'
+import { PublicGlobalNav } from './PublicGlobalNav'
+import styles from './PublicLayout.module.css'
+
+type Props = {
+  children: ReactNode
+}
+
+export const PublicLayout: FC<Props> = ({ children }) => {
+  return (
+    <div className={styles.layout}>
+      <PublicGlobalNav />
+      <div className={styles.mainContent}>
+        <PublicAppBar />
+        <main className={styles.content}>{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/PublicLayout/index.ts
+++ b/frontend/apps/app/components/PublicLayout/index.ts
@@ -1,0 +1,1 @@
+export { PublicLayout } from './PublicLayout'

--- a/frontend/apps/app/components/PublicSessionDetailPage/PublicSessionDetailPage.module.css
+++ b/frontend/apps/app/components/PublicSessionDetailPage/PublicSessionDetailPage.module.css
@@ -1,0 +1,6 @@
+.publicWrapper {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/apps/app/components/PublicSessionDetailPage/PublicSessionDetailPage.tsx
+++ b/frontend/apps/app/components/PublicSessionDetailPage/PublicSessionDetailPage.tsx
@@ -1,0 +1,150 @@
+import { schemaSchema } from '@liam-hq/schema'
+import { notFound } from 'next/navigation'
+import type { ReactElement } from 'react'
+import { safeParse } from 'valibot'
+import { createPublicServerClient } from '@/libs/db/server'
+import { PublicLayout } from '../PublicLayout'
+import { ViewModeProvider } from '../SessionDetailPage/contexts/ViewModeContext'
+import { SessionDetailPageClient } from '../SessionDetailPage/SessionDetailPageClient'
+import { buildPrevSchema } from '../SessionDetailPage/services/buildPrevSchema/server/buildPrevSchema'
+
+type Props = {
+  designSessionId: string
+}
+
+export const PublicSessionDetailPage = async ({
+  designSessionId,
+}: Props): Promise<ReactElement> => {
+  // Use public client for all anonymous access
+  const supabase = await createPublicServerClient()
+
+  // First check if the session is publicly shared
+  const { data: publicShareData } = await supabase
+    .from('public_share_settings')
+    .select('design_session_id')
+    .eq('design_session_id', designSessionId)
+    .single()
+
+  if (!publicShareData) {
+    notFound()
+  }
+
+  // Fetch design session data directly from tables
+  const { data: designSession, error: sessionError } = await supabase
+    .from('design_sessions')
+    .select('id, name, created_at, parent_design_session_id')
+    .eq('id', designSessionId)
+    .single()
+
+  if (sessionError || !designSession) {
+    notFound()
+  }
+
+  // Fetch timeline items
+  const { data: timelineItems } = await supabase
+    .from('timeline_items')
+    .select(
+      'id, design_session_id, content, created_at, updated_at, building_schema_version_id, type, query_result_id, assistant_role',
+    )
+    .eq('design_session_id', designSessionId)
+    .order('created_at', { ascending: true })
+
+  // Fetch building schema
+  const { data: buildingSchemas } = await supabase
+    .from('building_schemas')
+    .select(
+      'id, design_session_id, schema, created_at, git_sha, initial_schema_snapshot, schema_file_path',
+    )
+    .eq('design_session_id', designSessionId)
+
+  if (!buildingSchemas || buildingSchemas.length === 0) {
+    notFound()
+  }
+
+  const buildingSchema = buildingSchemas[0]
+  if (!buildingSchema || !buildingSchema.id) {
+    notFound()
+  }
+  const buildingSchemaId = buildingSchema.id
+
+  // Fetch versions
+  const { data: versions } = await supabase
+    .from('building_schema_versions')
+    .select('id, building_schema_id, number, created_at, patch, reverse_patch')
+    .eq('building_schema_id', buildingSchemaId)
+    .order('number', { ascending: false })
+
+  if (!versions || versions.length === 0) {
+    notFound()
+  }
+
+  // Parse schema
+  const parsedSchema = safeParse(schemaSchema, buildingSchema.schema)
+  if (!parsedSchema.success) {
+    notFound()
+  }
+  const initialSchema = parsedSchema.output
+
+  // Get latest version for prev schema
+  const latestVersion = versions[0]
+  if (!latestVersion || !latestVersion.id || latestVersion.number === null) {
+    notFound()
+  }
+
+  const initialPrevSchema =
+    (await buildPrevSchema({
+      currentSchema: initialSchema,
+      currentVersionId: latestVersion.id,
+    })) ?? initialSchema
+
+  // Add required fields for timeline items and design session
+  const designSessionWithTimelineItems = {
+    id: designSession.id ?? '',
+    organization_id: 'public', // Dummy value for public access
+    timeline_items: (timelineItems || []).map((item) => ({
+      ...item,
+      id: item.id ?? '',
+      content: item.content ?? '',
+      type: item.type ?? 'user',
+      created_at: item.created_at ?? new Date().toISOString(),
+      design_session_id: item.design_session_id ?? designSessionId,
+      organization_id: 'public', // Dummy value for public access
+      user_id: null, // Public access doesn't have user info
+      updated_at: item.updated_at ?? new Date().toISOString(),
+    })),
+  }
+
+  return (
+    <PublicLayout>
+      <ViewModeProvider mode="public">
+        <SessionDetailPageClient
+          buildingSchemaId={buildingSchemaId}
+          designSessionWithTimelineItems={designSessionWithTimelineItems}
+          initialDisplayedSchema={initialSchema}
+          initialPrevSchema={initialPrevSchema}
+          initialVersions={versions
+            .filter(
+              (
+                v,
+              ): v is NonNullable<typeof v> & {
+                id: string
+                number: number
+                created_at: string
+              } => v.id !== null && v.number !== null && v.created_at !== null,
+            )
+            .map((v) => ({
+              id: v.id,
+              number: v.number,
+              created_at: v.created_at,
+              building_schema_id: v.building_schema_id ?? '',
+              patch: v.patch ?? {},
+              reverse_patch: v.reverse_patch ?? {},
+            }))}
+          initialWorkflowRunStatus={null}
+          isDeepModelingEnabled={false}
+          initialIsPublic={true}
+        />
+      </ViewModeProvider>
+    </PublicLayout>
+  )
+}

--- a/frontend/apps/app/components/PublicSessionDetailPage/index.ts
+++ b/frontend/apps/app/components/PublicSessionDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { PublicSessionDetailPage } from './PublicSessionDetailPage'

--- a/frontend/apps/app/components/ShareDialog/ShareDialog.tsx
+++ b/frontend/apps/app/components/ShareDialog/ShareDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@liam-hq/ui'
 import { type FC, useState } from 'react'
 import { usePublicShareServerAction } from '@/hooks/usePublicShareServerAction'
+import { urlgen } from '@/libs/routes'
 import styles from './ShareDialog.module.css'
 
 type Props = {
@@ -47,7 +48,7 @@ export const ShareDialog: FC<Props> = ({
   const copyLink = async () => {
     if (!isPublic) return
 
-    const publicUrl = `${window.location.origin}/app/public/design_sessions/${designSessionId}`
+    const publicUrl = `${window.location.origin}${urlgen('public/design_sessions/[id]', { id: designSessionId })}`
     await navigator.clipboard.writeText(publicUrl)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)

--- a/frontend/apps/app/libs/routes/constants.ts
+++ b/frontend/apps/app/libs/routes/constants.ts
@@ -1,0 +1,7 @@
+// Route prefixes for middleware and other path checks
+export const ROUTE_PREFIXES = {
+  APP: '/app',
+  PUBLIC: '/app/public',
+  LOGIN: '/app/login',
+  AUTH: '/app/auth',
+} as const

--- a/frontend/apps/app/libs/routes/index.ts
+++ b/frontend/apps/app/libs/routes/index.ts
@@ -1,2 +1,3 @@
+export * from './constants'
 export * from './paramsSchema'
 export * from './urlgen'

--- a/frontend/apps/app/libs/routes/routeDefinitions.ts
+++ b/frontend/apps/app/libs/routes/routeDefinitions.ts
@@ -29,6 +29,7 @@ export type RouteDefinitions = {
     schemaFilePath: string
   }) => string
   'design_sessions/[id]': (params: { id: string }) => string
+  'public/design_sessions/[id]': (params: { id: string }) => string
 }
 
 export const routeDefinitions: RouteDefinitions = {
@@ -79,5 +80,8 @@ export const routeDefinitions: RouteDefinitions = {
   },
   'design_sessions/[id]': ({ id }) => {
     return `/app/design_sessions/${id}`
+  },
+  'public/design_sessions/[id]': ({ id }) => {
+    return `/app/public/design_sessions/${id}`
   },
 } as const

--- a/frontend/apps/app/libs/routes/routeDefinitions.ts
+++ b/frontend/apps/app/libs/routes/routeDefinitions.ts
@@ -1,3 +1,5 @@
+import { ROUTE_PREFIXES } from './constants'
+
 export type RouteDefinitions = {
   login: string
   projects: string
@@ -82,6 +84,6 @@ export const routeDefinitions: RouteDefinitions = {
     return `/app/design_sessions/${id}`
   },
   'public/design_sessions/[id]': ({ id }) => {
-    return `/app/public/design_sessions/${id}`
+    return `${ROUTE_PREFIXES.PUBLIC}/design_sessions/${id}`
   },
 } as const

--- a/frontend/apps/app/middleware.ts
+++ b/frontend/apps/app/middleware.ts
@@ -1,10 +1,11 @@
 import { createServerClient } from '@liam-hq/db'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
+import { ROUTE_PREFIXES } from './libs/routes/constants'
 
 export async function updateSession(request: NextRequest) {
   // Skip middleware if path doesn't start with /app
-  if (!request.nextUrl.pathname.startsWith('/app')) {
+  if (!request.nextUrl.pathname.startsWith(ROUTE_PREFIXES.APP)) {
     return NextResponse.next()
   }
 
@@ -47,12 +48,13 @@ export async function updateSession(request: NextRequest) {
 
   if (
     !user &&
-    !request.nextUrl.pathname.startsWith('/app/login') &&
-    !request.nextUrl.pathname.startsWith('/app/auth')
+    !request.nextUrl.pathname.startsWith(ROUTE_PREFIXES.LOGIN) &&
+    !request.nextUrl.pathname.startsWith(ROUTE_PREFIXES.AUTH) &&
+    !request.nextUrl.pathname.startsWith(ROUTE_PREFIXES.PUBLIC)
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone()
-    url.pathname = '/app/login'
+    url.pathname = ROUTE_PREFIXES.LOGIN
 
     // Create the redirect response
     const redirectResponse = NextResponse.redirect(url)

--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import { withSentryConfig } from '@sentry/nextjs'
 import type { NextConfig } from 'next'
+import { ROUTE_PREFIXES } from './libs/routes/constants'
 
 const gitCommitHash = execSync('git rev-parse --short HEAD').toString().trim()
 const releaseDate = new Date().toISOString().split('T')[0]
@@ -119,6 +120,20 @@ const nextConfig: NextConfig = {
     process.env.NEXT_PUBLIC_ENV_NAME === 'production'
       ? process.env.ASSET_PREFIX
       : undefined,
+  async headers() {
+    return [
+      {
+        source: `${ROUTE_PREFIXES.PUBLIC}/:path*`,
+        headers: [
+          {
+            key: 'Cache-Control',
+            value:
+              'public, max-age=0, s-maxage=60, stale-while-revalidate=86400',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5370

## Why is this change needed?

This implements Phase 1.4 of the Public Share feature, adding public session pages with anonymous access. The implementation follows a Server-Only design pattern where all Supabase access goes through the server, leveraging RLS policies for secure anonymous data access.

### Key Changes

1. **Public Session Page Implementation**
   - Added public route at `/app/public/design_sessions/[id]` with Server Component architecture
   - Implemented `createPublicServerClient` for anonymous Supabase access
   - Added proper 404 handling for non-public sessions
   - Enabled ISR with 60-second revalidation for optimal performance

2. **Public Layout Components**
   - Created `PublicLayout` with simplified navigation for public views
   - Added `PublicGlobalNav` with Liam logo and "Public View" indicator
   - Implemented `PublicAppBar` showing "Public Share" badge and read-only status
   - Ensured responsive design with proper scrolling behavior

3. **Route Infrastructure Improvements**
   - Standardized `ROUTE_PREFIXES.PUBLIC` constant usage across the codebase
   - Updated ShareDialog to generate correct public URLs
   - Configured middleware to allow unauthenticated access to public routes
   - Added appropriate cache headers for CDN optimization

4. **Type Safety and Code Quality**
   - Fixed async Server Component type definitions
   - Replaced error divs with proper `notFound()` calls for invalid parameters
   - Ensured consistent error handling patterns

### Security Considerations
- No cookie operations (stateless anonymous access)
- RLS policies enforce access to public data only
- Server-Only design prevents client-side database access
- All data fetching happens through server components

### Performance Optimizations
- ISR with 60-second revalidation for public pages
- Cache headers configured for optimal CDN performance:
  - Browser: `max-age=0` (always revalidate)
  - CDN: `s-maxage=60` (1-minute cache)
  - `stale-while-revalidate=86400` (24-hour grace period)

### tested


https://github.com/user-attachments/assets/17739ce8-94ed-4334-87d3-15757a185db0

