### PR TITLE
fix: increase PGlite initial memory to prevent out of bounds error

### DIFF
--- a/frontend/packages/pglite-server/src/PGliteInstanceManager.ts
+++ b/frontend/packages/pglite-server/src/PGliteInstanceManager.ts
@@ -87,7 +87,9 @@ export class PGliteInstanceManager {
    * Creates a new PGlite instance for query execution
    */
   private async createInstance(): Promise<PGlite> {
-    return new PGlite()
+    return new PGlite({
+      initialMemory: 256 * 1024 * 1024, // 256MB initial memory allocation
+    })
   }
 
   /**


### PR DESCRIPTION
## Summary
- Increased PGlite initial memory allocation from default 16MB to 256MB
- Fixes WebAssembly memory access violations during Deep Modeling process
- Resolves runtime crashes in complex DDL/DML operations

## Issue
- resolve: https://github.com/route06/liam-internal/issues/5446

## Why is this change needed?
The default Emscripten memory allocation (16MB) was insufficient for handling large schema operations in the Deep Modeling process. This caused `RuntimeError: memory access out of bounds` when executing complex DDL/DML statements.

## Changes
- Modified `PGliteInstanceManager.ts` to explicitly set `initialMemory: 256MB` when creating PGlite instances
- This provides adequate memory headroom and avoids performance penalties from dynamic memory growth

## Testing
- ✅ Tested with `pnpm execute-deep-modeling` script
- ✅ Memory error no longer occurs
- ✅ Process runs successfully (previously crashed after ~2 minutes)

## Technical Details
- WebAssembly uses pages of 64KB as the memory allocation unit
- Default: 16MB (256 pages)
- New setting: 256MB (4,096 pages)
- PGlite can still grow memory automatically if needed, but starting with adequate memory prevents costly TypedArray copies during expansion

🤖 Generated with [Claude Code](https://claude.ai/code)