### PR TITLE
🐛 Fix sidebar scroll issues on Android Chrome

### DIFF
--- a/.changeset/smooth-olives-eat.md
+++ b/.changeset/smooth-olives-eat.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/ui": patch
+---
+
+🐛 Fixed an issue where the sidebar couldn't be scrolled properly on Android Chrome browsers.

--- a/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -47,7 +47,7 @@
 .sidebar {
   background: var(--pane-background);
   width: 100%;
-  height: 100%;
+  height: 100svh;
   display: flex;
   flex-direction: column;
 }
@@ -56,6 +56,7 @@
   flex: 1 1 0%;
   overflow-y: auto;
   padding-bottom: var(--spacing-10);
+  touch-action: pan-y;
 }
 
 .sidebarMenuItem {


### PR DESCRIPTION


## Issue

- resolve: https://github.com/route06/liam-internal/issues/5477


## Why is this change needed?

The sidebar component was experiencing critical scrolling issues specifically on Android Chrome browsers:
1. Users couldn't scroll the sidebar at all initially
2. After adding `touch-action: pan-y`, scrolling was partially restored but users still couldn't reach the bottom of the content
3. The issue was caused by viewport height calculation differences in Android Chrome, where the dynamic address bar affects the available height

This fix uses `100svh` (small viewport height) instead of `100%` to ensure consistent height calculation regardless of browser chrome visibility, and includes `touch-action: pan-y` for proper touch gesture handling.

## Testing
