### PR TITLE
fix(ui): Fix sidebar table list scroll issue

### DIFF
--- a/.changeset/plenty-bars-read.md
+++ b/.changeset/plenty-bars-read.md
@@ -1,0 +1,6 @@
+---
+"@liam-hq/erd-core": patch
+"@liam-hq/ui": patch
+---
+
+🐛 Fixed an issue where the last few tables in the sidebar were not visible when scrolling in schemas with 30-40 tables

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/LeftPane.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/LeftPane.module.css
@@ -40,6 +40,13 @@
   }
 }
 
+.tablesMenu {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding-bottom: var(--spacing-4);
+}
+
 .contentControls {
   padding: var(--spacing-2) 0;
   border-block: 1px solid var(--global-border);

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/LeftPane.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/LeftPane/LeftPane.tsx
@@ -159,7 +159,7 @@ export const LeftPane = () => {
             </span>
           </SidebarGroupLabel>
           <SidebarGroupContent>
-            <SidebarMenu>
+            <SidebarMenu className={styles.tablesMenu}>
               {tableNodes.map((node) => (
                 <TableNameMenuButton
                   key={node.id}

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -55,6 +55,7 @@
 .sidebarContent {
   flex: 1 1 0%;
   overflow-y: auto;
+  padding-bottom: var(--spacing-10);
 }
 
 .sidebarMenuItem {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5459

## Why is this change needed?

Fixed an issue where the last few tables in the sidebar were not visible when scrolling in schemas with 30-40 tables.

## Summary

This PR fixes a scrolling issue in the sidebar where the last 2 tables would not be visible for schemas with approximately 30-40 tables, while schemas with 99+ tables displayed correctly.

### Changes made:
- Added dedicated flex layout and scroll settings to the table list menu
- Increased sidebar content padding-bottom for complete visibility  
- Ensured proper scrolling behavior regardless of the number of tables

### Test URLs:
- Working (99 tables): https://liam-app-git-fix-sidebar-table-list-scroll-liambx.vercel.app/erd/p/github.com/mastodon/mastodon/blob/e2f085e2b2cec08dc1f5ae825730c2a3bf62e054/db/schema.rb

- Previously broken (30-40 tables): https://liam-app-git-fix-sidebar-table-list-scroll-liambx.vercel.app/erd/p/github.com/langfuse/langfuse/blob/cf29c6b7e447cf1aec7a8d50ae6a877c3844b7cd/packages/shared/prisma/schema.prisma
<img width="468" height="166" alt="ss 3801" src="https://github.com/user-attachments/assets/dbf3c2a0-ddf5-44aa-b816-5edf860a9e45" />

- Previously broken (30-40 tables): https://liam-app-git-fix-sidebar-table-list-scroll-liambx.vercel.app/erd/p/github.com/liam-hq/liam/blob/main/frontend/internal-packages/db/schema/schema.sql


<img width="473" height="225" alt="ss 3802" src="https://github.com/user-attachments/assets/a86f3060-5b5c-494b-836b-175ad82b45d7" />

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the last tables in the sidebar were not visible when scrolling in large schemas (30–40 tables).
  * Improved sidebar scroll behavior and layout to ensure full visibility of table lists.
  * Adjusted spacing within the sidebar content for clearer, more consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->