### PR TITLE
Revert "chore(deps): update actions/create-github-app-token action to v2.1.0"

### DIFF
--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -19,7 +19,7 @@ jobs:
       issues: write
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ secrets.LIAM_CODE_ASSISTANT_APP_ID }}

--- a/.github/workflows/license-report-update.yml
+++ b/.github/workflows/license-report-update.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.LICENSE_CI_TRIGGER_APP_ID }}

--- a/.github/workflows/process-scheduled-issues.yml
+++ b/.github/workflows/process-scheduled-issues.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ secrets.LIAM_CODE_ASSISTANT_APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.CHANGESET_CI_TRIGGER_APP_ID }}


### PR DESCRIPTION
Reverts liam-hq/liam#3135

## why

- our action https://github.com/liam-hq/liam/actions/workflows/release.yml fails now 🙇 
   - maybe `#3135` ( or `#3144` ) will cause

<img width="992" height="616" alt="スクリーンショット 2025-08-25 10 03 50" src="https://github.com/user-attachments/assets/e328f3ad-e96d-47ea-a147-610dd7dcc8e8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to standardize the action used for generating GitHub App tokens across PR creation, license reporting, scheduled issue processing, and release automation.
  * Improves consistency and maintainability of automation and ensures predictable authentication during workflow runs.
  * No user-facing changes; existing build and release pipelines continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->