### PR TITLE
Fix WebAssembly URL path errors in serverless environments

### DIFF
--- a/frontend/packages/schema/src/parser/sql/postgresql/parser.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/parser.ts
@@ -18,6 +18,10 @@ export const parse = async (str: string): Promise<PgParseResult> => {
       initial: 2048, // 128MB (64KB × 2048 pages)
       maximum: 4096, // 256MB max
     }),
+    locateFile: (path: string, prefix: string) => {
+      // Fixes URL object type errors in serverless environments
+      return String(prefix) + path
+    },
   })
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const result = pgQuery.parse(filteredStr)


### PR DESCRIPTION
## Issue

Resolves DDL execution validation failures in Vercel production environment caused by WebAssembly URL path resolution issues.

## Why is this change needed?

In production (Vercel), the system was experiencing DDL execution validation failures with errors like:
```
Error: DDL execution validation failed: SQL: CREATE TYPE "category_enum" AS ENUM (...), Error: {"error":"The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of URL"}
```

This occurred because `pg-query-emscripten`'s Module constructor receives URL objects in serverless environments, but expects string paths.

## Changes

- Add `locateFile` option to `pg-query-emscripten` Module initialization
- Use `String(prefix) + path` to convert URL objects to strings in all environments
- Maintains WebAssembly memory configuration for optimal performance

## Solution Approach

Instead of using `serverExternalPackages` configuration, this solution addresses the root cause by ensuring proper path resolution in the WebAssembly module itself. The `locateFile` function handles both:
- Local development (where `prefix` is already a string)
- Vercel serverless (where `prefix` can be a URL object)

## Testing

- [x] Local development continues to work
- [x] All tests pass
- [x] Linting passes
- [x] WebAssembly memory optimization preserved

🤖 Generated with [Claude Code](https://claude.ai/code)