### PR TITLE
📝(claude): Add English requirement to update-pr-description command

### DIFF
--- a/.claude/commands/update-pr-description.md
+++ b/.claude/commands/update-pr-description.md
@@ -8,7 +8,9 @@ description: Update a pull request description to match the project's PR templat
 
 Update the specified pull request's description to follow the project's PR template format defined in @.github/pull_request_template.md.
 
-**IMPORTANT**: Always read the exact content of @.github/pull_request_template.md first to understand the current template structure. Do not assume the template contains sections that are not actually present.
+**IMPORTANT**:
+- Always read the exact content of @.github/pull_request_template.md first to understand the current template structure. Do not assume the template contains sections that are not actually present.
+- **Write all PR descriptions in English**. This is critical for project consistency.
 
 ### Steps
 


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This change adds an explicit instruction to the update-pr-description command to ensure that all PR descriptions are written in **English**. This is critical for maintaining project consistency and supporting international collaboration.

The instruction has been added as an important note in the command documentation to make it clear that English is required for all PR content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified PR description guidance by adding two bullets under the IMPORTANT section: read the current pull request template before writing, and write all PR descriptions in English for consistency.
  * Improved readability by adding a line break after the IMPORTANT heading.
  * No changes to features or behavior; this update only refines contributor instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->