### PR TITLE
✨ Add streaming support for lead agent summary workflow

### DIFF
--- a/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
@@ -1,4 +1,9 @@
-import { type AIMessage, SystemMessage } from '@langchain/core/messages'
+import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
+import {
+  AIMessage,
+  AIMessageChunk,
+  SystemMessage,
+} from '@langchain/core/messages'
 import { END } from '@langchain/langgraph'
 import { ChatOpenAI } from '@langchain/openai'
 import { ResultAsync } from 'neverthrow'
@@ -46,8 +51,45 @@ Please summarize:
 
 Keep the summary informative but concise, focusing on the key achievements and decisions made during this database design session.`
 
-  return ResultAsync.fromPromise(
-    llm.invoke([new SystemMessage(summaryPrompt), ...state.messages]),
+  const invoke = ResultAsync.fromThrowable(
+    () => {
+      return llm.stream([new SystemMessage(summaryPrompt), ...state.messages])
+    },
     (error) => (error instanceof Error ? error : new Error(String(error))),
   )
+
+  return invoke().andThen((stream) => {
+    return ResultAsync.fromPromise(
+      (async () => {
+        // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
+        // so we overwrite with a UUID to unify chunk ids for consistent handling.
+        const id = crypto.randomUUID()
+        let accumulatedChunk: AIMessageChunk | null = null
+
+        for await (const _chunk of stream) {
+          const chunk = new AIMessageChunk({ ..._chunk, id, name: 'lead' })
+          await dispatchCustomEvent('messages', chunk)
+
+          // Accumulate chunks using concat method
+          accumulatedChunk = accumulatedChunk
+            ? accumulatedChunk.concat(chunk)
+            : chunk
+        }
+
+        // Convert the final accumulated chunk to AIMessage
+        const response = accumulatedChunk
+          ? new AIMessage({
+              content: accumulatedChunk.content,
+              additional_kwargs: accumulatedChunk.additional_kwargs,
+              ...(accumulatedChunk.tool_calls && {
+                tool_calls: accumulatedChunk.tool_calls,
+              }),
+            })
+          : new AIMessage('')
+
+        return response
+      })(),
+      (error) => (error instanceof Error ? error : new Error(String(error))),
+    )
+  })
 }

--- a/frontend/internal-packages/agent/src/pm-agent/nodes/invokeSaveArtifactToolNode.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/nodes/invokeSaveArtifactToolNode.ts
@@ -13,10 +13,18 @@ export const invokeSaveArtifactToolNode = async (
 ) => {
   const toolNode = new ToolNode([saveRequirementsToArtifactTool])
 
-  return toolNode.invoke(state, {
+  const stream = await toolNode.stream(state, {
     configurable: {
       ...config.configurable,
       designSessionId: state.designSessionId,
     },
   })
+
+  let result = {}
+
+  for await (const chunk of stream) {
+    result = chunk
+  }
+
+  return result
 }


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This PR adds streaming support to the lead agent's summary workflow, enabling real-time summary generation. Previously, users had to wait for the entire summary to be generated before seeing any output. With this change, users can see the summary being generated progressively, providing better user experience and immediate feedback.

### Key Changes:
- Modified `summarizeWorkflow` to stream responses chunk-by-chunk
- Implemented proper chunk accumulation and event dispatching
- Updated `invokeSaveArtifactToolNode` to use streaming for consistency
- Ensures consistent UUID assignment for all message chunks