### PR TITLE
♻️ refact(command palette): add suggestion type to make the option categories clearer

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -1,6 +1,6 @@
 import { Button, Table2 } from '@liam-hq/ui'
 import { DialogClose } from '@radix-ui/react-dialog'
-import { Command } from 'cmdk'
+import { Command, defaultFilter } from 'cmdk'
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
 import { useSchemaOrThrow } from '@/stores'
@@ -66,7 +66,16 @@ export const CommandPaletteContent: FC<Props> = ({ closeDialog }) => {
   }, [suggestedTableName])
 
   return (
-    <Command value={suggestionText} onValueChange={(v) => setSuggestionText(v)}>
+    <Command
+      value={suggestionText}
+      onValueChange={(v) => setSuggestionText(v)}
+      filter={(value, ...rest) => {
+        const suggestion = textToSuggestion(value)
+        if (!suggestion) return 0
+
+        return defaultFilter(suggestion.name, ...rest)
+      }}
+    >
       <div className={styles.searchContainer}>
         <CommandPaletteSearchInput
           mode={inputMode}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -17,6 +17,13 @@ const getTableLinkHref = (activeTableName: string) => {
   return `?${searchParams.toString()}`
 }
 
+const commandPaletteFilter: typeof defaultFilter = (value, ...rest) => {
+  const suggestion = textToSuggestion(value)
+  if (!suggestion) return 0
+
+  return defaultFilter(suggestion.name, ...rest)
+}
+
 type Props = {
   closeDialog: () => void
 }
@@ -69,12 +76,7 @@ export const CommandPaletteContent: FC<Props> = ({ closeDialog }) => {
     <Command
       value={suggestionText}
       onValueChange={(v) => setSuggestionText(v)}
-      filter={(value, ...rest) => {
-        const suggestion = textToSuggestion(value)
-        if (!suggestion) return 0
-
-        return defaultFilter(suggestion.name, ...rest)
-      }}
+      filter={commandPaletteFilter}
     >
       <div className={styles.searchContainer}>
         <CommandPaletteSearchInput

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -5,7 +5,6 @@ import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTableSelection } from '@/features/erd/hooks'
 import { useSchemaOrThrow } from '@/stores'
 import { TableNode } from '../../../ERDContent/components'
-import { CommandPaletteCommandOptions } from '../CommandPaletteOptions'
 import { CommandPaletteSearchInput } from '../CommandPaletteSearchInput'
 import type { CommandPaletteInputMode } from '../types'
 import { getSuggestionText, textToSuggestion } from '../utils'
@@ -124,9 +123,12 @@ export const CommandPaletteContent: FC<Props> = ({ closeDialog }) => {
               ))}
             </Command.Group>
           )}
-          {(inputMode.type === 'default' || inputMode.type === 'command') && (
-            <CommandPaletteCommandOptions />
-          )}
+          {
+            (inputMode.type === 'default' || inputMode.type === 'command') &&
+              null
+            // TODO(command options): uncomment the following line to release command options
+            // <CommandPaletteCommandOptions />
+          }
         </Command.List>
         <div
           className={styles.previewContainer}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -18,6 +18,9 @@ const getTableLinkHref = (activeTableName: string) => {
 
 const commandPaletteFilter: typeof defaultFilter = (value, ...rest) => {
   const suggestion = textToSuggestion(value)
+
+  // if the value is inappropriate for suggestion, it returns 0 and the options is hidden
+  // https://github.com/pacocoursey/cmdk/blob/d6fde235386414196bf80d9b9fa91e2cf89a72ea/cmdk/src/index.tsx#L91-L95
   if (!suggestion) return 0
 
   return defaultFilter(suggestion.name, ...rest)

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteOptions/CommandOptions.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteOptions/CommandOptions.tsx
@@ -12,6 +12,7 @@ import { useUserEditingOrThrow } from '@/stores'
 import { useCommandPalette } from '../CommandPaletteProvider'
 import { useCopyLink } from '../hooks/useCopyLink'
 import { useFitScreen } from '../hooks/useFitScreen'
+import { getSuggestionText } from '../utils'
 import styles from './CommandPaletteOptions.module.css'
 
 export const CommandPaletteCommandOptions: FC = () => {
@@ -26,7 +27,7 @@ export const CommandPaletteCommandOptions: FC = () => {
     <Command.Group heading="Commands">
       <Command.Item
         className={styles.item}
-        value="copy link"
+        value={getSuggestionText({ type: 'command', name: 'copy link' })}
         onSelect={() => {
           copyLink()
           setOpen(false)
@@ -38,7 +39,7 @@ export const CommandPaletteCommandOptions: FC = () => {
         <span className={styles.keyIcon}>C</span>
       </Command.Item>
       <Command.Item
-        value="Zoom to Fit"
+        value={getSuggestionText({ type: 'command', name: 'Zoom to Fit' })}
         onSelect={() => {
           zoomToFit()
           setOpen(false)
@@ -51,7 +52,7 @@ export const CommandPaletteCommandOptions: FC = () => {
         <span className={styles.keyIcon}>1</span>
       </Command.Item>
       <Command.Item
-        value="Tidy Up"
+        value={getSuggestionText({ type: 'command', name: 'Tidy Up' })}
         onSelect={() => {
           tidyUp()
           setOpen(false)
@@ -64,7 +65,7 @@ export const CommandPaletteCommandOptions: FC = () => {
         <span className={styles.keyIcon}>T</span>
       </Command.Item>
       <Command.Item
-        value="Show All Fields"
+        value={getSuggestionText({ type: 'command', name: 'Show All Fields' })}
         onSelect={() => {
           setShowMode('ALL_FIELDS')
           setOpen(false)
@@ -77,7 +78,7 @@ export const CommandPaletteCommandOptions: FC = () => {
         <span className={styles.keyIcon}>2</span>
       </Command.Item>
       <Command.Item
-        value="Show Table Name"
+        value={getSuggestionText({ type: 'command', name: 'Show Table Name' })}
         onSelect={() => {
           setShowMode('TABLE_NAME')
           setOpen(false)
@@ -90,7 +91,7 @@ export const CommandPaletteCommandOptions: FC = () => {
         <span className={styles.keyIcon}>3</span>
       </Command.Item>
       <Command.Item
-        value="Show Key Only"
+        value={getSuggestionText({ type: 'command', name: 'Show Key Only' })}
         onSelect={() => {
           setShowMode('KEY_ONLY')
           setOpen(false)

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
@@ -1,3 +1,7 @@
 export type CommandPaletteInputMode = { type: 'default' } | { type: 'command' }
 // upcoming input mode
 // | { type: 'column'; tableName: string }
+
+export type CommandPaletteSuggestion =
+  | { type: 'table'; name: string }
+  | { type: 'command'; name: string }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/index.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './suggestion'

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/suggestion.test.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/suggestion.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { CommandPaletteSuggestion } from '../types'
+import { getSuggestionText, textToSuggestion } from './suggestion'
+
+describe('getSuggestionText', () => {
+  it('should return "table|users" when suggestion is "user" table', () => {
+    const suggestion: CommandPaletteSuggestion = {
+      type: 'table',
+      name: 'users',
+    }
+
+    const result = getSuggestionText(suggestion)
+
+    expect(result).toBe('table|users')
+  })
+
+  it('should return "command|show tables" when suggestion is "show tables" command', () => {
+    const suggestion: CommandPaletteSuggestion = {
+      type: 'command',
+      name: 'show tables',
+    }
+
+    const result = getSuggestionText(suggestion)
+
+    expect(result).toBe('command|show tables')
+  })
+})
+
+describe('textToSuggestion', () => {
+  it('should return the "posts" table suggestion when suggestion text is "table|posts"', () => {
+    const suggestionText = 'table|posts'
+
+    const result = textToSuggestion(suggestionText)
+
+    expect(result).toEqual({ type: 'table', name: 'posts' })
+  })
+
+  it('should return the "hide tables" command suggestion when suggestion text is "command|hide tables"', () => {
+    const suggestionText = 'command|hide tables'
+
+    const result = textToSuggestion(suggestionText)
+
+    expect(result).toEqual({ type: 'command', name: 'hide tables' })
+  })
+
+  describe('with unexpected formats', () => {
+    it('should return null when an unknown suggested type is given', () => {
+      const suggestionText = 'fruits|lemon'
+
+      const result = textToSuggestion(suggestionText)
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null when a table name is empty', () => {
+      const suggestionText = 'table|'
+
+      const result = textToSuggestion(suggestionText)
+
+      expect(result).toBeNull()
+    })
+  })
+})
+
+describe('integration test, (value) => textToSuggestion(getSuggestionText(value))', () => {
+  describe('it should return the input value', () => {
+    it.each<CommandPaletteSuggestion>([
+      { type: 'table', name: 'user_posts' },
+      { type: 'command', name: 'export as CSV' },
+    ])('in case: %p', (suggestion) => {
+      const result = textToSuggestion(getSuggestionText(suggestion))
+
+      expect(result).toEqual(suggestion)
+    })
+  })
+})

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/suggestion.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/suggestion.ts
@@ -1,12 +1,14 @@
 import type { CommandPaletteSuggestion } from '../types'
 
+const SEPARATOR = '|'
+
 export const getSuggestionText = (suggestion: CommandPaletteSuggestion) =>
-  `${suggestion.type}|${suggestion.name}`
+  `${suggestion.type}${SEPARATOR}${suggestion.name}`
 
 export const textToSuggestion = (
   text: string,
 ): CommandPaletteSuggestion | null => {
-  const words = text.split('|')
+  const words = text.split(SEPARATOR)
 
   const [suggestionType, name] = words
   if (!suggestionType || !name) return null

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/suggestion.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/utils/suggestion.ts
@@ -1,0 +1,18 @@
+import type { CommandPaletteSuggestion } from '../types'
+
+export const getSuggestionText = (suggestion: CommandPaletteSuggestion) =>
+  `${suggestion.type}|${suggestion.name}`
+
+export const textToSuggestion = (
+  text: string,
+): CommandPaletteSuggestion | null => {
+  const words = text.split('|')
+
+  const [suggestionType, name] = words
+  if (!suggestionType || !name) return null
+
+  if (suggestionType === 'table' || suggestionType === 'command')
+    return { type: suggestionType, name }
+
+  return null
+}


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

It need to identify categories of options for a future update about preview, for example "users" is table option and "copy link" is command option.
To do so, I updated the option `value`s to include category inforrmation.

I defined `CommandPaletteSuggestion` type and converters `getSuggestionText`, which converts `CommandPaletteSuggestion` to suggestion text, and `textToSuggestion`, which does the reverse.

Basically, suggestion texts are used in the `Command.Option` of `cmdk`. The reason why I don't use `CommandPaletteSuggestion` values directly to the `Command.Option` is its value accepts only string values. We may be able to make the logic simpler by pushing some patch to the library in the future 😉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified text input with smart suggestions for tables and commands and mode switching support.

* **Refactor**
  * Keyboard/Enter now acts on the top suggestion; command items and filtering render consistent suggestion-based values for more predictable navigation.

* **API**
  * Suggestion utilities re-exported for reuse.

* **Tests**
  * Added unit and integration tests for suggestion serialization/parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->