### PR TITLE
fix: PostgreSQL CHECK constraint parsing with chunk offset correction

### DIFF
--- a/frontend/packages/schema/src/parser/sql/postgresql/converter.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/converter.ts
@@ -195,7 +195,6 @@ const constraintToCheckConstraint = (
     return null
   }
 
-  // Use location-based approach with chunk offset correction
   const absoluteLocation = constraint.location + (chunkOffset || 0)
   const parentheses = findBalancedParentheses(rawSql, absoluteLocation)
 


### PR DESCRIPTION
## Summary

Fix PostgreSQL CHECK constraint parsing issues where constraint locations were relative to chunks but used against the full SQL text, causing malformed constraints like `CHECK (email)` instead of proper constraint expressions.

```json
"design_sessions_project_or_org_check": {
  "name": "design_sessions_project_or_org_check",
  "type": "CHECK",
  "detail": "email"
},
```

## Problem

When parsing large SQL files in chunks, CHECK constraints were being extracted incorrectly because:
- `constraint.location` was relative to the chunk (0-based within chunk)
- But the location was used to search in the full SQL text
- This caused extraction of wrong text content, leading to malformed CHECK constraints

## Solution

- Add `chunkOffset` parameter to `processSQLInChunks` callback
- Calculate absolute location using `constraint.location + chunkOffset`
- Propagate chunk offset through all PostgreSQL parsing functions
- Add test to verify chunk offset calculation for constraint parsing
- Remove unused fallback code for cleaner implementation

## Changes

### Core Fix
- **processSqlInChunks.ts**: Calculate character-based chunk offsets and pass to callback
- **converter.ts**: Use `absoluteLocation = constraint.location + chunkOffset` for accurate constraint extraction
- **index.ts**: Propagate chunk offset through parsing pipeline

### Testing
- **processSqlInChunks.test.ts**: Add test for chunk offset calculation verification
- Update existing tests to match new callback signature with chunk offset parameter

## Testing

In Liam's schema, the CHECK constraints for `design_sessions_project_or_org_check` and `validation_results_status_check` were incorrect.

`design_sessions_project_or_org_check`
<img width="1136" height="181" alt="ss 3803" src="https://github.com/user-attachments/assets/001bb205-74d2-4c6f-8761-f557ed4ac591" />

`validation_results_status_check`
<img width="1326" height="414" alt="ss 3804" src="https://github.com/user-attachments/assets/cf881c5b-8d57-4e7e-a7c0-771e712bcfa7" />


https://supabase.com/dashboard/project/pqoyorhmpsvezkctnohy/editor/17956?schema=public

### Liam DB Test

I was able to continue the design session without any errors.

https://liam-app-git-fix-postgresql-check-constraint-chun-c03a41-liambx.vercel.app/app/design_sessions/27bc9d41-175c-4cd5-af16-0cdab821b771?deepModeling=true


🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved PostgreSQL schema import with per-chunk position tracking so CHECK constraints are located correctly across chunked SQL inputs.

- Bug Fixes
  - Prevents crashes when CHECK constraint parentheses aren’t found; falls back to safe, generic names.
  - More stable handling of large or multi-statement SQL split across chunks.

- Tests
  - Expanded coverage validating chunk-offset propagation and CHECK constraint parsing across chunk boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->