### PR TITLE
feat(pglite-server): add dynamic extension loading support for PGlite

### DIFF
--- a/frontend/internal-packages/agent/src/db-agent/tools/schemaDesignTool.ts
+++ b/frontend/internal-packages/agent/src/db-agent/tools/schemaDesignTool.ts
@@ -36,9 +36,13 @@ const validateAndExecuteDDL = async (
   }
 
   const ddlStatements = ddlResult.value
+  const requiredExtensions = Object.keys(schema.extensions)
 
   // Execute DDL to validate it
-  const results: SqlResult[] = await executeQuery(ddlStatements)
+  const results: SqlResult[] = await executeQuery(
+    ddlStatements,
+    requiredExtensions,
+  )
 
   const hasExecutionErrors = results.some(
     (result: SqlResult) => !result.success,

--- a/frontend/internal-packages/agent/src/qa-agent/validateSchema/index.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/validateSchema/index.ts
@@ -22,6 +22,7 @@ import type { TestcaseDmlExecutionResult } from './types'
 async function executeDmlOperationsByTestcase(
   ddlStatements: string,
   testcases: Testcase[],
+  requiredExtensions: string[],
 ): Promise<TestcaseDmlExecutionResult[]> {
   const results: TestcaseDmlExecutionResult[] = []
 
@@ -51,7 +52,7 @@ async function executeDmlOperationsByTestcase(
 
     const startTime = new Date()
     const executionResult = await ResultAsync.fromPromise(
-      executeQuery(combinedSql),
+      executeQuery(combinedSql, requiredExtensions),
       (error) => new Error(String(error)),
     )
 
@@ -177,6 +178,7 @@ export async function validateSchemaNode(
   const { repositories } = configurableResult.value
 
   const ddlStatements = generateDdlFromSchema(state.schemaData)
+  const requiredExtensions = Object.keys(state.schemaData.extensions)
   const hasDdl = ddlStatements?.trim()
   const hasTestcases =
     state.generatedTestcases && state.generatedTestcases.length > 0
@@ -201,7 +203,10 @@ export async function validateSchemaNode(
 
   // Execute DDL first if present
   if (hasDdl && ddlStatements) {
-    const ddlResults: SqlResult[] = await executeQuery(ddlStatements)
+    const ddlResults: SqlResult[] = await executeQuery(
+      ddlStatements,
+      requiredExtensions,
+    )
     allResults = [...ddlResults]
   }
 
@@ -211,6 +216,7 @@ export async function validateSchemaNode(
     testcaseExecutionResults = await executeDmlOperationsByTestcase(
       ddlStatements || '',
       state.generatedTestcases,
+      requiredExtensions,
     )
 
     const dmlSqlResults: SqlResult[] = testcaseExecutionResults.map(

--- a/frontend/internal-packages/pglite-server/src/client.ts
+++ b/frontend/internal-packages/pglite-server/src/client.ts
@@ -3,8 +3,11 @@ import type { SqlResult } from './types'
 
 const manager = new PGliteInstanceManager()
 
-export async function executeQuery(sql: string): Promise<SqlResult[]> {
-  return await manager.executeQuery(sql)
+export async function executeQuery(
+  sql: string,
+  requiredExtensions: string[] = [],
+): Promise<SqlResult[]> {
+  return await manager.executeQuery(sql, requiredExtensions)
 }
 
 export { manager as pgliteManager }

--- a/frontend/internal-packages/pglite-server/src/extensionUtils.ts
+++ b/frontend/internal-packages/pglite-server/src/extensionUtils.ts
@@ -1,0 +1,131 @@
+import type { Extensions } from '@electric-sql/pglite'
+
+// Extract the value type from Extensions to ensure type safety
+type ExtensionModule = Extensions[string]
+
+// Mapping of extension names to their import paths
+const EXTENSION_IMPORT_PATHS: Record<string, string> = {
+  live: '@electric-sql/pglite/live',
+  vector: '@electric-sql/pglite/vector',
+  pg_ivm: '@electric-sql/pglite/pg_ivm',
+  amcheck: '@electric-sql/pglite/contrib/amcheck',
+  auto_explain: '@electric-sql/pglite/contrib/auto_explain',
+  bloom: '@electric-sql/pglite/contrib/bloom',
+  btree_gin: '@electric-sql/pglite/contrib/btree_gin',
+  btree_gist: '@electric-sql/pglite/contrib/btree_gist',
+  citext: '@electric-sql/pglite/contrib/citext',
+  cube: '@electric-sql/pglite/contrib/cube',
+  earthdistance: '@electric-sql/pglite/contrib/earthdistance',
+  fuzzystrmatch: '@electric-sql/pglite/contrib/fuzzystrmatch',
+  hstore: '@electric-sql/pglite/contrib/hstore',
+  isn: '@electric-sql/pglite/contrib/isn',
+  lo: '@electric-sql/pglite/contrib/lo',
+  ltree: '@electric-sql/pglite/contrib/ltree',
+  pg_trgm: '@electric-sql/pglite/contrib/pg_trgm',
+  seg: '@electric-sql/pglite/contrib/seg',
+  tablefunc: '@electric-sql/pglite/contrib/tablefunc',
+  tcn: '@electric-sql/pglite/contrib/tcn',
+  tsm_system_rows: '@electric-sql/pglite/contrib/tsm_system_rows',
+  tsm_system_time: '@electric-sql/pglite/contrib/tsm_system_time',
+  uuid_ossp: '@electric-sql/pglite/contrib/uuid_ossp',
+}
+
+/**
+ * Normalize extension name to match PGlite supported format
+ */
+function normalizeExtensionName(name: string): string {
+  const normalized = name.toLowerCase().trim()
+  // Special case: uuid-ossp needs to be converted to uuid_ossp for PGlite import
+  return normalized === 'uuid-ossp' ? 'uuid_ossp' : normalized
+}
+
+/**
+ * Dynamically load extension module by name
+ */
+async function loadExtensionModule(
+  extensionName: string,
+): Promise<ExtensionModule | null> {
+  const importPath = EXTENSION_IMPORT_PATHS[extensionName]
+  if (!importPath) {
+    return null
+  }
+
+  try {
+    const module = await import(importPath)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const extensionExport = module[extensionName]
+    return extensionExport || null
+  } catch (error) {
+    console.error(
+      `Failed to dynamically import extension ${extensionName}:`,
+      error,
+    )
+    return null
+  }
+}
+
+/**
+ * Load and filter extensions for PGlite
+ * Returns both the Extensions object and the list of actually supported extensions
+ */
+export async function loadExtensions(
+  requiredExtensions: string[],
+): Promise<{ extensions: Extensions; supportedExtensions: string[] }> {
+  const extensions: Extensions = {}
+  const supportedExtensions: string[] = []
+
+  for (const ext of requiredExtensions) {
+    const normalizedExt = normalizeExtensionName(ext)
+
+    // Try to dynamically load the extension module
+    const extensionModule = await loadExtensionModule(normalizedExt)
+
+    if (extensionModule) {
+      try {
+        extensions[normalizedExt] = extensionModule
+        supportedExtensions.push(ext) // Add original extension name to supported list
+      } catch (error) {
+        console.error(`Failed to configure extension ${normalizedExt}:`, error)
+      }
+    } else {
+      console.warn(
+        `Extension '${ext}' is not supported in PGlite environment and will be excluded`,
+      )
+    }
+  }
+
+  if (supportedExtensions.length !== requiredExtensions.length) {
+    console.info(
+      `Filtered extensions: ${supportedExtensions.join(', ')} (${supportedExtensions.length}/${requiredExtensions.length} supported)`,
+    )
+  }
+
+  return { extensions, supportedExtensions }
+}
+
+/**
+ * Filter CREATE EXTENSION statements to only include supported extensions
+ */
+export function filterExtensionDDL(
+  sql: string,
+  supportedExtensions: string[],
+): string {
+  // Create a Set of normalized supported extensions for efficient lookup
+  const normalizedSupported = new Set(
+    supportedExtensions.map((ext) => normalizeExtensionName(ext)),
+  )
+
+  // Pattern to match CREATE EXTENSION statements
+  const createExtensionRegex =
+    /CREATE\s+EXTENSION\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?([^"'\s;]+)["']?/gi
+
+  return sql.replace(createExtensionRegex, (match, extensionName) => {
+    const normalizedExt = normalizeExtensionName(extensionName)
+    // Check if extension is in our supported list (dynamic import handled extensions)
+    if (normalizedSupported.has(normalizedExt)) {
+      return match // Keep the statement
+    }
+    // Comment out unsupported extension
+    return `-- Excluded (not supported in PGlite): ${match}`
+  })
+}

--- a/frontend/packages/schema/src/deparser/postgresql/utils.test.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { generateCreateExtensionStatement } from './utils.js'
+
+describe('generateCreateExtensionStatement', () => {
+  it('should generate CREATE EXTENSION statement with quotes for hyphenated names', () => {
+    const extension = { name: 'uuid-ossp' }
+    const result = generateCreateExtensionStatement(extension)
+
+    expect(result).toBe('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
+  })
+
+  it('should generate CREATE EXTENSION statement without quotes for simple names', () => {
+    const extension = { name: 'vector' }
+    const result = generateCreateExtensionStatement(extension)
+
+    expect(result).toBe('CREATE EXTENSION IF NOT EXISTS vector;')
+  })
+
+  it('should quote extension names with uppercase letters', () => {
+    const extension = { name: 'PostGIS' }
+    const result = generateCreateExtensionStatement(extension)
+
+    expect(result).toBe('CREATE EXTENSION IF NOT EXISTS "PostGIS";')
+  })
+
+  it('should preserve exact extension name without normalization', () => {
+    const extension = { name: 'UUID-OSSP' }
+    const result = generateCreateExtensionStatement(extension)
+
+    expect(result).toBe('CREATE EXTENSION IF NOT EXISTS "UUID-OSSP";')
+  })
+
+  it('should handle extension names with underscores', () => {
+    const extension = { name: 'pg_trgm' }
+    const result = generateCreateExtensionStatement(extension)
+
+    expect(result).toBe('CREATE EXTENSION IF NOT EXISTS pg_trgm;')
+  })
+
+  it('should handle mixed case with underscores', () => {
+    const extension = { name: 'PG_TRGM' }
+    const result = generateCreateExtensionStatement(extension)
+
+    expect(result).toBe('CREATE EXTENSION IF NOT EXISTS "PG_TRGM";')
+  })
+
+  describe('various extension names', () => {
+    const extensionTestCases = [
+      {
+        name: 'uuid-ossp',
+        expected: 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";',
+      },
+      {
+        name: 'pgcrypto',
+        expected: 'CREATE EXTENSION IF NOT EXISTS pgcrypto;',
+      },
+      { name: 'plpgsql', expected: 'CREATE EXTENSION IF NOT EXISTS plpgsql;' },
+      { name: 'vector', expected: 'CREATE EXTENSION IF NOT EXISTS vector;' },
+      { name: 'pg_trgm', expected: 'CREATE EXTENSION IF NOT EXISTS pg_trgm;' },
+      {
+        name: 'PostGIS',
+        expected: 'CREATE EXTENSION IF NOT EXISTS "PostGIS";',
+      },
+      {
+        name: 'my-extension',
+        expected: 'CREATE EXTENSION IF NOT EXISTS "my-extension";',
+      },
+      {
+        name: 'MyExtension',
+        expected: 'CREATE EXTENSION IF NOT EXISTS "MyExtension";',
+      },
+    ]
+
+    it.each(extensionTestCases)(
+      'should generate correct DDL for $name',
+      ({ name, expected }) => {
+        const extension = { name }
+        const result = generateCreateExtensionStatement(extension)
+
+        expect(result).toBe(expected)
+      },
+    )
+  })
+})

--- a/frontend/packages/schema/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/utils.ts
@@ -2,6 +2,7 @@ import type {
   Column,
   Constraint,
   Enum,
+  Extension,
   Index,
   Table,
 } from '../../schema/index.js'
@@ -462,4 +463,17 @@ export function generateCreateEnumStatement(enumObj: Enum): string {
   }
 
   return ddl
+}
+
+/**
+ * Generate CREATE EXTENSION statement from Extension type
+ */
+export function generateCreateExtensionStatement(extension: Extension): string {
+  // Quote extension names containing hyphens or uppercase letters
+  const quotedName =
+    extension.name.includes('-') || /[A-Z]/.test(extension.name)
+      ? `"${extension.name}"`
+      : extension.name
+
+  return `CREATE EXTENSION IF NOT EXISTS ${quotedName};`
 }


### PR DESCRIPTION
## Issue
- ref: https://github.com/route06/liam-internal/issues/5227

Add support for dynamically loading PostgreSQL extensions in PGlite environment with proper filtering and normalization.

## Why is this change needed?

Previously, `PGliteInstanceManager` could not load PostgreSQL extensions, which prevented testing schemas that depend on extensions like uuid-ossp, vector, or hstore. This PR enables extension support by:

- Dynamically importing required extensions at runtime
- Filtering unsupported extensions with appropriate warnings
- Normalizing extension names (e.g., uuid-ossp → uuid_ossp)

## Changes

### Added
- Support for 21 PGlite extensions (3 native/plugin + 18 contrib)
- `EXTENSION_IMPORTS` mapping for all supported extensions
- `normalizeExtensionName()` method to handle special cases like uuid-ossp
- `loadExtensions()` method for dynamic import and filtering
- Optional `requiredExtensions` parameter to `executeQuery()` method
- Comprehensive tests for extension functionality

### Supported Extensions
**Native/Plugin:** live, vector, pg_ivm
**Contrib:** amcheck, auto_explain, bloom, btree_gin, btree_gist, citext, cube, earthdistance, fuzzystrmatch, hstore, isn, lo, ltree, pg_trgm, seg, tablefunc, tcn, tsm_system_rows, tsm_system_time, uuid_ossp

## Testing

- ✅ Added tests for unsupported extension filtering
- ✅ Added tests for extension name normalization
- ✅ Added tests for supported extension loading
- ✅ All existing tests pass with backward compatibility

## Notes

- Maintains full backward compatibility - `requiredExtensions` parameter is optional
- Extensions are loaded only when needed, avoiding unnecessary imports
- Unsupported extensions are filtered with console warnings rather than errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dynamic loading of PostgreSQL extensions during query execution.
  - Optional per-query list of required extensions; unsupported extensions are filtered and warned.
  - Support for common contrib extensions with name normalization and correct CREATE EXTENSION quoting.

- **Tests**
  - Coverage for extension handling: supported/unsupported filtering, empty lists, and contrib loading.
  - Tests for accurate CREATE EXTENSION SQL generation across varied naming cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->