### PR TITLE
✨(chat): Add copy button to user messages

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.module.css
@@ -1,0 +1,46 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: flex-end;
+  gap: var(--spacing-2);
+}
+
+.messageContainer {
+  display: flex;
+  flex-direction: column;
+  max-width: 70%;
+  position: relative;
+}
+
+.messageContent {
+  background-color: var(--primary-accent);
+  color: var(--global-background);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--border-radius-base);
+  font-family: var(--main-font);
+  font-weight: 400;
+  font-size: var(--font-size-4);
+  line-height: 1.8em;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.contentWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.copyButtonWrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--spacing-1);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.messageContainer:hover .copyButtonWrapper {
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.tsx
@@ -1,0 +1,30 @@
+import type { HumanMessage as HumanMessageType } from '@langchain/core/messages'
+import type { FC } from 'react'
+import { CopyButton } from '@/components/SessionDetailPage/components/CopyButton'
+import { getContentString } from '../utils/getContentString'
+import styles from './HumanMessage.module.css'
+
+type Props = {
+  message: HumanMessageType
+}
+
+export const HumanMessage: FC<Props> = ({ message }) => {
+  const messageContent = getContentString(message.content)
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.messageContainer}>
+        <div className={styles.contentWrapper}>
+          <div className={styles.messageContent}>{messageContent}</div>
+          <div className={styles.copyButtonWrapper}>
+            <CopyButton
+              textToCopy={messageContent}
+              tooltipLabel="Copy message"
+              size="sm"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/index.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/index.ts
@@ -1,0 +1,1 @@
+export * from './HumanMessage'

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/Messages.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/Messages.tsx
@@ -1,6 +1,11 @@
-import { type BaseMessage, isAIMessage } from '@langchain/core/messages'
+import {
+  type BaseMessage,
+  isAIMessage,
+  isHumanMessage,
+} from '@langchain/core/messages'
 import type { FC } from 'react'
 import { AiMessage } from './AiMessage'
+import { HumanMessage } from './HumanMessage'
 
 type Props = {
   messages: BaseMessage[]
@@ -10,6 +15,10 @@ export const Messages: FC<Props> = ({ messages }) => {
   return messages.map((message) => {
     if (isAIMessage(message)) {
       return <AiMessage key={message.id} message={message} />
+    }
+
+    if (isHumanMessage(message)) {
+      return <HumanMessage key={message.id} message={message} />
     }
 
     return null


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5522

## Why is this change needed?

Users need to be able to copy their own messages from the chat interface to reuse them in other sessions. This is particularly useful when running multiple sessions with similar prompts to compare results.

## Changes

This PR adds a copy button to user messages in the chat interface, matching the existing pattern used for AI messages.

### Implementation Details

1. **Created HumanMessage component** - A new component that displays user messages with:
   - User message content styled with blue background (using primary accent color)
   - Copy button that appears on hover
   - Responsive layout aligned to the right side of the chat

2. **Updated Messages component** - Modified to handle both AI and human messages:
   - Added `isHumanMessage` check from langchain
   - Renders the appropriate component based on message type

3. **Reused existing infrastructure**:
   - Used the existing `CopyButton` component for consistency
   - Applied the same hover-triggered visibility pattern as AI messages
   - Utilized the `getContentString` utility to extract message text

### UI/UX Features

- Copy button appears on hover for better visual clarity
- Button positioned at the bottom right of the message bubble
- Visual feedback when content is copied (check icon)
- Consistent with the existing AI message copy functionality

## Testing

- Built and type-checked successfully
- Visual testing confirms hover functionality works as expected
- Copy functionality verified to work with various message lengths

## Screenshots

The copy button appears when hovering over user messages, matching the existing AI message pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>