### PR TITLE
🐛(pglite): Add test case and improve error messages for PGlite transaction abort issue

### DIFF
--- a/frontend/internal-packages/agent/src/qa-agent/validateSchema/formatValidationErrors.test.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/validateSchema/formatValidationErrors.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from 'vitest'
+import { formatValidationErrors } from './formatValidationErrors'
+import type { TestcaseDmlExecutionResult } from './types'
+
+describe('formatValidationErrors', () => {
+  it('should format single error with single operation', () => {
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'Test Insert Operation',
+        success: false,
+        executedOperations: 1,
+        failedOperations: [
+          {
+            sql: "INSERT INTO users (id, name) VALUES (1, 'John')",
+            error: 'duplicate key value violates unique constraint',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 1 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** Test Insert Operation
+      ### 1. Error: \`duplicate key value violates unique constraint\`
+      Statement:
+      \`\`\`sql
+      INSERT INTO users (id, name) VALUES (1, 'John')
+      \`\`\`"
+    `)
+  })
+
+  it('should format multiple errors in single test case', () => {
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'Complex Transaction Test',
+        success: false,
+        executedOperations: 3,
+        failedOperations: [
+          {
+            sql: "INSERT INTO accounts (id) VALUES ('invalid-uuid')",
+            error: 'invalid input syntax for type uuid',
+          },
+          {
+            sql: "UPDATE accounts SET balance = 100 WHERE id = 'invalid-uuid'",
+            error:
+              'current transaction is aborted, commands ignored until end of transaction block',
+          },
+          {
+            sql: "DELETE FROM accounts WHERE id = 'invalid-uuid'",
+            error:
+              'current transaction is aborted, commands ignored until end of transaction block',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 1 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** Complex Transaction Test
+      ### 1. Error: \`invalid input syntax for type uuid\`
+      Statement:
+      \`\`\`sql
+      INSERT INTO accounts (id) VALUES ('invalid-uuid')
+      \`\`\`
+
+      ### 2. Error: \`current transaction is aborted, commands ignored until end of transaction block\`
+      Statement:
+      \`\`\`sql
+      UPDATE accounts SET balance = 100 WHERE id = 'invalid-uuid'
+      \`\`\`
+
+      ### 3. Error: \`current transaction is aborted, commands ignored until end of transaction block\`
+      Statement:
+      \`\`\`sql
+      DELETE FROM accounts WHERE id = 'invalid-uuid'
+      \`\`\`"
+    `)
+  })
+
+  it('should format errors from multiple test cases', () => {
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'First Test Case',
+        success: false,
+        executedOperations: 1,
+        failedOperations: [
+          {
+            sql: 'INSERT INTO table1 VALUES (1)',
+            error: 'table1 does not exist',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+      {
+        testCaseId: 'test-2',
+        testCaseTitle: 'Second Test Case',
+        success: true,
+        executedOperations: 2,
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+      {
+        testCaseId: 'test-3',
+        testCaseTitle: 'Third Test Case',
+        success: false,
+        executedOperations: 1,
+        failedOperations: [
+          {
+            sql: 'UPDATE table2 SET col = 1',
+            error: 'permission denied',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 2 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** First Test Case
+      ### 1. Error: \`table1 does not exist\`
+      Statement:
+      \`\`\`sql
+      INSERT INTO table1 VALUES (1)
+      \`\`\`
+
+      ## ❌ **Test Case:** Third Test Case
+      ### 1. Error: \`permission denied\`
+      Statement:
+      \`\`\`sql
+      UPDATE table2 SET col = 1
+      \`\`\`"
+    `)
+  })
+
+  it('should truncate long SQL statements', () => {
+    const longSql = `INSERT INTO very_long_table_name_with_many_columns (
+      column1, column2, column3, column4, column5, column6, column7, column8,
+      column9, column10, column11, column12, column13, column14, column15,
+      column16, column17, column18, column19, column20, column21, column22,
+      column23, column24, column25, column26, column27, column28, column29,
+      column30, column31, column32, column33, column34, column35
+    ) VALUES (
+      'value1', 'value2', 'value3', 'value4', 'value5', 'value6', 'value7',
+      'value8', 'value9', 'value10', 'value11', 'value12', 'value13'
+    )`
+
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'Long SQL Test',
+        success: false,
+        executedOperations: 1,
+        failedOperations: [
+          {
+            sql: longSql,
+            error: 'syntax error',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 1 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** Long SQL Test
+      ### 1. Error: \`syntax error\`
+      Statement:
+      \`\`\`sql
+      INSERT INTO very_long_table_name_with_many_columns (
+            column1, column2, column3, column4, column5, column6, column7, column8,
+            column9, column10, column11, column12, column13, column14, column15,
+            column16, column17, column18, column19, column20, column21, column22,
+            column23, co...
+      \`\`\`"
+    `)
+  })
+
+  it('should preserve comment lines in SQL', () => {
+    const sqlWithComments = `-- This is a comment
+    INSERT INTO users (id, name) VALUES (1, 'John');
+    -- Another comment
+    UPDATE users SET active = true WHERE id = 1;`
+
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'SQL with Comments',
+        success: false,
+        executedOperations: 1,
+        failedOperations: [
+          {
+            sql: sqlWithComments,
+            error: 'some error',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 1 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** SQL with Comments
+      ### 1. Error: \`some error\`
+      Statement:
+      \`\`\`sql
+      -- This is a comment
+          INSERT INTO users (id, name) VALUES (1, 'John');
+          -- Another comment
+          UPDATE users SET active = true WHERE id = 1;
+      \`\`\`"
+    `)
+  })
+
+  it('should handle empty failed operations array', () => {
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'Test with empty failures',
+        success: false,
+        executedOperations: 0,
+        failedOperations: [],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 1 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** Test with empty failures"
+    `)
+  })
+
+  it('should return success message when all tests pass', () => {
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'Successful Test 1',
+        success: true,
+        executedOperations: 5,
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+      {
+        testCaseId: 'test-2',
+        testCaseTitle: 'Successful Test 2',
+        success: true,
+        executedOperations: 3,
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(
+      `"Database validation complete: all checks passed successfully"`,
+    )
+  })
+
+  it('should handle special characters in error messages', () => {
+    const results: TestcaseDmlExecutionResult[] = [
+      {
+        testCaseId: 'test-1',
+        testCaseTitle: 'Test with Special Characters',
+        success: false,
+        executedOperations: 1,
+        failedOperations: [
+          {
+            sql: "INSERT INTO test VALUES ('data')",
+            error: 'Error with `backticks` and "quotes" and \'single quotes\'',
+          },
+        ],
+        executedAt: new Date('2024-01-01T00:00:00Z'),
+      },
+    ]
+
+    const formatted = formatValidationErrors(results)
+
+    expect(formatted).toMatchInlineSnapshot(`
+      "Database validation found 1 issues. Please fix the following errors:
+
+      ## ❌ **Test Case:** Test with Special Characters
+      ### 1. Error: \`Error with \`backticks\` and "quotes" and 'single quotes'\`
+      Statement:
+      \`\`\`sql
+      INSERT INTO test VALUES ('data')
+      \`\`\`"
+    `)
+  })
+})

--- a/frontend/internal-packages/agent/src/qa-agent/validateSchema/formatValidationErrors.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/validateSchema/formatValidationErrors.ts
@@ -1,0 +1,50 @@
+import type { FailedOperation, TestcaseDmlExecutionResult } from './types'
+
+function formatSqlForDisplay(sql: string, maxLength = 300): string {
+  const cleanSql = sql.trim()
+
+  if (cleanSql.length > maxLength) {
+    return `${cleanSql.substring(0, maxLength)}...`
+  }
+  return cleanSql
+}
+
+function formatFailedOperations(failedOperations: FailedOperation[]): string {
+  return failedOperations
+    .map((op, index) => {
+      let details = `### ${index + 1}. Error: \`${op.error}\`\n`
+      details += 'Statement:\n'
+      details += '```sql\n'
+      details += formatSqlForDisplay(op.sql)
+      details += '\n```'
+      return details
+    })
+    .join('\n\n')
+}
+
+export function formatValidationErrors(
+  testcaseExecutionResults: TestcaseDmlExecutionResult[],
+): string {
+  const failedResults = testcaseExecutionResults.filter(
+    (result) => !result.success,
+  )
+
+  if (failedResults.length === 0) {
+    return 'Database validation complete: all checks passed successfully'
+  }
+
+  const errorCount = failedResults.length
+  const errorDetails = failedResults
+    .map((result) => {
+      let details = `## ❌ **Test Case:** ${result.testCaseTitle}`
+
+      if (result.failedOperations && result.failedOperations.length > 0) {
+        details += `\n${formatFailedOperations(result.failedOperations)}`
+      }
+
+      return details
+    })
+    .join('\n\n')
+
+  return `Database validation found ${errorCount} issues. Please fix the following errors:\n\n${errorDetails}`
+}

--- a/frontend/internal-packages/agent/src/qa-agent/validateSchema/types.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/validateSchema/types.ts
@@ -1,0 +1,13 @@
+export type FailedOperation = {
+  sql: string
+  error: string
+}
+
+export type TestcaseDmlExecutionResult = {
+  testCaseId: string
+  testCaseTitle: string
+  success: boolean
+  executedOperations: number
+  failedOperations?: FailedOperation[]
+  executedAt: Date
+}


### PR DESCRIPTION
## Issue

- resolve: #3176

## Why is this change needed?

When PGlite encounters an error within an explicit BEGIN/COMMIT transaction block, the transaction gets aborted but subsequent operations still return success responses even though they are ignored. This causes misleading error reporting.

**Important Note:** This PR does NOT fix the underlying PGlite transaction handling issue. The issue appears to be a limitation in PGlite itself that requires deeper investigation. Instead, this PR:

1. **Documents the problem** with a regression test that demonstrates the transaction abort behavior
2. **Improves error visibility** by enhancing how validation errors are displayed to users

### Changes made:

1. **Added regression test** (`PGliteInstanceManager.test.ts`)
   - Demonstrates the transaction abort problem with explicit BEGIN
   - Shows that subsequent commands after an error return success but are actually ignored
   - Serves as documentation of the issue for future debugging

2. **Improved error message formatting** (`formatValidationErrors.ts`)
   - Extracted error formatting logic into a testable function
   - Shows SQL statements alongside their error messages for better context
   - Makes it clearer which operations failed and why

3. **Added comprehensive tests** for the error formatting function
   - Ensures error messages are properly formatted
   - Tests edge cases like long SQL statements and special characters

### What this PR does NOT do:

- Does not fix the root cause of transaction abort handling in PGlite
- Does not prevent the misleading "success" responses after transaction abort
- The actual fix would require changes to how PGlite handles transactions or how we interact with PGlite

### Next steps:

The root cause fix would likely require one of:
- Upstream fix in PGlite library
- Wrapping PGlite transactions with additional state management
- Converting explicit BEGIN/COMMIT to implicit transactions

For now, the improved error messages will at least make it clearer to users when transaction issues occur.