### PR TITLE
feat(app): add app.liambx.com to server action allowed origins

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
     serverActions: {
       allowedOrigins:
         process.env.VERCEL_ENV === 'production'
-          ? ['liambx.com', 'liam-erd-web.vercel.app']
+          ? ['liambx.com', 'liam-erd-web.vercel.app', 'app.liambx.com']
           : undefined,
     },
   },
@@ -36,6 +36,10 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'liam-erd-web.vercel.app',
+      },
+      {
+        protocol: 'https',
+        hostname: 'app.liambx.com',
       },
     ],
   },


### PR DESCRIPTION
## Summary
Add `app.liambx.com` to the allowed origins for Next.js server actions as part of the subdomain migration plan.

## Why
As outlined in Issue route06/liam-internal#5234 , we're migrating from `liambx.com/app/*` to `app.liambx.com/app/*`. This change prepares the application to accept server action requests from the new subdomain.

## What
- Added `app.liambx.com` to the `allowedOrigins` array in `next.config.ts`

## Related Issues
- Resolves part of route06/liam-internal#5234

## Checklist
- [x] Code changes follow the project's style guidelines
- [ ] Tests have been run locally
- [ ] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled full app access from the app.liambx.com domain in production so users on that subdomain can use server-driven features seamlessly.
- Chores
  - Updated production allowlist to include app.liambx.com and added it as an approved image source; non-production behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->