### PR TITLE
Fix PostgreSQL schema parser: add missing constraints merge in mergeSchema

### DIFF
--- a/frontend/packages/schema/src/parser/sql/postgresql/mergeSchemas.test.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/mergeSchemas.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { aSchema, aTable } from '../../../schema/factories.js'
+import { mergeSchemas } from './mergeSchemas.js'
+
+describe('mergeSchemas', () => {
+  it('should merge constraints correctly', () => {
+    const target = aSchema({
+      tables: {
+        users: aTable({
+          name: 'users',
+          constraints: {
+            users_email_key: {
+              name: 'users_email_key',
+              type: 'UNIQUE',
+              columnNames: ['email'],
+            },
+          },
+        }),
+      },
+    })
+
+    const source = aSchema({
+      tables: {
+        users: aTable({
+          name: 'users',
+          constraints: {
+            users_pkey: {
+              name: 'users_pkey',
+              type: 'PRIMARY KEY',
+              columnNames: ['id'],
+            },
+          },
+        }),
+      },
+    })
+
+    mergeSchemas(target, source)
+
+    // Both constraints should be preserved
+    expect(target.tables['users']?.constraints).toEqual({
+      users_email_key: {
+        name: 'users_email_key',
+        type: 'UNIQUE',
+        columnNames: ['email'],
+      },
+      users_pkey: {
+        name: 'users_pkey',
+        type: 'PRIMARY KEY',
+        columnNames: ['id'],
+      },
+    })
+  })
+
+  it('should merge multiple tables with constraints', () => {
+    const target = aSchema({
+      tables: {
+        users: aTable({
+          name: 'users',
+          constraints: {
+            users_email_key: {
+              name: 'users_email_key',
+              type: 'UNIQUE',
+              columnNames: ['email'],
+            },
+          },
+        }),
+        posts: aTable({
+          name: 'posts',
+        }),
+      },
+    })
+
+    const source = aSchema({
+      tables: {
+        users: aTable({
+          name: 'users',
+          constraints: {
+            users_pkey: {
+              name: 'users_pkey',
+              type: 'PRIMARY KEY',
+              columnNames: ['id'],
+            },
+          },
+        }),
+        posts: aTable({
+          name: 'posts',
+          constraints: {
+            posts_pkey: {
+              name: 'posts_pkey',
+              type: 'PRIMARY KEY',
+              columnNames: ['id'],
+            },
+          },
+        }),
+      },
+    })
+
+    mergeSchemas(target, source)
+
+    // All constraints should be preserved
+    expect(target.tables['users']?.constraints).toEqual({
+      users_email_key: {
+        name: 'users_email_key',
+        type: 'UNIQUE',
+        columnNames: ['email'],
+      },
+      users_pkey: {
+        name: 'users_pkey',
+        type: 'PRIMARY KEY',
+        columnNames: ['id'],
+      },
+    })
+
+    expect(target.tables['posts']?.constraints).toEqual({
+      posts_pkey: {
+        name: 'posts_pkey',
+        type: 'PRIMARY KEY',
+        columnNames: ['id'],
+      },
+    })
+  })
+})

--- a/frontend/packages/schema/src/parser/sql/postgresql/mergeSchemas.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/mergeSchemas.ts
@@ -13,6 +13,10 @@ export const mergeSchemas = (target: Schema, source: Schema) => {
         ...target.tables[tableName]?.indexes,
         ...table.indexes,
       },
+      constraints: {
+        ...target.tables[tableName]?.constraints,
+        ...table.constraints,
+      },
     }
   }
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5434

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

The PostgreSQL schema parser was losing PRIMARY KEY and other constraints when processing large schema files in chunks. When parsing the production schema.sql file with 33 PRIMARY KEY constraints, only 13 were preserved in the final output, causing significant data loss in the parsed schema representation. The root cause was in the mergeSchemas function, which explicitly merged columns and indexes fields but was missing the constraints field. This meant that when schemas were processed in chunks and merged together, constraint definitions from earlier chunks were being overwritten by later chunks that didn't have those constraints.


## Testing

### 📝 schema parser --> JSON

PRIMARY KEY constraints for tables that were not saved are now saved.

https://supabase.com/dashboard/project/qnzgmtrwbbrhotkothdg/editor/17956?schema=public

<img width="353" height="172" alt="ss 3793" src="https://github.com/user-attachments/assets/e85ae8e6-b76c-4531-8f1a-f80b9181cb2b" />


The PRIMARY KEY constraints of tables that were not displayed in the ERD View are now displayed.

<img width="1171" height="347" alt="ss 3792" src="https://github.com/user-attachments/assets/90c2a72f-0895-463e-a734-d564e90cd051" />

### 📝 In Liam DB

Debugging the combinedDDL value.
Before (liam's schema) and after (combinedDDL)

（The number of constraints in PRIMARY has been reduced by one because the prompt requested to “Delete the workflow_runs table and its foreign keys from the current schema.”）

<img width="1462" height="251" alt="ss 3790" src="https://github.com/user-attachments/assets/4492ae56-4581-4204-ac24-a5dfdd5ecdc5" />


You can also check it from the preview environment.
https://liam-app-git-fix-merge-schemas-constraints-re-liambx.vercel.app/app/design_sessions/d9356199-3255-464a-9410-878bef834e8f?deepModeling=true

<img width="784" height="193" alt="ss 3791" src="https://github.com/user-attachments/assets/ff6e3dc4-692f-48d3-ba88-6e29a70b7157" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Schema merging now preserves and combines per-table constraints, ensuring primary keys and unique constraints are retained across merged tables.

* Tests
  * Added unit tests covering constraint merging for single and multiple tables to validate expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->