### PR TITLE
✨ Add tool calls extraction for AI message display

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/AiMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/AiMessage.tsx
@@ -7,6 +7,7 @@ import { MarkdownContent } from '@/components/MarkdownContent'
 import { CopyButton } from '@/components/SessionDetailPage/components/CopyButton'
 import { extractReasoningFromMessage } from '../utils/extractReasoningFromMessage'
 import { extractResponseFromMessage } from '../utils/extractResponseFromMessage'
+import { extractToolCallsFromMessage } from '../utils/extractToolCallsFromMessage'
 import { DBAgent, PMAgent, QAAgent } from './AgentAvatar'
 import styles from './AiMessage.module.css'
 import { ReasoningMessage } from './ReasoningMessage'
@@ -40,6 +41,7 @@ export const AiMessage: FC<Props> = ({ message }) => {
   const { avatar, name } = getAgentInfo(message.name)
   const messageContentString = extractResponseFromMessage(message)
   const reasoningText = extractReasoningFromMessage(message)
+  const toolCalls = extractToolCallsFromMessage(message)
 
   return (
     <div className={styles.wrapper}>
@@ -50,19 +52,21 @@ export const AiMessage: FC<Props> = ({ message }) => {
       <div className={styles.contentContainer}>
         <div className={styles.messagesWrapper}>
           {reasoningText && <ReasoningMessage content={reasoningText} />}
-          <div className={styles.responseMessageWrapper}>
-            <div className={styles.markdownWrapper}>
-              <MarkdownContent content={messageContentString} />
+          {messageContentString !== '' && (
+            <div className={styles.responseMessageWrapper}>
+              <div className={styles.markdownWrapper}>
+                <MarkdownContent content={messageContentString} />
+              </div>
+              <div className={styles.copyButtonWrapper}>
+                <CopyButton
+                  textToCopy={messageContentString}
+                  tooltipLabel="Copy message"
+                  size="sm"
+                />
+              </div>
             </div>
-            <div className={styles.copyButtonWrapper}>
-              <CopyButton
-                textToCopy={messageContentString}
-                tooltipLabel="Copy message"
-                size="sm"
-              />
-            </div>
-          </div>
-          <ToolCalls toolCalls={message.tool_calls} />
+          )}
+          <ToolCalls toolCalls={toolCalls} />
         </div>
       </div>
     </div>

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.module.css
@@ -5,75 +5,48 @@
   gap: 0.5rem;
 }
 
+.title {
+  font-size: var(--font-size-4);
+  color: var(--global-body-text);
+}
+
 .toolCall {
-  border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
+  display: grid;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  border: 1px solid var(--pane-border);
+  border-radius: var(--border-radius-md);
+  background-color: var(--pane-background);
   overflow: hidden;
 }
 
-.header {
-  border-bottom: 1px solid var(--color-border);
-  background-color: var(--color-card);
-  padding: 0.5rem 1rem;
+.toolCallTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
 }
 
-.title {
-  color: var(--color-foreground);
-  font-weight: 500;
+.icon {
+  width: 1rem;
+  height: 1rem;
 }
 
-.id {
-  background-color: var(--color-muted);
-  margin-left: 0.5rem;
-  border-radius: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
+.functionName {
+  font-size: var(--font-size-4);
 }
 
-.table {
-  min-width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
+.args {
+  display: grid;
+  gap: var(--spacing-2);
 }
 
-.table tbody {
-  border-top: 1px solid var(--color-border);
+.argTitle {
+  font-size: var(--font-size-2);
 }
 
-.tableRow {
-  border-bottom: 1px solid var(--color-border);
-}
-
-.tableRow:last-child {
-  border-bottom: none;
-}
-
-.keyCell {
-  color: var(--color-foreground);
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.valueCell {
-  color: var(--color-foreground-secondary);
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-}
-
-.complexValue {
-  background-color: var(--color-muted-secondary);
-  border-radius: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  font-family: monospace;
-  font-size: 0.875rem;
-  word-break: break-all;
-}
-
-.emptyArgs {
-  color: var(--color-foreground-secondary);
-  display: block;
-  padding: 0.75rem;
-  font-size: 0.875rem;
+.argCode {
+  padding: var(--spacing-2);
+  border-radius: var(--border-radius-base);
+  background-color: var(--pane-muted-background);
+  font-size: var(--font-size-2);
 }

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.tsx
@@ -1,66 +1,40 @@
-import type { AIMessage } from '@langchain/langgraph-sdk'
+import { Wrench } from 'lucide-react'
 import type { FC } from 'react'
+import type { ToolCalls as ToolCallsType } from '../../schema'
 import styles from './ToolCalls.module.css'
 
-function isComplexValue(value: unknown): boolean {
-  return Array.isArray(value) || (typeof value === 'object' && value !== null)
-}
-
 type Props = {
-  toolCalls: AIMessage['tool_calls']
+  toolCalls: ToolCallsType
 }
 
 /**
- * TODO: Design Request
+ * TODO: Design Improvement
  *
- * ## Component Overview
- * Tool Execution History Cards - Visualizes the external tools/functions called by AI during task execution
+ * ## Current Implementation
+ * Displays tool calls made by AI during conversation with basic styling
  *
- * ## Display Elements
- * 1. Tool Name - Name of the executed function (e.g., search_database, analyze_data)
- * 2. Execution ID - Unique identifier for traceability (optional)
- * 3. Parameter List - Arguments passed to the tool in key-value format
- *    - Simple values: Display as plain text
- *    - Complex values (arrays/objects): Display as formatted JSON
+ * ## Areas for Enhancement
+ * 1. Visual Design - Improve card appearance and spacing
+ * 2. Icon System - Add specific icons for different tool types
+ * 3. Argument Display - Better formatting for JSON arguments
  */
 export const ToolCalls: FC<Props> = ({ toolCalls }) => {
-  if (!toolCalls || toolCalls.length === 0) return null
+  if (toolCalls.length === 0) return null
 
   return (
     <div className={styles.container}>
+      <div className={styles.title}>Tool Calls ({toolCalls.length})</div>
       {toolCalls.map((tc, _idx) => {
-        const args = tc.args
-        const hasArgs = Object.keys(args).length > 0
         return (
-          <div key={tc.name} className={styles.toolCall}>
-            <div className={styles.header}>
-              <h3 className={styles.title}>
-                {tc.name}
-                {tc.id && <code className={styles.id}>{tc.id}</code>}
-              </h3>
+          <div key={tc.id} className={styles.toolCall}>
+            <div className={styles.toolCallTitle}>
+              <Wrench className={styles.icon} />
+              <p className={styles.functionName}>{tc.function.name}</p>
             </div>
-            {hasArgs ? (
-              <table className={styles.table}>
-                <tbody>
-                  {Object.entries(args).map(([key, value]) => (
-                    <tr key={key} className={styles.tableRow}>
-                      <td className={styles.keyCell}>{key}</td>
-                      <td className={styles.valueCell}>
-                        {isComplexValue(value) ? (
-                          <code className={styles.complexValue}>
-                            {JSON.stringify(value, null, 2)}
-                          </code>
-                        ) : (
-                          String(value)
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            ) : (
-              <code className={styles.emptyArgs}>{'{}'}</code>
-            )}
+            <div className={styles.args}>
+              <span className={styles.argTitle}>ARGUMENTS</span>
+              <code className={styles.argCode}>{tc.function.arguments}</code>
+            </div>
           </div>
         )
       })}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/schema.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/schema.ts
@@ -1,0 +1,31 @@
+import * as v from 'valibot'
+
+const summaryItemSchema = v.object({
+  type: v.literal('summary_text'),
+  text: v.string(),
+  index: v.number(),
+})
+
+const reasoningSchema = v.object({
+  id: v.string(),
+  type: v.literal('reasoning'),
+  summary: v.array(summaryItemSchema),
+})
+
+const toolCallSchema = v.object({
+  id: v.string(),
+  type: v.literal('function'),
+  index: v.number(),
+  function: v.object({
+    arguments: v.string(),
+    name: v.string(),
+  }),
+})
+
+const toolCallsSchema = v.array(toolCallSchema)
+export type ToolCalls = v.InferOutput<typeof toolCallsSchema>
+
+export const additionalKwargsSchema = v.object({
+  reasoning: v.optional(reasoningSchema),
+  tool_calls: v.optional(toolCallsSchema),
+})

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/utils/extractReasoningFromMessage.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/utils/extractReasoningFromMessage.ts
@@ -1,21 +1,6 @@
 import type { Message } from '@langchain/langgraph-sdk'
 import * as v from 'valibot'
-
-const summaryItemSchema = v.object({
-  type: v.literal('summary_text'),
-  text: v.string(),
-  index: v.number(),
-})
-
-const reasoningSchema = v.object({
-  id: v.string(),
-  type: v.literal('reasoning'),
-  summary: v.array(summaryItemSchema),
-})
-
-const additionalKwargsSchema = v.object({
-  reasoning: v.optional(reasoningSchema),
-})
+import { additionalKwargsSchema } from '../schema'
 
 export function extractReasoningFromMessage(message: Message): string | null {
   const parsed = v.safeParse(additionalKwargsSchema, message.additional_kwargs)

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/utils/extractToolCallsFromMessage.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/utils/extractToolCallsFromMessage.ts
@@ -1,0 +1,10 @@
+import type { Message } from '@langchain/langgraph-sdk'
+import * as v from 'valibot'
+import { additionalKwargsSchema, type ToolCalls } from '../schema'
+
+export function extractToolCallsFromMessage(message: Message): ToolCalls {
+  const parsed = v.safeParse(additionalKwargsSchema, message.additional_kwargs)
+  if (!parsed.success || parsed.output.tool_calls === undefined) return []
+
+  return parsed.output.tool_calls
+}


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This PR extracts tool call information from AI messages and improves the display of tool calls in the chat interface. The changes separate schema definitions into a shared module and create a dedicated utility for extracting tool calls, making the codebase more maintainable and type-safe.


### Changes made:
1. **Schema extraction**: Moved message parsing schemas to a shared `schema.ts` file
2. **Tool calls utility**: Created `extractToolCallsFromMessage` utility for parsing tool calls from messages
3. **Type safety**: Defined `ToolCalls` type for better type safety across components
4. **UI improvements**: Simplified the ToolCalls component with cleaner styling and layout
5. **Conditional rendering**: Response messages now only render when content exists

### Technical details:
- Uses Valibot for runtime type validation of tool calls
- Follows existing patterns from `extractReasoningFromMessage`
- Maintains consistency with the existing message architecture

## Test

https://github.com/user-attachments/assets/32cdfe82-ad05-45c4-9b56-10417e3f83e3


