### PR TITLE
♻️ Move CtaBar styles to dedicated module CSS file

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/ChatInput/ChatInput.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/ChatInput/ChatInput.module.css
@@ -5,33 +5,6 @@
   padding: var(--spacing-2);
 }
 
-.ctaBar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-3) var(--spacing-4);
-  background-color: var(--primary-accent);
-  border-radius: var(--border-radius-base);
-  color: var(--global-foreground);
-}
-
-.ctaText {
-  font-size: var(--font-size-3);
-  font-weight: var(--font-weight-medium);
-}
-
-.ctaButton {
-  background-color: white !important;
-  color: var(--primary-accent) !important;
-  border: 1px solid transparent !important;
-  font-weight: var(--font-weight-medium);
-}
-
-.ctaButton:hover {
-  background-color: rgba(255, 255, 255, 0.9) !important;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
 .inputContainer {
   display: flex;
   align-items: flex-end;

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/ChatInput/CtaBar.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/ChatInput/CtaBar.module.css
@@ -1,0 +1,26 @@
+.ctaBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3) var(--spacing-4);
+  background-color: var(--primary-accent);
+  border-radius: var(--border-radius-base);
+  color: var(--global-foreground);
+}
+
+.ctaText {
+  font-size: var(--font-size-3);
+  font-weight: var(--font-weight-medium);
+}
+
+.ctaButton {
+  background-color: white !important;
+  color: var(--primary-accent) !important;
+  border: 1px solid transparent !important;
+  font-weight: var(--font-weight-medium);
+}
+
+.ctaButton:hover {
+  background-color: rgba(255, 255, 255, 0.9) !important;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/ChatInput/CtaBar.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/ChatInput/CtaBar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@liam-hq/ui'
 import type { FC } from 'react'
-import styles from './ChatInput.module.css'
+import styles from './CtaBar.module.css'
 
 type Props = {
   onSignUpClick: () => void

--- a/frontend/apps/app/eslint-suppressions.json
+++ b/frontend/apps/app/eslint-suppressions.json
@@ -209,7 +209,7 @@
   },
   "components/SessionDetailPage/components/Chat/components/ChatInput/ChatInput.module.css": {
     "css-modules-kit/no-unused-class-names": {
-      "count": 5
+      "count": 1
     }
   },
   "components/SessionDetailPage/components/Chat/components/ChatInput/ChatInput.tsx": {


### PR DESCRIPTION
## Issue

- ref. https://github.com/liam-hq/liam/pull/3124#discussion_r2297418734
- resolve: N/A (Code review feedback)

## Why is this change needed?

As suggested in PR review comments, the styles used in the CtaBar component should be moved to their own module CSS file (`CtaBar.module.css`) for better component encapsulation and maintainability, rather than importing styles from `ChatInput.module.css`.

This change improves code organization by ensuring each component manages its own styles.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes.
- Refactor
  - Moved chat input call-to-action (CTA) styling into a dedicated module for cleaner separation and easier maintenance without changing behavior.
- Style
  - Aligned CTA styling with design tokens for consistent colors, spacing, and typography; preserved existing hover and visual treatments.
- Chores
  - Updated lint suppression counts related to unused CSS class names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->