### PR TITLE
✨ Add Streaming Support to `leadAgent`

### DIFF
--- a/frontend/apps/app/package.json
+++ b/frontend/apps/app/package.json
@@ -9,6 +9,7 @@
     "@codemirror/merge": "6.10.2",
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "6.38.1",
+    "@langchain/core": "0.3.72",
     "@lezer/highlight": "1.2.1",
     "@liam-hq/agent": "workspace:*",
     "@liam-hq/artifact": "workspace:*",

--- a/frontend/internal-packages/agent/src/lead-agent/classifyMessage/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/classifyMessage/index.ts
@@ -1,4 +1,9 @@
-import { SystemMessage } from '@langchain/core/messages'
+import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
+import {
+  AIMessage,
+  AIMessageChunk,
+  SystemMessage,
+} from '@langchain/core/messages'
 import type { RunnableConfig } from '@langchain/core/runnables'
 import { END } from '@langchain/langgraph'
 import { ToolNode } from '@langchain/langgraph/prebuilt'
@@ -25,14 +30,50 @@ export async function classifyMessage(
 ): Promise<Partial<LeadAgentState>> {
   const invoke = ResultAsync.fromThrowable(
     (configurable: WorkflowConfigurable) => {
-      return model.invoke([new SystemMessage(prompt), ...state.messages], {
+      return model.stream([new SystemMessage(prompt), ...state.messages], {
         configurable,
       })
     },
     (error) => (error instanceof Error ? error : new Error(String(error))),
   )
 
-  const result = await getConfigurable(config).asyncAndThen(invoke)
+  const result = await getConfigurable(config)
+    .asyncAndThen(invoke)
+    .andThen((stream) => {
+      return ResultAsync.fromPromise(
+        (async () => {
+          // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
+          // so we overwrite with a UUID to unify chunk ids for consistent handling.
+          const id = crypto.randomUUID()
+          let accumulatedChunk: AIMessageChunk | null = null
+
+          for await (const _chunk of stream) {
+            const chunk = new AIMessageChunk({ ..._chunk, id, name: 'lead' })
+            await dispatchCustomEvent('messages', chunk)
+
+            // Accumulate chunks using concat method
+            accumulatedChunk = accumulatedChunk
+              ? accumulatedChunk.concat(chunk)
+              : chunk
+          }
+
+          // Convert the final accumulated chunk to AIMessage
+          const response = accumulatedChunk
+            ? new AIMessage({
+                content: accumulatedChunk.content,
+                additional_kwargs: accumulatedChunk.additional_kwargs,
+                ...(accumulatedChunk.tool_calls && {
+                  tool_calls: accumulatedChunk.tool_calls,
+                }),
+                ...(accumulatedChunk.name && { name: accumulatedChunk.name }),
+              })
+            : new AIMessage('')
+
+          return response
+        })(),
+        (error) => (error instanceof Error ? error : new Error(String(error))),
+      )
+    })
 
   if (result.isErr()) {
     throw new WorkflowTerminationError(result.error, 'classifyMessage')

--- a/frontend/internal-packages/agent/src/pm-agent/invokePmAnalysisAgent.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/invokePmAnalysisAgent.ts
@@ -62,10 +62,13 @@ export const invokePmAnalysisAgent = (
   return formatPrompt.andThen(invoke).andThen((stream) => {
     return ResultAsync.fromPromise(
       (async () => {
+        // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
+        // so we overwrite with a UUID to unify chunk ids for consistent handling.
+        const id = crypto.randomUUID()
         let accumulatedChunk: AIMessageChunk | null = null
 
         for await (const _chunk of stream) {
-          const chunk = new AIMessageChunk({ ..._chunk, name: 'pm' })
+          const chunk = new AIMessageChunk({ ..._chunk, id, name: 'pm' })
           await dispatchCustomEvent('messages', chunk)
 
           // Accumulate chunks using concat method

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@codemirror/view':
         specifier: 6.38.1
         version: 6.38.1
+      '@langchain/core':
+        specifier: 0.3.72
+        version: 0.3.72(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@5.12.2(ws@8.18.3)(zod@3.25.76))
       '@lezer/highlight':
         specifier: 1.2.1
         version: 1.2.1
@@ -777,7 +780,7 @@ importers:
         version: 8.2.0
       nuqs:
         specifier: 2.4.3
-        version: 2.4.3(next@15.3.5(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 2.4.3(next@15.3.5(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       pako:
         specifier: 2.1.0
         version: 2.1.0
@@ -10298,7 +10301,7 @@ packages:
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -18491,7 +18494,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.11.0(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.11.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -20029,7 +20032,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.4.3(next@15.3.5(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  nuqs@2.4.3(next@15.3.5(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       mitt: 3.0.1
       react: 19.1.1
@@ -21136,7 +21139,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.11.0(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.11.0):
     dependencies:
       axios: 1.11.0(debug@4.4.1)
 


### PR DESCRIPTION
## Issue

- N/A (no tracked issue)

## Summary

This pull request **adds native streaming support for `leadAgent`**.  
It builds directly on the functionality introduced in **[PR #3121](https://github.com/liam-hq/liam/pull/3121)**—already merged into `main`—by making that implementation streaming-compatible.

> **Commits:** All commits in this PR relate exclusively to the new streaming logic.

## Why is this change needed?

- **Real-time UX** – Streaming delivers incremental tokens, reducing perceived latency and aligning `leadAgent` with our other agents.  
- **Feature parity with #3121** – The work in #3121 handled only non-streaming paths; this PR completes the feature set.

## Test

<img width="808" height="864" alt="スクリーンショット 2025-08-25 17 48 04" src="https://github.com/user-attachments/assets/c64e0d92-9fcb-4bd8-888a-57469dddb2a4" />

