### PR TITLE
🐛(pglite): Fix memory configuration for pg-query-emscripten and PGlite

### DIFF
--- a/frontend/packages/pglite-server/src/PGliteInstanceManager.ts
+++ b/frontend/packages/pglite-server/src/PGliteInstanceManager.ts
@@ -21,7 +21,12 @@ const getPgQueryInstance = (): ResultAsync<PgQueryInstance, Error> => {
   }
 
   return ResultAsync.fromPromise(
-    new Module(),
+    new Module({
+      wasmMemory: new WebAssembly.Memory({
+        initial: 2048, // 128MB (64KB × 2048 pages)
+        maximum: 4096, // 256MB max
+      }),
+    }),
     (error) => new Error(`Failed to initialize pg-query module: ${error}`),
   )
     .andThen((instance: unknown) => {
@@ -88,7 +93,7 @@ export class PGliteInstanceManager {
    */
   private async createInstance(): Promise<PGlite> {
     return new PGlite({
-      initialMemory: 256 * 1024 * 1024, // 256MB initial memory allocation
+      initialMemory: 2 * 1024 * 1024 * 1024, // 2GB initial memory allocation
     })
   }
 

--- a/frontend/packages/schema/src/parser/sql/postgresql/parser.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/parser.ts
@@ -4,7 +4,12 @@ import type { RawStmt } from '@pgsql/types'
 import Module from 'pg-query-emscripten'
 
 export const parse = async (str: string): Promise<ParseResult> => {
-  const pgQuery = await new Module()
+  const pgQuery = await new Module({
+    wasmMemory: new WebAssembly.Memory({
+      initial: 2048, // 128MB (64KB × 2048 pages)
+      maximum: 4096, // 256MB max
+    }),
+  })
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const result = pgQuery.parse(str)
   return result


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5450

## Why is this change needed?

This PR fixes memory allocation issues in both pg-query-emscripten (SQL parser) and PGlite (SQL execution engine) that were causing CI failures during the Deep Modeling process.

### Problem
1. **pg-query-emscripten**: Default WebAssembly memory was insufficient for parsing large SQL statements, causing "memory access out of bounds" errors
2. **PGlite**: Even after PR #3092 increased memory to 256MB, it was still insufficient for Deep Modeling's complex SQL operations

### Solution
1. **pg-query-emscripten**: Added explicit WebAssembly.Memory configuration with 128MB initial allocation
2. **PGlite**: Increased initial memory from 256MB to 2GB to handle large-scale SQL statements

### Technical Details
- pg-query-emscripten and PGlite are separate WebAssembly instances with independent memory spaces
- WebAssembly memory is managed in 64KB pages
- Both components needed memory adjustments due to the scale of SQL processed in Deep Modeling

This ensures the CI execute-deep-modeling script can complete successfully without memory errors.

### Note on CI Status
After resolving the memory errors, the CI now progresses further and reveals a different validation error related to DML execution logs parsing. This is a separate issue that was previously masked by the memory errors - the process would crash before reaching this validation step. The memory fix allows the process to proceed to the point where this pre-existing validation issue becomes visible.

```
Error parsing DML operations result: [
  {
    kind: 'schema',
    type: 'object',
    input: undefined,
    expected: '"dml_execution_logs"',
    received: 'undefined',
    message: 'Invalid key: Expected "dml_execution_logs" but received undefined',
    requirement: undefined,
    path: [ [Object], [Object], [Object] ],
    issues: undefined,
    lang: undefined,
    abortEarly: undefined,
    abortPipeEarly: undefined
  },
```