### PR TITLE
refactor: Extract common issue creation guidelines to shared file

### DIFF
--- a/.claude/commands/create-internal-issue.md
+++ b/.claude/commands/create-internal-issue.md
@@ -5,28 +5,17 @@ description: Create an issue in the route06/liam-internal repository
 ## Task
 Create a new issue in the route06/liam-internal repository using the GitHub CLI.
 
-### Process
-1. **Analyze the request**: First, understand the context and technical implications
-2. **Gather information**: If the issue involves technical implementation, think through:
-   - Current state vs desired state
-   - Technical requirements and dependencies
-   - Potential implementation approaches
-   - Impact and risks
-3. **Structure the issue**: Create a well-structured issue with:
-   - Clear title in Japanese
-   - Detailed body with background, requirements, and technical considerations
-   - Use proper markdown formatting
+Follow the general issue creation guidelines in @.claude/commands/create-issue.md with the following specific requirements:
 
-Use the `gh issue create --repo route06/liam-internal` command to create the issue.  
-Write both the issue title **and** body in Japanese.
+### Repository-Specific Requirements
+- **Repository**: `route06/liam-internal`
+- **Language**: Write both the issue title **and** body in Japanese
+- **Command**: Use `gh issue create --repo route06/liam-internal`
 
 ### Arguments
 $ARGUMENTS
 
-**Argument Handling**:
-- When arguments are provided: Create an issue based on the given content
-- When arguments are empty: Detect technical discussions from recent conversation and suggest creating an issue based on that context
-- When instructed to "create from conversation": Analyze conversation history to generate an issue
+See @.claude/commands/create-issue.md for argument handling guidelines.
 
 ### Examples
 - Simple issue: `/create-internal-issue "バグ: データベース接続タイムアウト"`
@@ -35,15 +24,5 @@ $ARGUMENTS
 - Empty args: `/create-internal-issue` (suggest auto-detection from conversation)
 
 ### Best Practices
-- **Argument validation**: When arguments are empty, first analyze available conversation context
-- **Conversation history utilization**: Auto-detect technical investigations, bug discoveries, refactoring proposals
-- **Research integration**: Use code investigation and search results as evidence for the issue
-- **Structured issues**: Include the following sections:
-  - Overview (problem summary)
-  - Current state (technical current situation)
-  - Investigation results (detailed research findings)
-  - Action items (specific work to be done)
-  - Impact analysis (risks and benefits)
-  - Technical considerations (implementation notes)
-- **Evidence documentation**: Include specific file paths, line numbers, and search results
+Follow the best practices in @.claude/commands/create-issue.md with special attention to:
 - **Cross-repository references**: When referencing PRs or issues from repositories other than route06/liam-internal (e.g., liam-hq/liam), use the full format `repository#number` (e.g., `liam-hq/liam#2991`) instead of just `#number` to ensure proper GitHub linking

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,40 @@
+---
+description: General guidelines for creating GitHub issues
+---
+
+## Task
+Create a new issue in a GitHub repository using the GitHub CLI.
+
+### Process
+1. **Analyze the request**: First, understand the context and technical implications
+2. **Gather information**: If the issue involves technical implementation, think through:
+   - Current state vs desired state
+   - Technical requirements and dependencies
+   - Potential implementation approaches
+   - Impact and risks
+3. **Structure the issue**: Create a well-structured issue with:
+   - Clear title
+   - Detailed body with background, requirements, and technical considerations
+   - Use proper markdown formatting
+
+### Arguments
+$ARGUMENTS
+
+**Argument Handling**:
+- When arguments are provided: Create an issue based on the given content
+- When arguments are empty: Detect technical discussions from recent conversation and suggest creating an issue based on that context
+- When instructed to "create from conversation": Analyze conversation history to generate an issue
+
+### Best Practices
+- **Argument validation**: When arguments are empty, first analyze available conversation context
+- **Conversation history utilization**: Auto-detect technical investigations, bug discoveries, refactoring proposals
+- **Research integration**: Use code investigation and search results as evidence for the issue
+- **Structured issues**: Include the following sections:
+  - Overview (problem summary)
+  - Current state (technical current situation)
+  - Investigation results (detailed research findings)
+  - Action items (specific work to be done)
+  - Impact analysis (risks and benefits)
+  - Technical considerations (implementation notes)
+- **Evidence documentation**: Include specific file paths, line numbers, and search results
+- **Cross-repository references**: When referencing PRs or issues from repositories other than the target repository, use the full format `repository#number` (e.g., `liam-hq/liam#2991`) instead of just `#number` to ensure proper GitHub linking


### PR DESCRIPTION
## Issue

- resolve: N/A (refactoring)

## Why is this change needed?

This change improves maintainability by extracting common issue creation guidelines that were duplicated in create-internal-issue.md into a new shared file create-issue.md. This follows the DRY principle and makes it easier to maintain consistent issue creation practices across different repository-specific commands.

## Changes

- Created `.claude/commands/create-issue.md` with general issue creation guidelines
- Updated `.claude/commands/create-internal-issue.md` to reference the shared guidelines while maintaining repository-specific requirements (Japanese language, route06/liam-internal repo)

🤖 Generated with [Claude Code](https://claude.ai/code)