### PR TITLE
Revert "chore: enable automerge for lockfile maintenance in renovate"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,8 +7,7 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
+    "enabled": true
   },
   "minimumReleaseAge": "14 days",
   "schedule": ["* * * * 0,6"],


### PR DESCRIPTION
temp stop "auto-merging ` lockfile maintenance` "  for https://github.com/liam-hq/liam/pull/3148

Reverts liam-hq/liam#3050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency maintenance settings to disable automatic merging of lock file maintenance updates, requiring manual review and approval.
  * Enhances oversight and reduces risk from unattended dependency version changes; all other update rules remain unchanged.
  * No user-facing changes; functionality and schedules remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->