### PR TITLE
feat: Add copy button to user messages

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.module.css
@@ -1,0 +1,84 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--spacing-2);
+}
+
+.avatarContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0;
+  min-height: 24px;
+  gap: var(--spacing-1);
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--spacing-2);
+}
+
+.messageWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  max-width: 100%;
+  position: relative;
+}
+
+.messageContent {
+  background-color: var(--overlay-5);
+  border-radius: var(--border-radius-base);
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  width: 100%;
+}
+
+.messageText {
+  color: var(--overlay-70);
+  font-family: var(--main-font), sans-serif;
+  font-weight: 400;
+  font-size: var(--font-size-4);
+  line-height: 1.6;
+  word-wrap: break-word;
+  white-space: normal;
+  width: 100%;
+}
+
+.userName {
+  font-family: var(--main-font), sans-serif;
+  font-weight: 500;
+  font-size: var(--font-size-3);
+  line-height: 1.6;
+  color: var(--global-body-text);
+  margin-left: var(--spacing-1);
+}
+
+.messageTime {
+  font-family: var(--main-font), sans-serif;
+  font-weight: 400;
+  font-size: var(--font-size-2);
+  line-height: 1.6;
+  color: var(--overlay-50);
+  margin-left: var(--spacing-1);
+}
+
+.copyButtonWrapper {
+  position: absolute;
+  bottom: var(--spacing-1);
+  right: calc(-1 * var(--spacing-10));
+  opacity: 0;
+  animation: fadeIn 0.2s ease-in-out forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { Avatar, Check, Copy, IconButton } from '@liam-hq/ui'
+import { type FC, useState } from 'react'
+import { MarkdownContent } from '@/components/MarkdownContent'
+import styles from './HumanMessage.module.css'
+
+type Props = {
+  content: string
+  timestamp?: Date
+}
+
+export const HumanMessage: FC<Props> = ({ content, timestamp }) => {
+  const [isCopied, setIsCopied] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
+
+  const handleCopyMessage = async () => {
+    try {
+      await navigator.clipboard.writeText(content)
+      setIsCopied(true)
+      setTimeout(() => {
+        setIsCopied(false)
+      }, 2000)
+    } catch (error) {
+      console.error('Failed to copy message:', error)
+    }
+  }
+
+  const formattedTime = timestamp
+    ? timestamp.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: 'UTC',
+      })
+    : null
+
+  return (
+    <div
+      className={styles.container}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className={styles.avatarContainer}>
+        <Avatar initial="U" size="sm" user="you" />
+        <span className={styles.userName}>User</span>
+        {formattedTime && (
+          <span className={styles.messageTime}>{formattedTime}</span>
+        )}
+      </div>
+      <div className={styles.contentContainer}>
+        <div className={styles.messageWrapper}>
+          <div className={styles.messageContent}>
+            <div className={styles.messageText}>
+              <MarkdownContent content={content} />
+            </div>
+          </div>
+          {isHovered && (
+            <div className={styles.copyButtonWrapper}>
+              <IconButton
+                icon={isCopied ? <Check size={16} /> : <Copy size={16} />}
+                onClick={handleCopyMessage}
+                tooltipContent={isCopied ? 'Copied!' : 'Copy message'}
+                size="sm"
+                variant="hoverBackground"
+                aria-label={isCopied ? 'Message copied' : 'Copy message'}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/index.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/index.ts
@@ -1,0 +1,1 @@
+export { HumanMessage } from './HumanMessage'

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/Messages.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/Messages.tsx
@@ -1,6 +1,11 @@
-import { type BaseMessage, isAIMessage } from '@langchain/core/messages'
+import {
+  type BaseMessage,
+  isAIMessage,
+  isHumanMessage,
+} from '@langchain/core/messages'
 import type { FC } from 'react'
 import { AiMessage } from './AiMessage'
+import { HumanMessage } from './HumanMessage'
 
 type Props = {
   messages: BaseMessage[]
@@ -10,6 +15,20 @@ export const Messages: FC<Props> = ({ messages }) => {
   return messages.map((message) => {
     if (isAIMessage(message)) {
       return <AiMessage key={message.id} message={message} />
+    }
+
+    if (isHumanMessage(message)) {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content)
+      return (
+        <HumanMessage
+          key={message.id}
+          content={content}
+          timestamp={new Date()}
+        />
+      )
     }
 
     return null


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5522

## Why is this change needed?

This feature allows users to easily copy messages from one session to another when running multiple sessions simultaneously to compare results. The copy button provides a quick way to replicate prompts across different sessions.

## Summary

Updated implementation for the new Messages component architecture:
- Added HumanMessage component with copy button functionality
- Updated Messages component to handle HumanMessage rendering  
- Implemented clipboard copy functionality with error handling
- Added visual feedback (check icon) when copy is successful
- Positioned button on bottom-right outside message bubble
- Added smooth fade-in animation for button appearance

## Test plan

- [x] Start development server and navigate to a session with messages
- [x] Verify user messages are displayed properly
- [x] Hover over a user message to see the copy button appear
- [x] Click the copy button and verify the message is copied to clipboard
- [x] Verify the button icon changes to a check mark on successful copy
- [x] Test with long messages and markdown formatted content
- [x] Verify the button disappears when mouse leaves the message area

🤖 Generated with [Claude Code](https://claude.ai/code)