### PR TITLE
fix: add onConflict parameter to prevent duplicate key errors in checkpoint operations

### DIFF
--- a/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.ts
@@ -303,7 +303,9 @@ export class SupabaseCheckpointSaver extends BaseCheckpointSaver<number> {
 
     const { error: checkpointError } = await this.client
       .from('checkpoints')
-      .upsert(checkpointInsert)
+      .upsert(checkpointInsert, {
+        onConflict: 'thread_id,checkpoint_ns,checkpoint_id,organization_id',
+      })
 
     if (checkpointError) {
       // BaseCheckpointSaver expects exceptions to be thrown
@@ -322,7 +324,9 @@ export class SupabaseCheckpointSaver extends BaseCheckpointSaver<number> {
     if (blobs.length > 0) {
       const { error: blobError } = await this.client
         .from('checkpoint_blobs')
-        .upsert(blobs)
+        .upsert(blobs, {
+          onConflict: 'thread_id,checkpoint_ns,channel,version,organization_id',
+        })
 
       if (blobError) {
         // BaseCheckpointSaver expects exceptions to be thrown
@@ -362,7 +366,10 @@ export class SupabaseCheckpointSaver extends BaseCheckpointSaver<number> {
     if (dumpedWrites.length > 0) {
       const { error } = await this.client
         .from('checkpoint_writes')
-        .upsert(dumpedWrites)
+        .upsert(dumpedWrites, {
+          onConflict:
+            'thread_id,checkpoint_ns,checkpoint_id,task_id,idx,organization_id',
+        })
 
       if (error) {
         // BaseCheckpointSaver expects exceptions to be thrown


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5447

## Why is this change needed?

Fixes duplicate key constraint violations in checkpoint_blobs table that occur during concurrent LangGraph workflow executions. The onConflict parameter ensures existing records are updated instead of throwing constraint violation errors.

## Summary

This PR adds the `onConflict` parameter to all upsert operations in the `SupabaseCheckpointSaver` class to properly handle concurrent checkpoint operations. Without this parameter, when multiple workflow instances try to save checkpoints simultaneously, PostgreSQL's unique constraints cause errors instead of updating existing records.

### Changes:
- Add `onConflict` parameter to checkpoints table upsert
- Add `onConflict` parameter to checkpoint_blobs table upsert
- Add `onConflict` parameter to checkpoint_writes table upsert

## Test Plan

The existing unit tests continue to pass. However, since the tests use MSW to mock HTTP responses, they cannot directly verify the `onConflict` behavior. The fix should be validated in staging/production environments where concurrent workflow executions occur.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of saving checkpoint data in multi-tenant environments.
  * Prevented rare cross-tenant conflicts that could cause duplicate or overwritten checkpoint records.
  * Enhanced data integrity for checkpoints, blobs, and write operations during concurrent updates.
  * Reduced sporadic save errors by tightening conflict resolution during upserts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->