### PR TITLE
🔒(public-share): Add robots meta tag to prevent indexing of public share pages

### DIFF
--- a/frontend/apps/app/app/app/public/design_sessions/[id]/page.tsx
+++ b/frontend/apps/app/app/app/public/design_sessions/[id]/page.tsx
@@ -7,6 +7,11 @@ const paramsSchema = v.object({
   id: v.string(),
 })
 
+// Prevent search engines from indexing public share pages
+export const metadata = {
+  robots: 'noindex, nofollow, noarchive',
+}
+
 // Cache configuration for public pages
 export const revalidate = 60 // Revalidate every 60 seconds
 


### PR DESCRIPTION
## Issue

- resolve: route06/liam-internal/issues/5506

## Why is this change needed?

Add robots meta tag (noindex, nofollow, noarchive) to public share pages to prevent them from being indexed by search engines. This protects shared design sessions from unintended discovery through search results.

## tested

tested in local env

<img width="1339" height="763" alt="スクリーンショット 2025-08-28 11 17 27" src="https://github.com/user-attachments/assets/72aae2fc-db91-496b-afa5-94614d65c5bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Prevent search engines from indexing public share pages by adding robots metadata (noindex, nofollow, noarchive).
  * Reduces accidental discoverability in search results, helping protect shared session links from broad exposure.
  * No changes to page content, performance, or sharing behavior; existing revalidation and runtime behavior remain unchanged.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->