### PR TITLE
fix: limit release workflow build to CLI package only

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prebuild": "pnpm create-env-files",
     "prelint": "pnpm create-env-files",
     "prepare": "lefthook install",
-    "release": "pnpm build && pnpm changeset publish",
+    "release": "pnpm build --filter @liam-hq/cli && pnpm changeset publish",
     "test": "turbo test",
     "test:coverage": "vitest --coverage",
     "test:e2e": "turbo test:e2e",


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

The release workflow was building all packages in the monorepo when only the CLI package needs to be built for release. This change optimizes the release process by limiting the build to `@liam-hq/cli` package only, reducing unnecessary build time and resources.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined the release workflow by building only the CLI component before publishing, reducing build time and CI resource usage.
  - Publishing behavior remains the same, ensuring consistent release outputs while narrowing the build scope for faster iterations.
  - No changes to runtime behavior, APIs, or UI; end-user functionality remains unaffected.
  - Improves reliability by minimizing noise from unrelated packages during releases without altering the overall release flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->