### PR TITLE
💄 style(command palette): fix the `CommandPalettePreview` styles for the `CommandPreview` videos

### DIFF
--- a/.changeset/nine-pugs-sort.md
+++ b/.changeset/nine-pugs-sort.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+- 💄 style(command palette): fix table preview size

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.module.css
@@ -20,7 +20,7 @@
 .main [cmdk-list] {
   overflow-y: scroll;
   height: 100%;
-  width: 300px;
+  flex: 1;
 }
 
 .main [cmdk-group-heading] {
@@ -31,8 +31,7 @@
 .previewContainer {
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-10) var(--spacing-8) var(--spacing-10) var(--spacing-5);
-  flex: 1;
+  padding: var(--spacing-5) var(--spacing-6);
 }
 
 /* Empty search result display */

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/CommandPalettePreview.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/CommandPalettePreview.module.css
@@ -6,9 +6,10 @@
 }
 
 .tableNodeWrapper {
-  padding: var(--spacing-10) var(--spacing-12);
+  padding: var(--spacing-10) var(--spacing-9);
   height: 100%;
   width: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
+  scrollbar-gutter: stable both-edges;
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/CommandPalettePreview.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/CommandPalettePreview.module.css
@@ -1,7 +1,12 @@
 .container {
+<<<<<<< HEAD
   padding: var(--spacing-10) var(--spacing-12);
   background-color: var(--global-background);
-  height: 100%;
+  height: 361px;
+=======
+  height: 386px;
+>>>>>>> 59f96a61c (fix)
+  width: 271px;
   overflow-x: hidden;
   overflow-y: scroll;
   border-radius: var(--border-radius-lg-plus);

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/CommandPalettePreview.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/CommandPalettePreview.module.css
@@ -1,13 +1,14 @@
 .container {
-<<<<<<< HEAD
-  padding: var(--spacing-10) var(--spacing-12);
-  background-color: var(--global-background);
-  height: 361px;
-=======
   height: 386px;
->>>>>>> 59f96a61c (fix)
   width: 271px;
+  background-color: var(--global-background);
+  border-radius: var(--border-radius-lg-plus);
+}
+
+.tableNodeWrapper {
+  padding: var(--spacing-10) var(--spacing-12);
+  height: 100%;
+  width: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
-  border-radius: var(--border-radius-lg-plus);
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/TablePreview.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/TablePreview.tsx
@@ -13,30 +13,32 @@ export const TablePreview: FC<Props> = ({ tableName }) => {
 
   return (
     <div className={styles.container}>
-      {table && (
-        <TableNode
-          id=""
-          type="table"
-          data={{
-            table: table,
-            isActiveHighlighted: false,
-            isHighlighted: false,
-            isTooltipVisible: false,
-            sourceColumnName: undefined,
-            targetColumnCardinalities: undefined,
-            showMode: 'ALL_FIELDS',
-          }}
-          dragging={false}
-          isConnectable={false}
-          positionAbsoluteX={0}
-          positionAbsoluteY={0}
-          selectable={false}
-          deletable={false}
-          selected={false}
-          draggable={false}
-          zIndex={0}
-        />
-      )}
+      <div className={styles.tableNodeWrapper}>
+        {table && (
+          <TableNode
+            id=""
+            type="table"
+            data={{
+              table: table,
+              isActiveHighlighted: false,
+              isHighlighted: false,
+              isTooltipVisible: false,
+              sourceColumnName: undefined,
+              targetColumnCardinalities: undefined,
+              showMode: 'ALL_FIELDS',
+            }}
+            dragging={false}
+            isConnectable={false}
+            positionAbsoluteX={0}
+            positionAbsoluteY={0}
+            selectable={false}
+            deletable={false}
+            selected={false}
+            draggable={false}
+            zIndex={0}
+          />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

To introduce the CommandPreview component with videos, this PR will fix the preview container size with the video size.
It will also arrange the padding size of the elements to fit with the design data.

[Here is one of preview videos](https://github.com/liam-hq/liam/blob/e859f8258e452d44456af89f78e32fdfeadeaa08/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPalettePreview/assets/zoom-to-fit.mp4). The size is  386:271 (height : width).

|before|after|
| --- | --- |
|<img width="657" height="528" alt="Screenshot 0007-08-31 at 10 31 37" src="https://github.com/user-attachments/assets/c9317dc6-d1db-4e89-80a8-8ed186a20a80" />|<img width="657" height="528" alt="Screenshot 0007-08-31 at 10 31 44" src="https://github.com/user-attachments/assets/aa8271e5-47bf-4fae-b1c2-2bcecc2b3e39" />|
|<img width="361" height="467" alt="Screenshot 0007-08-31 at 10 30 44" src="https://github.com/user-attachments/assets/fbef47e1-c47e-4553-bbdb-e298a4dc98c1" />|<img width="361" height="467" alt="Screenshot 0007-08-31 at 10 30 38" src="https://github.com/user-attachments/assets/f67236e4-a479-43c9-9f6c-d7a0fb265b32" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Command Palette preview now renders at a consistent size with stable scrollbars, preventing overflow and layout shifts.
  * List panel adapts to available space for better responsiveness.
  * Adjusted padding to improve readability and alignment in the preview.

* Style
  * Refined spacing and rounded corners for a cleaner, more consistent look.

* Chores
  * Added changeset for a patch release documenting the Command Palette table preview size fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->