### PR TITLE
feat: Add parse-schema-for-dataset command for benchmark creation

### DIFF
--- a/.claude/commands/parse-schema-for-dataset.md
+++ b/.claude/commands/parse-schema-for-dataset.md
@@ -26,5 +26,5 @@ Expected arguments:
 - Format (optional - will auto-detect if not provided)
 
 Example usage:
-`/parse-schema schema.sql case-002`
-`/parse-schema prisma/schema.prisma case-003 --format prisma`
+`/parse-schema-for-dataset schema.sql case-002`
+`/parse-schema-for-dataset prisma/schema.prisma case-003 --format prisma`

--- a/.claude/commands/parse-schema-for-dataset.md
+++ b/.claude/commands/parse-schema-for-dataset.md
@@ -1,0 +1,30 @@
+---
+description: Parse schema for dataset - Convert SQL/schema files to JSON benchmark datasets
+---
+
+# Parse Schema for Dataset
+
+## Task
+
+Parse the specified schema file (SQL, Prisma, Drizzle, etc.) to JSON format and save it to the benchmark reference directory at `frontend/internal-packages/schema-bench/benchmark-workspace-default/execution/reference/`.
+
+### Process
+
+1. Identify the input schema file format (postgres, prisma, drizzle, tbls, schemarb)
+2. Use the @liam-hq/schema parser to convert to JSON
+3. Save the output to an appropriately named case file in the benchmark reference directory
+4. Verify the generated JSON structure matches the expected format
+
+### Arguments
+
+$ARGUMENTS
+
+Expected arguments:
+
+- Input file path (SQL or schema file)
+- Output case name (e.g., "case-002", "case-003")
+- Format (optional - will auto-detect if not provided)
+
+Example usage:
+`/parse-schema schema.sql case-002`
+`/parse-schema prisma/schema.prisma case-003 --format prisma`


### PR DESCRIPTION
## Summary

- Add new Claude command to parse SQL/schema files to JSON benchmark datasets
- Supports multiple schema formats (postgres, prisma, drizzle, tbls, schemarb)
- Outputs to benchmark reference directory for dataset creation

## Test plan

- [ ] Verify command is available via `/parse-schema-for-dataset`
- [ ] Test parsing PostgreSQL SQL files
- [ ] Test parsing other supported formats
- [ ] Verify output location in benchmark reference directory

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a user guide for the “Parse Schema for Dataset” CLI task that converts schema files into JSON benchmark datasets.
  * Covers supported formats (auto-detect, Postgres/SQL, Prisma, Drizzle, tbls, Rails schema.rb), required arguments (input path, case name, optional format), and output naming.
  * Provides step-by-step workflow, validation checklist, and usage examples (e.g., /parse-schema schema.sql case-002).
  * Helps streamline dataset creation from existing schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->