### PR TITLE
🐛 Fix GitHub Actions authentication error in license-report-update workflow

### DIFF
--- a/.github/workflows/license-report-update.yml
+++ b/.github/workflows/license-report-update.yml
@@ -58,7 +58,11 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           git add "$LICENSE_REPORT"
           git commit -m "Update $LICENSE_REPORT"
+          
+          # Configure git to use the token for authentication
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH_NAME"
+          
           gh pr create \
             --title "[$(date +'%Y/%m/%d')] License Report Update" \
             --body "This pull request automatically updates the license report."


### PR DESCRIPTION
## Issue

- resolve: GitHub Actions authentication error after adding persist-credentials: false

## Why is this change needed?

After the security improvements that added `persist-credentials: false` to all checkout actions, the license-report-update workflow started failing with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

This PR fixes the authentication issue by configuring git to use the GitHub App token for pushing branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the license report automation workflow to configure authenticated pushes before updating branches. This improves the reliability of automated license report updates and subsequent pull request creation across environments where credentials may not persist. No changes to application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->