### PR TITLE
🐛(auth): Fix anonymous user access to artifacts table

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/hooks/useRealtimeArtifact.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/hooks/useRealtimeArtifact.ts
@@ -12,7 +12,6 @@ const artifactDataSchema = v.object({
   artifact: artifactSchema,
   created_at: v.string(),
   updated_at: v.string(),
-  organization_id: v.pipe(v.string(), v.uuid()),
 })
 
 export function useRealtimeArtifact(designSessionId: string) {
@@ -34,9 +33,7 @@ export function useRealtimeArtifact(designSessionId: string) {
     const { data, error: fetchError } = await supabase
       .from('artifacts')
       // Explicitly specify columns as anon user has grants on individual columns, not all columns
-      .select(
-        'id, design_session_id, artifact, created_at, updated_at, organization_id',
-      )
+      .select('id, design_session_id, artifact, created_at, updated_at')
       .eq('design_session_id', designSessionId)
       .maybeSingle()
 


### PR DESCRIPTION
## Issue

- resolve: route06/liam-internal#5466

## Why is this change needed?
Anonymous users were unable to access artifacts because the query included the organization_id column, which they don't have read permissions for. This fix removes the organization_id from both the schema validation and the SELECT query to allow anonymous users to view artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified artifact data handling in Session Details by removing an organization field from real-time data and initial fetch, aligning schema and parsing to a reduced field set.
- Chores
  - Updated internal queries to match the refined artifact data shape.
- Impact
  - No visible UI changes; artifact views and real-time updates continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->