### PR TITLE
🐛 Fix agent name parsing and Lead Agent support in AiMessage

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/AiMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/AiMessage.tsx
@@ -1,5 +1,4 @@
 import type { AIMessage } from '@langchain/langgraph-sdk'
-import type { Database } from '@liam-hq/db'
 import type { FC } from 'react'
 import { match } from 'ts-pattern'
 import * as v from 'valibot'
@@ -13,9 +12,7 @@ import styles from './AiMessage.module.css'
 import { ReasoningMessage } from './ReasoningMessage'
 import { ToolCalls } from './ToolCalls'
 
-const agentRoleSchema: v.GenericSchema<
-  Database['public']['Enums']['assistant_role_enum']
-> = v.picklist(['db', 'pm', 'qa'])
+const agentRoleSchema = v.picklist(['db', 'pm', 'qa', 'lead'])
 
 const getAgentInfo = (name: string | undefined) => {
   const parsed = v.safeParse(agentRoleSchema, name)
@@ -23,14 +20,18 @@ const getAgentInfo = (name: string | undefined) => {
     return { avatar: <DBAgent />, name: 'DB Agent' }
   }
 
-  return match(parsed.output)
-    .with('db', () => ({
-      avatar: <DBAgent />,
-      name: 'DB Agent',
-    }))
-    .with('pm', () => ({ avatar: <PMAgent />, name: 'PM Agent' }))
-    .with('qa', () => ({ avatar: <QAAgent />, name: 'QA Agent' }))
-    .exhaustive()
+  return (
+    match(parsed.output)
+      .with('db', () => ({
+        avatar: <DBAgent />,
+        name: 'DB Agent',
+      }))
+      .with('pm', () => ({ avatar: <PMAgent />, name: 'PM Agent' }))
+      .with('qa', () => ({ avatar: <QAAgent />, name: 'QA Agent' }))
+      // TODO: Prepare <LeadAgent />
+      .with('lead', () => ({ avatar: <QAAgent />, name: 'Lead Agent' }))
+      .exhaustive()
+  )
 }
 
 type Props = {

--- a/frontend/apps/app/components/SessionDetailPage/hooks/useStream/useStream.ts
+++ b/frontend/apps/app/components/SessionDetailPage/hooks/useStream/useStream.ts
@@ -74,7 +74,10 @@ export const useStream = () => {
           if (index === undefined) {
             newMessages.push(message)
           } else {
-            newMessages[index] = message
+            newMessages[index] = {
+              ...prev[index],
+              ...message,
+            }
           }
 
           return newMessages


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This PR fixes two issues in the AiMessage component:

1. **Agent name parsing bug**: The `getAgentInfo` function was incorrectly returning DB Agent for all agent types due to a logic error
2. **Lead Agent support**: Added support for the new Lead Agent role in the streaming messages

### Changes made:
- Fixed message state preservation during streaming updates to maintain agent name and other properties
- Extended `agentRoleSchema` to include 'lead' role
- Added temporary Lead Agent display (currently using QA Agent avatar with TODO for dedicated component)
- Cleaned up unused Database type import

### Technical details:
The streaming update was replacing the entire message object instead of merging, which caused the agent name to be lost and default to DB Agent. This has been fixed by properly merging the incoming updates with existing state.


## Test

| Before | After |
|--------|--------|
| <img width="852" height="994" alt="スクリーンショット 2025-08-26 14 04 07" src="https://github.com/user-attachments/assets/3945a190-e81b-40b0-98fa-fbe7aea21159" /> | <img width="853" height="994" alt="スクリーンショット 2025-08-26 13 59 17" src="https://github.com/user-attachments/assets/d7f7fbbf-5bf2-4efe-a54c-180678c56408" /> |
