### PR TITLE
fix(agent): Fix QA agent to use actual schema instead of hardcoded data

### DIFF
--- a/frontend/internal-packages/agent/scripts/executeQaAgent.ts
+++ b/frontend/internal-packages/agent/scripts/executeQaAgent.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env tsx
 
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 import { HumanMessage } from '@langchain/core/messages'
 import { END } from '@langchain/langgraph'
-import type { Schema } from '@liam-hq/schema'
 import type { Result } from 'neverthrow'
 import { err, ok, okAsync } from 'neverthrow'
 import { DEFAULT_RECURSION_LIMIT } from '../src/chat/workflow/shared/langGraphUtils'
 import type { WorkflowState } from '../src/chat/workflow/types'
 import { createQaAgentGraph } from '../src/qa-agent/createQaAgentGraph'
-import { hasHelpFlag, parseDesignProcessArgs } from './shared/argumentParser'
+import { hasHelpFlag, parseQaAgentArgs } from './shared/argumentParser'
 import {
   createLogger,
-  getBusinessManagementSystemUserInput,
   getLogLevel,
   type SetupDatabaseAndUserResult,
   setupDatabaseAndUser,
@@ -35,166 +35,35 @@ type CreateWorkflowStateInput = SetupDatabaseAndUserResult & {
 const createWorkflowState = (
   setupData: CreateWorkflowStateInput,
   customUserInput?: string,
-  _isResume = false,
 ) => {
   const { organization, buildingSchema, designSession, user } = setupData
 
-  // Sample schema with some tables for QA testing
-  const sampleSchema: Schema = {
-    tables: {
-      users: {
-        name: 'users',
-        columns: {
-          id: {
-            name: 'id',
-            type: 'uuid',
-            notNull: true,
-            default: 'gen_random_uuid()',
-            check: null,
-            comment: null,
-          },
-          email: {
-            name: 'email',
-            type: 'varchar(255)',
-            notNull: true,
-            default: null,
-            check: null,
-            comment: null,
-          },
-          name: {
-            name: 'name',
-            type: 'varchar(255)',
-            notNull: false,
-            default: null,
-            check: null,
-            comment: null,
-          },
-          created_at: {
-            name: 'created_at',
-            type: 'timestamp',
-            notNull: true,
-            default: 'now()',
-            check: null,
-            comment: null,
-          },
-        },
-        comment: null,
-        indexes: {},
-        constraints: {
-          users_pkey: {
-            type: 'PRIMARY KEY' as const,
-            name: 'users_pkey',
-            columnNames: ['id'],
-          },
-          users_email_key: {
-            type: 'UNIQUE' as const,
-            name: 'users_email_key',
-            columnNames: ['email'],
-          },
-        },
-      },
-      posts: {
-        name: 'posts',
-        columns: {
-          id: {
-            name: 'id',
-            type: 'uuid',
-            notNull: true,
-            default: 'gen_random_uuid()',
-            check: null,
-            comment: null,
-          },
-          user_id: {
-            name: 'user_id',
-            type: 'uuid',
-            notNull: true,
-            default: null,
-            check: null,
-            comment: null,
-          },
-          title: {
-            name: 'title',
-            type: 'varchar(255)',
-            notNull: true,
-            default: null,
-            check: null,
-            comment: null,
-          },
-          content: {
-            name: 'content',
-            type: 'text',
-            notNull: false,
-            default: null,
-            check: null,
-            comment: null,
-          },
-          created_at: {
-            name: 'created_at',
-            type: 'timestamp',
-            notNull: true,
-            default: 'now()',
-            check: null,
-            comment: null,
-          },
-        },
-        comment: null,
-        indexes: {},
-        constraints: {
-          posts_pkey: {
-            type: 'PRIMARY KEY' as const,
-            name: 'posts_pkey',
-            columnNames: ['id'],
-          },
-          posts_user_id_fkey: {
-            type: 'FOREIGN KEY' as const,
-            name: 'posts_user_id_fkey',
-            columnNames: ['user_id'],
-            targetTableName: 'users',
-            targetColumnNames: ['id'],
-            updateConstraint: 'NO_ACTION' as const,
-            deleteConstraint: 'CASCADE' as const,
-          },
-        },
-      },
-    },
-    enums: {},
-  }
+  // Load initial state from fixtures
+  const fixturePath = path.join(
+    __dirname,
+    'fixtures',
+    'qa-agent-initial-state.json',
+  )
+  const fixtureData = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'))
+  const {
+    userInput: defaultUserInput,
+    analyzedRequirements,
+    schemaData,
+  } = fixtureData
 
-  // Use custom user input if provided, otherwise use default
-  const userInput = customUserInput || getBusinessManagementSystemUserInput()
+  // Use custom user input if provided, otherwise use from fixture
+  const userInput = customUserInput || defaultUserInput
 
   const workflowState: WorkflowState = {
     userInput,
     messages: [new HumanMessage(userInput)],
-    schemaData: sampleSchema,
+    schemaData,
     buildingSchemaId: buildingSchema.id,
     latestVersionNumber: buildingSchema.latest_version_number,
     designSessionId: designSession.id,
     userId: user.id,
     organizationId: organization.id,
-    // Add analyzed requirements for QA agent
-    analyzedRequirements: {
-      businessRequirement: 'Test the user and posts management system',
-      functionalRequirements: {
-        'User Management': [
-          'Users can register with email and name',
-          'Users can create posts',
-          'Posts are linked to users',
-        ],
-        'Content Management': [
-          'Posts have title and content',
-          'Posts track creation time',
-          'Posts are deleted when user is deleted',
-        ],
-      },
-      nonFunctionalRequirements: {
-        'Data Integrity': [
-          'Email must be unique',
-          'User ID is required for posts',
-          'Cascade delete for referential integrity',
-        ],
-      },
-    },
+    analyzedRequirements,
     next: END,
   }
 
@@ -209,11 +78,10 @@ const createWorkflowState = (
  */
 const executeQaAgent = async (
   customPrompt?: string,
-  resumeSessionId?: string,
 ): Promise<Result<void, Error>> => {
   const setupResult = await validateEnvironment()
     .andThen(setupDatabaseAndUser(logger))
-    .andThen(findOrCreateDesignSession(resumeSessionId))
+    .andThen(findOrCreateDesignSession())
     .andThen((data) => createWorkflowState(data, customPrompt))
 
   if (setupResult.isErr()) return err(setupResult.error)
@@ -255,10 +123,9 @@ const executeQaAgent = async (
 
   logger.info('QA workflow completed')
 
-  // Log the session_id for future reference when resuming sessions
+  // Log the session_id for reference
   const sessionId = workflowState.designSessionId
   logger.info(`Session ID: ${sessionId}`)
-  logger.info(`To resume this session later, use: --session-id ${sessionId}`)
 
   return ok(undefined)
 }
@@ -266,7 +133,7 @@ const executeQaAgent = async (
 // Execute if this file is run directly
 if (require.main === module) {
   // Parse command line arguments
-  const { prompt, sessionId } = parseDesignProcessArgs()
+  const { prompt } = parseQaAgentArgs()
 
   // Show usage information
   if (hasHelpFlag()) {
@@ -275,14 +142,13 @@ if (require.main === module) {
       `Executes the QA agent workflow for database schema testing and validation.
   This script creates a QA session and runs the QA workflow including
   use case generation, DML preparation, and schema validation.
+  Uses pre-generated schema and requirements from fixtures.
 
   Additional Options:
-    --prompt, -p <text>     Custom prompt for the AI
-    --session-id, -s <id>   Resume from existing session (session ID)`,
+    --prompt, -p <text>     Custom prompt for the AI`,
       [
         'pnpm --filter @liam-hq/agent execute-qa-agent',
-        'pnpm --filter @liam-hq/agent execute-qa-agent --prompt "Test user management system"',
-        'pnpm --filter @liam-hq/agent execute-qa-agent --session-id abc-123 --prompt "Add more test cases"',
+        'pnpm --filter @liam-hq/agent execute-qa-agent --prompt "Test specific edge cases"',
         'pnpm --filter @liam-hq/agent execute-qa-agent:debug',
       ],
     )
@@ -291,7 +157,7 @@ if (require.main === module) {
 
   logger.info(`Starting QA agent execution (log level: ${currentLogLevel})`)
 
-  executeQaAgent(prompt, sessionId).then((result) => {
+  executeQaAgent(prompt).then((result) => {
     if (result.isErr()) {
       logger.error(`FAILED: ${result.error.message}`)
       process.exit(1)

--- a/frontend/internal-packages/agent/scripts/fixtures/qa-agent-initial-state.json
+++ b/frontend/internal-packages/agent/scripts/fixtures/qa-agent-initial-state.json
@@ -1,0 +1,1139 @@
+{
+  "userInput": "Design a business management system database with the following core requirements:\n\n1. **Organization Structure**:\n   - Hierarchical organizations with self-referencing parent-child relationships\n   - Each organization has a unique code and name\n\n2. **Position & Employee Management**:\n   - Position master table with unique position codes and names\n   - Employee master table with employee codes and names\n   - Employee affiliations linking employees to organizations and positions\n   - Support for reporting relationships (employees reporting to other employees)\n\n3. **Business Partner System**:\n   - Unified business partner table for both clients and suppliers\n   - Business partner categories with CHECK constraints (CLIENT/SUPPLIER)\n   - Client-specific data with order amounts from last year\n   - Supplier-specific data with procurement amounts from last year\n\n4. **Product Management**:\n   - Brand master table with unique brand names\n   - Item categories for product classification\n   - Items with manufacturer part numbers as primary keys\n   - Items linked to brands and categories\n   - Supplier-brand handling relationships\n\nPlease design a normalized database schema with proper primary keys, foreign key relationships, and constraints to support these business operations effectively.",
+  "analyzedRequirements": {
+    "businessRequirement": "Design a normalized relational database for a business management system that manages organizational hierarchy, positions and employees (with affiliations and reporting lines), unified business partners (categorized as CLIENT or SUPPLIER with last-year amounts), and product masters (brands, categories, items keyed by MPN) with clear primary keys, foreign keys, and constraints to ensure data integrity and auditability.",
+    "functionalRequirements": {
+      "Organization Structure": [
+        "Maintain Organization master with unique, immutable organization_code and unique organization_name.",
+        "Support hierarchical organizations via self-referencing parent-child relationship; allow a single root (parent null).",
+        "Prevent cyclic hierarchies (no organization may be an ancestor of itself).",
+        "Capture effectivity (start_date, end_date) for organizations; only one active record per organization_code at a time.",
+        "If an organization has child organizations or active employee affiliations, deletion must be prevented; use end-dating to deactivate.",
+        "Optional org_type reference data (e.g., COMPANY, DIVISION, DEPARTMENT, TEAM) stored in a lookup table and enforced via FK or CHECK."
+      ],
+      "Positions & Employees": [
+        "Maintain Position master with unique, immutable position_code and unique position_name.",
+        "Positions are global (not tied to a specific organization); effectivity (start_date, end_date) and active flag required.",
+        "Maintain Employee master with unique, immutable employee_code and employee_name; capture employment_status (ACTIVE, INACTIVE) via CHECK or lookup.",
+        "Employee records must exist before affiliations or reporting lines can reference them; deletion of employees with related records is prohibited (end-date instead)."
+      ],
+      "Employee Affiliations & Reporting": [
+        "Link employees to organizations and positions through an EmployeeAffiliation entity with effectivity (start_date, end_date).",
+        "For a given employee, enforce at most one primary active affiliation at any point in time; additional non-overlapping historical affiliations are allowed.",
+        "For a given employee + organization + position, date ranges must not overlap.",
+        "Affiliations require that referenced employee, organization, and position are active on the affiliation start_date.",
+        "Support employee reporting relationships via a self-referencing EmployeeReporting entity (employee -> manager) with effectivity dates.",
+        "Prevent circular reporting (no employee can ultimately report to themselves); allow cross-organization reporting.",
+        "If an employee\u2019s primary affiliation ends, the reporting relationship must also end or be re-established (consistency rule)."
+      ],
+      "Business Partners": [
+        "Maintain a unified BusinessPartner entity with unique, immutable partner_code and unique partner_name.",
+        "Enforce partner_category via CHECK IN ('CLIENT','SUPPLIER'); category is required and immutable after creation.",
+        "ClientProfile exists only for partners where partner_category='CLIENT' and must store last_year_order_amount (>= 0).",
+        "SupplierProfile exists only for partners where partner_category='SUPPLIER' and must store last_year_procurement_amount (>= 0).",
+        "Enforce mutual exclusivity: a CLIENT must not have SupplierProfile; a SUPPLIER must not have ClientProfile.",
+        "Amounts labeled \u201clast year\u201d are defined as the previous calendar year relative to the as_of_date stored with each profile record.",
+        "Prevent deletion of a BusinessPartner if role-specific profile or brand-handling relationships exist; use end-dating/active flag."
+      ],
+      "Product Management": [
+        "Maintain Brand master with unique brand_name; brand_name is immutable once created.",
+        "Maintain ItemCategory master with unique category_code and unique category_name; optional self-referencing parent_category to support hierarchical classification.",
+        "Items are identified by manufacturer_part_number (MPN) as the primary key (natural key); MPN must be unique and not null.",
+        "Each Item must reference exactly one Brand and one ItemCategory via foreign keys; both must exist and be active.",
+        "Maintain SupplierBrandHandling relationship that maps SUPPLIER partners to Brands with effectivity dates (start_date, end_date).",
+        "Enforce that SupplierBrandHandling can only reference partners where partner_category='SUPPLIER'.",
+        "Disallow deletion of Brand or Category when Items or SupplierBrandHandling rows reference them; use end-dating."
+      ],
+      "Data Integrity & Constraints": [
+        "All entities must define primary keys; all relationships must be enforced via foreign keys with referential integrity.",
+        "Use NOT NULL on mandatory business attributes (codes, names, categories, effectivity dates).",
+        "Define CHECK constraints for enumerations (e.g., partner_category, employment_status) and for non-negative monetary amounts.",
+        "Define uniqueness constraints exactly as specified: organization_code, organization_name; position_code, position_name; partner_code, partner_name; brand_name; category_code, category_name; item MPN.",
+        "Restrict cascading deletes; prefer logical deletion through end_date or active flags.",
+        "Disallow overlapping effectivity where business rules require single-active records (e.g., affiliations, reporting lines per employee)."
+      ],
+      "Audit & History": [
+        "Record created_at/created_by and updated_at/updated_by on all master and relationship tables.",
+        "Capture change reason on end-dating deactivations for auditability.",
+        "Maintain history for effectivity-based tables by inserting new rows rather than updating historical rows (immutable history)."
+      ],
+      "Security & Access": [
+        "Role-based access control (RBAC) for CRUD on masters and relationships (e.g., HR, Vendor Mgmt, Product Mgmt roles).",
+        "Restrict access to employee PII to authorized roles; partner financial amounts visible to Finance and authorized users only."
+      ],
+      "Reporting & Analytics": [
+        "Provide database views or query support to report: (a) organization tree with roll-ups, (b) active headcount per org, (c) client last_year_order_amount by partner, (d) supplier last_year_procurement_amount by partner, and (e) suppliers per brand.",
+        "Enable traversal of reporting lines (employee-to-manager chain) for current and historical dates."
+      ],
+      "Data Quality & Governance": [
+        "Codes are immutable after creation; names changeable but must remain unique where required.",
+        "Validate that dates are valid (start_date <= end_date) and monetary amounts are numeric and >= 0.",
+        "Deduplication rule: prevent insertion of records with codes/names that would violate uniqueness ignoring leading/trailing whitespace."
+      ]
+    },
+    "nonFunctionalRequirements": {
+      "Normalization": [
+        "Logical model must be normalized to at least 3rd Normal Form (3NF) to reduce redundancy and update anomalies."
+      ],
+      "Performance": [
+        "Key lookups (by code, MPN, or PK) should return within 300 ms at P95 under expected load.",
+        "Complex joins across up to 1M rows (e.g., supplier-brand handling with item/brand/category) should complete within 2 seconds at P95."
+      ],
+      "Scalability": [
+        "Target data volumes: up to 10,000 organizations, 100,000 employees, 100,000 business partners, 50,000 brands/categories combined, and 1,000,000 items.",
+        "Design must support horizontal read scalability via indexing on codes, names, FK columns, and effectivity date ranges."
+      ],
+      "Security": [
+        "Enforce least-privilege access; encrypt data in transit (TLS) and at rest per organizational standards.",
+        "Audit tables/columns must not expose sensitive data to unauthorized roles."
+      ],
+      "Reliability & Backup": [
+        "Backups daily with RPO <= 24 hours and RTO <= 4 hours for the database.",
+        "Referential integrity must prevent orphaned records in all relationships (0 tolerance)."
+      ],
+      "Availability": [
+        "Planned maintenance windows must not exceed 4 hours per month; unplanned downtime <= 99.5% monthly availability target."
+      ],
+      "Auditability & Compliance": [
+        "All create/update/delete operations must be traceable via audit columns and history strategy for effectivity tables.",
+        "Retain historical data for at least 7 years or per organizational policy, whichever is greater."
+      ],
+      "Usability (Data Consumers)": [
+        "Provide clear, human-readable codes/names and reference data lookups for all enumerations to simplify reporting and integration."
+      ],
+      "Operability": [
+        "Provide seed/reference data scripts for enumerations (e.g., partner_category, employment_status, org_type) and validation routines for effectivity overlaps."
+      ]
+    }
+  },
+  "schemaData": {
+    "tables": {
+      "organizations": {
+        "name": "organizations",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "org_code": {
+            "name": "org_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique organization code"
+          },
+          "org_name": {
+            "name": "org_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique organization name"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "parent_org_id": {
+            "name": "parent_org_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Parent organization reference"
+          }
+        },
+        "comment": "Organization master with hierarchical self-reference",
+        "indexes": {
+          "idx_organizations_parent": {
+            "name": "idx_organizations_parent",
+            "unique": false,
+            "columns": ["parent_org_id"],
+            "type": "BTREE"
+          }
+        },
+        "constraints": {
+          "pk_organizations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_organizations",
+            "columnNames": ["id"]
+          },
+          "uq_organizations_code": {
+            "type": "UNIQUE",
+            "name": "uq_organizations_code",
+            "columnNames": ["org_code"]
+          },
+          "uq_organizations_name": {
+            "type": "UNIQUE",
+            "name": "uq_organizations_name",
+            "columnNames": ["org_name"]
+          },
+          "fk_organizations_parent": {
+            "type": "FOREIGN KEY",
+            "name": "fk_organizations_parent",
+            "columnNames": ["parent_org_id"],
+            "targetTableName": "organizations",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "ck_organizations_parent_not_self": {
+            "type": "CHECK",
+            "name": "ck_organizations_parent_not_self",
+            "detail": "(parent_org_id IS NULL OR parent_org_id <> id)"
+          }
+        }
+      },
+      "positions": {
+        "name": "positions",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "position_code": {
+            "name": "position_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique position code"
+          },
+          "position_name": {
+            "name": "position_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique position name"
+          }
+        },
+        "comment": "Position master",
+        "indexes": {},
+        "constraints": {
+          "pk_positions": {
+            "type": "PRIMARY KEY",
+            "name": "pk_positions",
+            "columnNames": ["id"]
+          },
+          "uq_positions_code": {
+            "type": "UNIQUE",
+            "name": "uq_positions_code",
+            "columnNames": ["position_code"]
+          },
+          "uq_positions_name": {
+            "type": "UNIQUE",
+            "name": "uq_positions_name",
+            "columnNames": ["position_name"]
+          }
+        }
+      },
+      "employees": {
+        "name": "employees",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "employee_code": {
+            "name": "employee_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique employee code"
+          },
+          "employee_name": {
+            "name": "employee_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee full name"
+          }
+        },
+        "comment": "Employee master",
+        "indexes": {},
+        "constraints": {
+          "pk_employees": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employees",
+            "columnNames": ["id"]
+          },
+          "uq_employees_code": {
+            "type": "UNIQUE",
+            "name": "uq_employees_code",
+            "columnNames": ["employee_code"]
+          }
+        }
+      },
+      "employee_affiliations": {
+        "name": "employee_affiliations",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "end_date": {
+            "name": "end_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Affiliation end date"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "is_primary": {
+            "name": "is_primary",
+            "type": "boolean",
+            "default": false,
+            "check": null,
+            "notNull": true,
+            "comment": "Whether primary affiliation"
+          },
+          "start_date": {
+            "name": "start_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Affiliation start date"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "employee_id": {
+            "name": "employee_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References employees"
+          },
+          "position_id": {
+            "name": "position_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References positions"
+          },
+          "organization_id": {
+            "name": "organization_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References organizations"
+          }
+        },
+        "comment": "Links employees to organizations and positions with effectivity",
+        "indexes": {
+          "idx_emp_aff_org": {
+            "name": "idx_emp_aff_org",
+            "unique": false,
+            "columns": ["organization_id"],
+            "type": "BTREE"
+          },
+          "idx_emp_aff_employee": {
+            "name": "idx_emp_aff_employee",
+            "unique": false,
+            "columns": ["employee_id"],
+            "type": "BTREE"
+          },
+          "idx_emp_aff_position": {
+            "name": "idx_emp_aff_position",
+            "unique": false,
+            "columns": ["position_id"],
+            "type": "BTREE"
+          }
+        },
+        "constraints": {
+          "fk_emp_aff_org": {
+            "type": "FOREIGN KEY",
+            "name": "fk_emp_aff_org",
+            "columnNames": ["organization_id"],
+            "targetTableName": "organizations",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "ck_emp_aff_dates": {
+            "type": "CHECK",
+            "name": "ck_emp_aff_dates",
+            "detail": "(end_date IS NULL OR start_date <= end_date)"
+          },
+          "fk_emp_aff_employee": {
+            "type": "FOREIGN KEY",
+            "name": "fk_emp_aff_employee",
+            "columnNames": ["employee_id"],
+            "targetTableName": "employees",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_emp_aff_position": {
+            "type": "FOREIGN KEY",
+            "name": "fk_emp_aff_position",
+            "columnNames": ["position_id"],
+            "targetTableName": "positions",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "pk_employee_affiliations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employee_affiliations",
+            "columnNames": ["id"]
+          },
+          "uq_emp_aff_emp_org_pos_start": {
+            "type": "UNIQUE",
+            "name": "uq_emp_aff_emp_org_pos_start",
+            "columnNames": [
+              "employee_id",
+              "organization_id",
+              "position_id",
+              "start_date"
+            ]
+          }
+        }
+      },
+      "employee_reporting": {
+        "name": "employee_reporting",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "end_date": {
+            "name": "end_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Reporting end date"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "start_date": {
+            "name": "start_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Reporting start date"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "employee_id": {
+            "name": "employee_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee who reports"
+          },
+          "manager_employee_id": {
+            "name": "manager_employee_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Manager employee"
+          }
+        },
+        "comment": "Employee reporting relationships (employee -> manager) with effectivity",
+        "indexes": {
+          "idx_emp_rep_manager": {
+            "name": "idx_emp_rep_manager",
+            "unique": false,
+            "columns": ["manager_employee_id"],
+            "type": "BTREE"
+          },
+          "idx_emp_rep_employee": {
+            "name": "idx_emp_rep_employee",
+            "unique": false,
+            "columns": ["employee_id"],
+            "type": "BTREE"
+          }
+        },
+        "constraints": {
+          "ck_emp_rep_dates": {
+            "type": "CHECK",
+            "name": "ck_emp_rep_dates",
+            "detail": "(end_date IS NULL OR start_date <= end_date)"
+          },
+          "fk_emp_rep_manager": {
+            "type": "FOREIGN KEY",
+            "name": "fk_emp_rep_manager",
+            "columnNames": ["manager_employee_id"],
+            "targetTableName": "employees",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "ck_emp_rep_not_self": {
+            "type": "CHECK",
+            "name": "ck_emp_rep_not_self",
+            "detail": "(employee_id <> manager_employee_id)"
+          },
+          "fk_emp_rep_employee": {
+            "type": "FOREIGN KEY",
+            "name": "fk_emp_rep_employee",
+            "columnNames": ["employee_id"],
+            "targetTableName": "employees",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "pk_employee_reporting": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employee_reporting",
+            "columnNames": ["id"]
+          },
+          "uq_emp_rep_emp_mgr_start": {
+            "type": "UNIQUE",
+            "name": "uq_emp_rep_emp_mgr_start",
+            "columnNames": ["employee_id", "manager_employee_id", "start_date"]
+          }
+        }
+      },
+      "business_partners": {
+        "name": "business_partners",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "category": {
+            "name": "category",
+            "type": "text",
+            "default": null,
+            "check": "(category IN ('CLIENT','SUPPLIER'))",
+            "notNull": true,
+            "comment": "Partner category: CLIENT or SUPPLIER"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "partner_code": {
+            "name": "partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique business partner code"
+          },
+          "partner_name": {
+            "name": "partner_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique business partner name"
+          }
+        },
+        "comment": "Unified business partner master for clients and suppliers",
+        "indexes": {},
+        "constraints": {
+          "uq_bp_code": {
+            "type": "UNIQUE",
+            "name": "uq_bp_code",
+            "columnNames": ["partner_code"]
+          },
+          "uq_bp_name": {
+            "type": "UNIQUE",
+            "name": "uq_bp_name",
+            "columnNames": ["partner_name"]
+          },
+          "pk_business_partners": {
+            "type": "PRIMARY KEY",
+            "name": "pk_business_partners",
+            "columnNames": ["id"]
+          }
+        }
+      },
+      "client_profiles": {
+        "name": "client_profiles",
+        "columns": {
+          "as_of_year": {
+            "name": "as_of_year",
+            "type": "integer",
+            "default": null,
+            "check": "(as_of_year >= 1900)",
+            "notNull": true,
+            "comment": "Calendar year for the amount (e.g., 2024 for 'last year')"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "partner_id": {
+            "name": "partner_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References business_partners (CLIENT)"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "last_year_order_amount": {
+            "name": "last_year_order_amount",
+            "type": "numeric(18,2)",
+            "default": "0",
+            "check": "(last_year_order_amount >= 0)",
+            "notNull": true,
+            "comment": "Client last year order amount"
+          }
+        },
+        "comment": "Client-specific profile data",
+        "indexes": {},
+        "constraints": {
+          "pk_client_profiles": {
+            "type": "PRIMARY KEY",
+            "name": "pk_client_profiles",
+            "columnNames": ["partner_id"]
+          },
+          "fk_client_profiles_partner": {
+            "type": "FOREIGN KEY",
+            "name": "fk_client_profiles_partner",
+            "columnNames": ["partner_id"],
+            "targetTableName": "business_partners",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "supplier_profiles": {
+        "name": "supplier_profiles",
+        "columns": {
+          "as_of_year": {
+            "name": "as_of_year",
+            "type": "integer",
+            "default": null,
+            "check": "(as_of_year >= 1900)",
+            "notNull": true,
+            "comment": "Calendar year for the amount (e.g., 2024 for 'last year')"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "partner_id": {
+            "name": "partner_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References business_partners (SUPPLIER)"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "last_year_procurement_amount": {
+            "name": "last_year_procurement_amount",
+            "type": "numeric(18,2)",
+            "default": "0",
+            "check": "(last_year_procurement_amount >= 0)",
+            "notNull": true,
+            "comment": "Supplier last year procurement amount"
+          }
+        },
+        "comment": "Supplier-specific profile data",
+        "indexes": {},
+        "constraints": {
+          "pk_supplier_profiles": {
+            "type": "PRIMARY KEY",
+            "name": "pk_supplier_profiles",
+            "columnNames": ["partner_id"]
+          },
+          "fk_supplier_profiles_partner": {
+            "type": "FOREIGN KEY",
+            "name": "fk_supplier_profiles_partner",
+            "columnNames": ["partner_id"],
+            "targetTableName": "business_partners",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "brands": {
+        "name": "brands",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "brand_name": {
+            "name": "brand_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique brand name"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          }
+        },
+        "comment": "Brand master",
+        "indexes": {},
+        "constraints": {
+          "pk_brands": {
+            "type": "PRIMARY KEY",
+            "name": "pk_brands",
+            "columnNames": ["id"]
+          },
+          "uq_brand_name": {
+            "type": "UNIQUE",
+            "name": "uq_brand_name",
+            "columnNames": ["brand_name"]
+          }
+        }
+      },
+      "item_categories": {
+        "name": "item_categories",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "category_code": {
+            "name": "category_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique category code"
+          },
+          "category_name": {
+            "name": "category_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique category name"
+          },
+          "parent_category_id": {
+            "name": "parent_category_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Parent category reference"
+          }
+        },
+        "comment": "Item category master with optional hierarchy",
+        "indexes": {
+          "idx_item_categories_parent": {
+            "name": "idx_item_categories_parent",
+            "unique": false,
+            "columns": ["parent_category_id"],
+            "type": "BTREE"
+          }
+        },
+        "constraints": {
+          "pk_item_categories": {
+            "type": "PRIMARY KEY",
+            "name": "pk_item_categories",
+            "columnNames": ["id"]
+          },
+          "uq_item_categories_code": {
+            "type": "UNIQUE",
+            "name": "uq_item_categories_code",
+            "columnNames": ["category_code"]
+          },
+          "uq_item_categories_name": {
+            "type": "UNIQUE",
+            "name": "uq_item_categories_name",
+            "columnNames": ["category_name"]
+          },
+          "fk_item_categories_parent": {
+            "type": "FOREIGN KEY",
+            "name": "fk_item_categories_parent",
+            "columnNames": ["parent_category_id"],
+            "targetTableName": "item_categories",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "ck_item_cat_parent_not_self": {
+            "type": "CHECK",
+            "name": "ck_item_cat_parent_not_self",
+            "detail": "(parent_category_id IS NULL OR parent_category_id <> id)"
+          }
+        }
+      },
+      "items": {
+        "name": "items",
+        "columns": {
+          "brand_id": {
+            "name": "brand_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References brands"
+          },
+          "item_name": {
+            "name": "item_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Item name/title"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          },
+          "category_id": {
+            "name": "category_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References item_categories"
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Natural key MPN"
+          }
+        },
+        "comment": "Items keyed by manufacturer part number, linked to brand and category",
+        "indexes": {
+          "idx_items_brand": {
+            "name": "idx_items_brand",
+            "unique": false,
+            "columns": ["brand_id"],
+            "type": "BTREE"
+          },
+          "idx_items_category": {
+            "name": "idx_items_category",
+            "unique": false,
+            "columns": ["category_id"],
+            "type": "BTREE"
+          }
+        },
+        "constraints": {
+          "pk_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_items",
+            "columnNames": ["manufacturer_part_number"]
+          },
+          "fk_items_brand": {
+            "type": "FOREIGN KEY",
+            "name": "fk_items_brand",
+            "columnNames": ["brand_id"],
+            "targetTableName": "brands",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_items_category": {
+            "type": "FOREIGN KEY",
+            "name": "fk_items_category",
+            "columnNames": ["category_id"],
+            "targetTableName": "item_categories",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "supplier_brand_handling": {
+        "name": "supplier_brand_handling",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Primary key"
+          },
+          "brand_id": {
+            "name": "brand_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References brands"
+          },
+          "end_date": {
+            "name": "end_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Handling end date"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp"
+          },
+          "partner_id": {
+            "name": "partner_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "References business_partners (SUPPLIER)"
+          },
+          "start_date": {
+            "name": "start_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Handling start date"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Last update timestamp"
+          }
+        },
+        "comment": "Supplier-brand handling relationships with effectivity",
+        "indexes": {
+          "idx_sbh_brand": {
+            "name": "idx_sbh_brand",
+            "unique": false,
+            "columns": ["brand_id"],
+            "type": "BTREE"
+          },
+          "idx_sbh_partner": {
+            "name": "idx_sbh_partner",
+            "unique": false,
+            "columns": ["partner_id"],
+            "type": "BTREE"
+          }
+        },
+        "constraints": {
+          "ck_sbh_dates": {
+            "type": "CHECK",
+            "name": "ck_sbh_dates",
+            "detail": "(end_date IS NULL OR start_date <= end_date)"
+          },
+          "fk_sbh_brand": {
+            "type": "FOREIGN KEY",
+            "name": "fk_sbh_brand",
+            "columnNames": ["brand_id"],
+            "targetTableName": "brands",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_sbh_partner": {
+            "type": "FOREIGN KEY",
+            "name": "fk_sbh_partner",
+            "columnNames": ["partner_id"],
+            "targetTableName": "business_partners",
+            "targetColumnNames": ["id"],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "pk_supplier_brand_handling": {
+            "type": "PRIMARY KEY",
+            "name": "pk_supplier_brand_handling",
+            "columnNames": ["id"]
+          },
+          "uq_sbh_partner_brand_start": {
+            "type": "UNIQUE",
+            "name": "uq_sbh_partner_brand_start",
+            "columnNames": ["partner_id", "brand_id", "start_date"]
+          }
+        }
+      }
+    },
+    "enums": {}
+  }
+}

--- a/frontend/internal-packages/agent/scripts/shared/argumentParser.ts
+++ b/frontend/internal-packages/agent/scripts/shared/argumentParser.ts
@@ -68,6 +68,25 @@ export const parseDesignProcessArgs = (): {
 }
 
 /**
+ * Parse command line arguments for QA agent (without session-id)
+ */
+export const parseQaAgentArgs = (): { prompt?: string } => {
+  const args = process.argv.slice(2)
+  const result: { prompt?: string } = {}
+
+  for (let i = 0; i < args.length; i++) {
+    // Parse prompt
+    const promptResult = parseArgValue(args, i, 'prompt', 'p')
+    if (promptResult.value !== undefined) {
+      result.prompt = promptResult.value
+      if (promptResult.skip) i++
+    }
+  }
+
+  return result
+}
+
+/**
  * Check if help flag is present
  */
 export const hasHelpFlag = (): boolean => {

--- a/frontend/internal-packages/agent/scripts/shared/argumentParser.ts
+++ b/frontend/internal-packages/agent/scripts/shared/argumentParser.ts
@@ -71,6 +71,7 @@ export const parseDesignProcessArgs = (): {
  * Parse command line arguments for QA agent (without session-id)
  */
 export const parseQaAgentArgs = (): { prompt?: string } => {
+  // skip Node exec path and script path, only keep user-provided args
   const args = process.argv.slice(2)
   const result: { prompt?: string } = {}
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5480

## Why is this change needed?

The QA agent was using hardcoded blog schema (users/posts tables) instead of the actual schema generated from user requirements. This made the QA validation meaningless as it was testing against incorrect data.

## Changes

### 1. Created new argument parser for QA agent
- Added `parseQaAgentArgs()` function that only accepts `--prompt` option
- Removed session-id support to simplify the workflow

### 2. Refactored executeQaAgent.ts
- Removed hardcoded `sampleSchema` with blog tables
- Removed hardcoded `analyzedRequirements`
- Removed session resumption logic and parameters
- Added fixture loading from `qa-agent-initial-state.json`
- Updated help text to reflect the simplified workflow

### 3. Added fixture data
- Created `scripts/fixtures/qa-agent-initial-state.json` with:
  - Real business management system requirements
  - Analyzed requirements from PM agent
  - Generated schema from DB agent (organizations, employees, positions, business partners, products)

## Test plan

- [x] Run `pnpm execute-qa-agent` and verify it uses business management schema
- [x] Verify QA agent generates test cases for the correct schema
- [x] Check that validation errors relate to actual business entities, not blog posts

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - QA Agent can initialize from a predefined fixture to run deterministic, reproducible sessions.
  - CLI argument parsing added to accept prompt input directly.

- **Improvements**
  - Streaming output now delivers incremental results during execution.
  - Simplified CLI: use --prompt / -p; session-resume options removed.
  - Clearer logging and explicit success confirmation.
  - Returns a clear error if no result is produced.

- **Documentation**
  - Updated CLI help and usage examples to match fixture-based initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->