### PR TITLE
✅(agent): Add integration tests and remove setupGraph helper

### DIFF
--- a/frontend/internal-packages/agent/package.json
+++ b/frontend/internal-packages/agent/package.json
@@ -55,6 +55,7 @@
     "lint:biome": "biome check .",
     "lint:eslint": "eslint .",
     "lint:tsc": "tsc --noEmit",
-    "test": "vitest --watch=false --passWithNoTests"
+    "test": "vitest --watch=false --passWithNoTests",
+    "test:integration": "vitest --watch=false --passWithNoTests --config vitest.config.integration.ts"
   }
 }

--- a/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.integration.test.ts
@@ -1,0 +1,43 @@
+import { HumanMessage } from '@langchain/core/messages'
+import { END } from '@langchain/langgraph'
+import { describe, it } from 'vitest'
+import {
+  getTestConfig,
+  outputStream,
+  setupGraph,
+} from '../../../test-utils/workflowTestHelpers'
+import type { WorkflowState } from '../../chat/workflow/types'
+import { designSchemaNode } from './designSchemaNode'
+
+describe('designSchemaNode Integration', () => {
+  it('should execute designSchemaNode with real APIs', async () => {
+    // Arrange
+    const graph = setupGraph(designSchemaNode)
+    const { config, context } = await getTestConfig()
+
+    const userInput =
+      'Create a user management system with users, roles, and permissions tables'
+
+    const state: WorkflowState = {
+      userInput,
+      messages: [new HumanMessage(userInput)],
+      schemaData: {
+        tables: {},
+        enums: {},
+        extensions: {},
+      },
+      buildingSchemaId: context.buildingSchemaId,
+      latestVersionNumber: context.latestVersionNumber,
+      designSessionId: context.designSessionId,
+      userId: context.userId,
+      organizationId: context.organizationId,
+      next: END,
+    }
+
+    // Act
+    const stream = await graph.stream(state, config)
+
+    // Assert (Output)
+    await outputStream(stream)
+  })
+})

--- a/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.integration.test.ts
@@ -1,18 +1,22 @@
 import { HumanMessage } from '@langchain/core/messages'
-import { END } from '@langchain/langgraph'
+import { END, START, StateGraph } from '@langchain/langgraph'
 import { describe, it } from 'vitest'
 import {
   getTestConfig,
   outputStream,
-  setupGraph,
 } from '../../../test-utils/workflowTestHelpers'
+import { workflowAnnotation } from '../../chat/workflow/shared/createAnnotations'
 import type { WorkflowState } from '../../chat/workflow/types'
 import { designSchemaNode } from './designSchemaNode'
 
 describe('designSchemaNode Integration', () => {
   it('should execute designSchemaNode with real APIs', async () => {
     // Arrange
-    const graph = setupGraph(designSchemaNode)
+    const graph = new StateGraph(workflowAnnotation)
+      .addNode('designSchemaNode', designSchemaNode)
+      .addEdge(START, 'designSchemaNode')
+      .addEdge('designSchemaNode', END)
+      .compile()
     const { config, context } = await getTestConfig()
 
     const userInput =

--- a/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.integration.test.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.integration.test.ts
@@ -1,18 +1,22 @@
 import { AIMessage, HumanMessage } from '@langchain/core/messages'
-import { END } from '@langchain/langgraph'
+import { END, START, StateGraph } from '@langchain/langgraph'
 import { describe, it } from 'vitest'
 import {
   getTestConfig,
   outputStream,
-  setupGraph,
 } from '../../../test-utils/workflowTestHelpers'
+import { workflowAnnotation } from '../../chat/workflow/shared/createAnnotations'
 import type { WorkflowState } from '../../chat/workflow/types'
 import { summarizeWorkflow } from './index'
 
 describe('summarizeWorkflow Integration', () => {
   it('should execute summarizeWorkflow with real APIs', async () => {
     // Arrange
-    const graph = setupGraph(summarizeWorkflow)
+    const graph = new StateGraph(workflowAnnotation)
+      .addNode('summarizeWorkflow', summarizeWorkflow)
+      .addEdge(START, 'summarizeWorkflow')
+      .addEdge('summarizeWorkflow', END)
+      .compile()
     const { config, context } = await getTestConfig()
 
     // Explicitly define the state needed for summarization

--- a/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.integration.test.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.integration.test.ts
@@ -1,0 +1,54 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages'
+import { END } from '@langchain/langgraph'
+import { describe, it } from 'vitest'
+import {
+  getTestConfig,
+  outputStream,
+  setupGraph,
+} from '../../../test-utils/workflowTestHelpers'
+import type { WorkflowState } from '../../chat/workflow/types'
+import { summarizeWorkflow } from './index'
+
+describe('summarizeWorkflow Integration', () => {
+  it('should execute summarizeWorkflow with real APIs', async () => {
+    // Arrange
+    const graph = setupGraph(summarizeWorkflow)
+    const { config, context } = await getTestConfig()
+
+    // Explicitly define the state needed for summarization
+    const state: WorkflowState = {
+      userInput:
+        'Create a user management system with users, roles, and permissions tables',
+      messages: [
+        new HumanMessage(
+          'Create a user management system with users, roles, and permissions tables',
+        ),
+        new HumanMessage('I need to track user permissions and roles'),
+        new AIMessage({
+          content:
+            'I understand you need a permission and role system. Let me design tables for users, roles, and permissions with proper relationships.',
+          name: 'db-agent',
+        }),
+        new HumanMessage('Yes, and make sure users can have multiple roles'),
+        new AIMessage({
+          content:
+            "I've designed a many-to-many relationship between users and roles using a user_roles junction table. This allows users to have multiple roles.",
+          name: 'db-agent',
+        }),
+      ],
+      schemaData: { tables: {}, enums: {}, extensions: {} }, // Not used by summarizeWorkflow
+      buildingSchemaId: context.buildingSchemaId,
+      latestVersionNumber: context.latestVersionNumber,
+      designSessionId: context.designSessionId,
+      userId: context.userId,
+      organizationId: context.organizationId,
+      next: END,
+    }
+
+    // Act
+    const stream = await graph.stream(state, config)
+
+    // Assert (Output)
+    await outputStream(stream)
+  })
+})

--- a/frontend/internal-packages/agent/src/pm-agent/nodes/analyzeRequirementsNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/nodes/analyzeRequirementsNode.integration.test.ts
@@ -1,0 +1,64 @@
+import { HumanMessage } from '@langchain/core/messages'
+import { END, START, StateGraph } from '@langchain/langgraph'
+import { aColumn, aSchema, aTable } from '@liam-hq/schema'
+import { describe, it } from 'vitest'
+import {
+  getTestConfig,
+  outputStream,
+} from '../../../test-utils/workflowTestHelpers'
+import {
+  type PmAgentState,
+  pmAgentStateAnnotation,
+} from '../pmAgentAnnotations'
+import { analyzeRequirementsNode } from './analyzeRequirementsNode'
+
+describe('analyzeRequirementsNode Integration', () => {
+  it('should execute analyzeRequirementsNode with real APIs', async () => {
+    // Arrange
+    const graph = new StateGraph(pmAgentStateAnnotation)
+      .addNode('analyzeRequirementsNode', analyzeRequirementsNode)
+      .addEdge(START, 'analyzeRequirementsNode')
+      .addEdge('analyzeRequirementsNode', END)
+      .compile()
+    const { config, context } = await getTestConfig()
+
+    const userInput =
+      'Create a task management system where users can create projects, assign tasks, and track progress'
+
+    const state: PmAgentState = {
+      messages: [new HumanMessage(userInput)],
+      analyzedRequirements: {
+        businessRequirement: '',
+        functionalRequirements: {},
+        nonFunctionalRequirements: {},
+      },
+      designSessionId: context.designSessionId,
+      schemaData: aSchema({
+        tables: {
+          users: aTable({
+            name: 'users',
+            columns: {
+              id: aColumn({
+                name: 'id',
+                type: 'uuid',
+                notNull: true,
+              }),
+              email: aColumn({
+                name: 'email',
+                type: 'varchar',
+                notNull: true,
+              }),
+            },
+          }),
+        },
+      }),
+      analyzedRequirementsRetryCount: 0,
+    }
+
+    // Act
+    const stream = await graph.stream(state, config)
+
+    // Assert (Output)
+    await outputStream(stream)
+  })
+})

--- a/frontend/internal-packages/agent/test-utils/workflowTestHelpers.ts
+++ b/frontend/internal-packages/agent/test-utils/workflowTestHelpers.ts
@@ -1,0 +1,97 @@
+import type { RunnableConfig } from '@langchain/core/runnables'
+import { END, START, StateGraph } from '@langchain/langgraph'
+import {
+  createLogger,
+  setupDatabaseAndUser,
+  validateEnvironment,
+} from '../scripts/shared/scriptUtils'
+import { findOrCreateDesignSession } from '../scripts/shared/sessionUtils'
+import { processStreamChunk } from '../scripts/shared/streamingUtils'
+import { workflowAnnotation } from '../src/chat/workflow/shared/createAnnotations'
+import type { WorkflowState } from '../src/chat/workflow/types'
+
+type NodeFn =
+  | ((state: WorkflowState) => Promise<Partial<WorkflowState> | WorkflowState>)
+  | ((
+      state: WorkflowState,
+      config: RunnableConfig,
+    ) => Promise<Partial<WorkflowState> | WorkflowState>)
+
+/**
+ * Sets up a compiled graph for a single node workflow
+ * Encapsulates the repetitive graph construction pattern
+ */
+export const setupGraph = (nodeFn: NodeFn, annotation = workflowAnnotation) => {
+  const nodeName = nodeFn.name
+
+  return new StateGraph(annotation)
+    .addNode(nodeName, nodeFn)
+    .addEdge(START, nodeName)
+    .addEdge(nodeName, END)
+    .compile()
+}
+
+type StreamChunk = Record<string, unknown>
+
+/**
+ * Processes and outputs the stream from a workflow execution
+ * Encapsulates the streaming and logging logic
+ */
+export const outputStream = async (
+  stream: AsyncGenerator<StreamChunk, void, unknown>,
+  logLevel: 'ERROR' | 'INFO' | 'DEBUG' = 'INFO',
+): Promise<void> => {
+  const logger = createLogger(logLevel)
+
+  for await (const chunk of stream) {
+    // Find the first non-null node output in the chunk
+    const nodeOutput = Object.values(chunk).find((value) => value !== undefined)
+    if (nodeOutput) {
+      processStreamChunk(logger, nodeOutput)
+    }
+  }
+}
+
+/**
+ * Gets the minimal configuration needed for integration tests
+ * Directly sets up the test environment without creating unnecessary state
+ */
+export const getTestConfig = async (): Promise<{
+  config: RunnableConfig
+  context: {
+    buildingSchemaId: string
+    latestVersionNumber: number
+    designSessionId: string
+    userId: string
+    organizationId: string
+  }
+}> => {
+  const logger = createLogger('ERROR') // Only show errors during test setup
+
+  const setupResult = await validateEnvironment()
+    .andThen(setupDatabaseAndUser(logger))
+    .andThen(findOrCreateDesignSession(undefined))
+
+  if (setupResult.isErr()) {
+    throw setupResult.error
+  }
+
+  const { organization, buildingSchema, designSession, user, repositories } =
+    setupResult.value
+
+  return {
+    config: {
+      configurable: {
+        repositories,
+        thread_id: designSession.id,
+      },
+    },
+    context: {
+      buildingSchemaId: buildingSchema.id,
+      latestVersionNumber: buildingSchema.latest_version_number,
+      designSessionId: designSession.id,
+      userId: user.id,
+      organizationId: organization.id,
+    },
+  }
+}

--- a/frontend/internal-packages/agent/test-utils/workflowTestHelpers.ts
+++ b/frontend/internal-packages/agent/test-utils/workflowTestHelpers.ts
@@ -1,5 +1,4 @@
 import type { RunnableConfig } from '@langchain/core/runnables'
-import { END, START, StateGraph } from '@langchain/langgraph'
 import {
   createLogger,
   setupDatabaseAndUser,
@@ -7,38 +6,13 @@ import {
 } from '../scripts/shared/scriptUtils'
 import { findOrCreateDesignSession } from '../scripts/shared/sessionUtils'
 import { processStreamChunk } from '../scripts/shared/streamingUtils'
-import { workflowAnnotation } from '../src/chat/workflow/shared/createAnnotations'
-import type { WorkflowState } from '../src/chat/workflow/types'
-
-type NodeFn =
-  | ((state: WorkflowState) => Promise<Partial<WorkflowState> | WorkflowState>)
-  | ((
-      state: WorkflowState,
-      config: RunnableConfig,
-    ) => Promise<Partial<WorkflowState> | WorkflowState>)
-
-/**
- * Sets up a compiled graph for a single node workflow
- * Encapsulates the repetitive graph construction pattern
- */
-export const setupGraph = (nodeFn: NodeFn, annotation = workflowAnnotation) => {
-  const nodeName = nodeFn.name
-
-  return new StateGraph(annotation)
-    .addNode(nodeName, nodeFn)
-    .addEdge(START, nodeName)
-    .addEdge(nodeName, END)
-    .compile()
-}
-
-type StreamChunk = Record<string, unknown>
 
 /**
  * Processes and outputs the stream from a workflow execution
  * Encapsulates the streaming and logging logic
  */
-export const outputStream = async (
-  stream: AsyncGenerator<StreamChunk, void, unknown>,
+export const outputStream = async <T extends Record<string, unknown>>(
+  stream: AsyncGenerator<T, void, unknown>,
   logLevel: 'ERROR' | 'INFO' | 'DEBUG' = 'INFO',
 ): Promise<void> => {
   const logger = createLogger(logLevel)

--- a/frontend/internal-packages/agent/tsconfig.json
+++ b/frontend/internal-packages/agent/tsconfig.json
@@ -5,6 +5,11 @@
     "declaration": true,
     "target": "ES2022"
   },
-  "include": ["src/**/*", "scripts/**/*"],
+  "include": [
+    "src/**/*",
+    "scripts/**/*",
+    "test-utils/**/*",
+    "vitest.config.*.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/frontend/internal-packages/agent/vitest.config.integration.ts
+++ b/frontend/internal-packages/agent/vitest.config.integration.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['**/*.integration.test.ts'],
+    testTimeout: 300000,
+    reporters: ['dot'],
+  },
+})


### PR DESCRIPTION
## Issue

- resolve: N/A (Proactive improvement)

## Why is this change needed?

This PR adds integration test infrastructure for the agent package and removes the setupGraph helper to fix type errors. The changes include:

1. **Integration test infrastructure**: Added test utilities and configuration for running integration tests separately from unit tests
2. **Test coverage**: Added integration tests for critical workflows (designSchemaNode, summarizeWorkflow, analyzeRequirementsNode)  
3. **Type safety improvement**: Removed the setupGraph helper function which was causing type errors and replaced with direct usage of typed methods

These changes improve the reliability and maintainability of the agent package by providing better test coverage and cleaner type-safe code.