### PR TITLE
fix: prevent ToolbarIconButton text truncation in mobile toolbar

### DIFF
--- a/.changeset/dry-bugs-sip.md
+++ b/.changeset/dry-bugs-sip.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+🐛 Fixed collapsed toolbar buttons to display text properly in mobile view.

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/Toolbar/ToolbarIconButton/ToolbarIconButton.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/Toolbar/ToolbarIconButton/ToolbarIconButton.module.css
@@ -23,11 +23,13 @@
   display: flex;
   padding: var(--spacing-2, 8px) var(--spacing-1, 4px);
   align-items: center;
-  align-self: stretch;
+  align-self: flex-start;
   gap: var(--spacing-2, 8px);
   color: var(--global-foreground, #fff);
   font-size: var(--font-size-2, 11px);
   border-radius: var(--border-radius-base);
+  width: auto;
+  min-width: fit-content;
 }
 
 .menuButtonWithText:focus-visible {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5476

## Why is this change needed?

The `ToolbarIconButton` components in the mobile toolbar were appearing collapsed/truncated when they contained text content ("Zoom in", "Zoom out"). This was caused by the IconButton component's fixed width (1.5rem) overriding the ToolbarIconButton's attempt to expand for text content.

<img width="344" height="439" alt="ss 3813" src="https://github.com/user-attachments/assets/eece9f3a-60e8-4e93-9b8b-518c9404c188" />


## Changes

- Add `width: auto` and `min-width: fit-content` to `.menuButtonWithText` class
- Change `align-self` from `stretch` to `flex-start` for better layout behavior
- Ensures text content in toolbar buttons displays properly without truncation

🤖 Generated with [Claude Code](https://claude.ai/code)

## Testing

Confirmed on Chrome and Safari for mobile devices.


|  Chrome | Safari |
| ------------- | ------------- |
| <img width="400" height="1290" alt="IMG_0087" src="https://github.com/user-attachments/assets/463fbadc-4530-4359-89bf-074f41a505fb" />  | <img width="400" height="1289" alt="IMG_0088" src="https://github.com/user-attachments/assets/8eadb9bb-54b0-4a5b-ba86-6dec15a3910c" />  |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collapsed toolbar buttons with text now align to the start and size to their content, preventing them from stretching and fixing display issues on mobile and small screens.

* **Style**
  * Improved toolbar button spacing and visual consistency for icon+text buttons, reducing overflow and awkward gaps across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->