### PR TITLE
fix: change Avatar import from @/components to @liam-hq/ui in HumanMessage

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/HumanMessage/HumanMessage.tsx
@@ -1,7 +1,7 @@
 import type { HumanMessage as HumanMessageType } from '@langchain/core/messages'
+import { Avatar } from '@liam-hq/ui'
 import type { FC } from 'react'
 import * as v from 'valibot'
-import { Avatar } from '@/components'
 import { MarkdownContent } from '@/components/MarkdownContent'
 import { extractResponseFromMessage } from '../utils/extractResponseFromMessage'
 import styles from './HumanMessage.module.css'


### PR DESCRIPTION
## Issue

- resolve: #3222

## Why is this change needed?

The HumanMessage component was importing Avatar from `@/components`, which caused Storybook build failures.

### Root Cause

- Next.js tsconfig.json has multiple path mappings for `@/*`:
  - `./components` (within app)  
  - `../../packages/ui/src/components` (within ui package)
- Storybook's webpack config only resolves `@` to `apps/app`, missing the additional path mappings
- When `@/components` is used in Next.js app, it automatically falls back to `ui/src/components` since there's no `components/index.ts` in app
- But Storybook can't resolve this, causing the build error

### Solution

Changed the import from `@/components` to `@liam-hq/ui` for consistency and to fix the Storybook build.

### Test plan
- [x] Storybook build succeeds (`pnpm --filter @liam-hq/storybook build`)
- [x] HumanMessage component renders correctly in Storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Chat avatars in human messages now use the unified design system, resulting in minor visual refinements and improved consistency across the app.

* **Refactor**
  * Switched to a shared UI library for the avatar component in chat messages. No functional changes; behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->