### PR TITLE
Fix pg-query-emscripten serverless compatibility

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -39,7 +39,7 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  serverExternalPackages: ['@electric-sql/pglite'],
+  serverExternalPackages: ['@electric-sql/pglite', 'pg-query-emscripten'],
   webpack: (config) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (Array.isArray(config.externals)) {

--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -39,7 +39,7 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  serverExternalPackages: ['@electric-sql/pglite', 'pg-query-emscripten'],
+  serverExternalPackages: ['@electric-sql/pglite', 'libpg-query'],
   webpack: (config) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (Array.isArray(config.externals)) {


### PR DESCRIPTION
## Issue

- ref: https://github.com/route06/liam-internal/issues/5426#issuecomment-3219187896

## Why is this change needed?

In production (Vercel), the system was experiencing DDL execution validation failures with errors like:
```
Error: DDL execution validation failed: SQL: CREATE TYPE "category_enum" AS ENUM (...), Error: {"error":"The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of URL"}
```

This occurred because `pg-query-emscripten` wasn't included in `serverExternalPackages`, causing WebAssembly bundling issues in serverless environments.

## Changes

- Add `pg-query-emscripten` to `serverExternalPackages` in `next.config.ts`
- This prevents Next.js from trying to bundle the WebAssembly module, allowing it to run properly in Vercel's serverless environment

## Testing

- [x] Local development continues to work
- [x] All tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated server-side configuration to include an additional runtime dependency for database query handling, improving compatibility during server rendering and builds. This reduces potential build-time errors and enhances stability across environments. No functional or UI changes for end users; deployments should be smoother with fewer configuration workarounds required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->