### PR TITLE
✨(auth): Add dynamic OAuth callback URL based on accessed domain

### DIFF
--- a/frontend/apps/app/components/LoginPage/services/loginByGithub.ts
+++ b/frontend/apps/app/components/LoginPage/services/loginByGithub.ts
@@ -1,23 +1,40 @@
 'use server'
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/libs/db/server'
 
 type OAuthProvider = 'github'
 
-function getAuthCallbackUrl({
+async function getAuthCallbackUrl({
   next = '/app/design_sessions/new',
   provider,
 }: {
   next?: string
   provider: OAuthProvider
-}): string {
-  let url = process.env.SITE_URL
-    ? `https://${process.env.SITE_URL}`
-    : process.env.VERCEL_BRANCH_URL
-      ? `https://${process.env.VERCEL_BRANCH_URL}`
-      : 'http://localhost:3001/'
+}): Promise<string> {
+  const headersList = await headers()
+  const host = headersList.get('host')
+
+  let url: string
+
+  // Production environment with custom domain handling
+  if (process.env.SITE_URL && process.env.NODE_ENV === 'production') {
+    // Check if accessed via app.liambx.com
+    if (host === 'app.liambx.com') {
+      url = 'https://app.liambx.com'
+    } else {
+      // Default to SITE_URL (liambx.com)
+      url = `https://${process.env.SITE_URL}`
+    }
+  } else if (process.env.VERCEL_BRANCH_URL) {
+    // Preview deployments
+    url = `https://${process.env.VERCEL_BRANCH_URL}`
+  } else {
+    // Local development
+    url = 'http://localhost:3001/'
+  }
+
   url = url.endsWith('/') ? url : `${url}/`
   return `${url}app/auth/callback/${provider}?next=${encodeURIComponent(next)}`
 }
@@ -36,7 +53,7 @@ export async function loginByGithub(formData: FormData) {
   const cookieStore = await cookies()
   cookieStore.delete('returnTo')
 
-  const redirectTo = getAuthCallbackUrl({
+  const redirectTo = await getAuthCallbackUrl({
     provider: 'github',
     next: returnTo,
   })


### PR DESCRIPTION
## Issue

- resolve:  https://github.com/route06/liam-internal/issues/5534 (Internal migration requirement)

## Why is this change needed?

We are preparing to migrate from `liambx.com` to `app.liambx.com` as our main production domain. During the transition period, we need to support OAuth authentication from both domains simultaneously.

This change modifies the OAuth callback URL generation to dynamically use the domain that the user accessed the application from, ensuring seamless authentication during the migration period.

## Changes

- Modified `getAuthCallbackUrl` function in `loginByGithub.ts` to:
  - Read the Host header from the incoming request
  - Return `app.liambx.com` callback URL when accessed via `app.liambx.com`
  - Return `liambx.com` callback URL when accessed via `liambx.com`
  - Maintain existing behavior for preview and local environments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GitHub login now supports preview deployments with correct callback URLs.
- Bug Fixes
  - Fixed occasional misdirected or failing redirects during GitHub sign-in by accurately determining the callback URL based on the current environment (production, preview, local).
  - Ensures consistent redirection after authentication, reducing login errors for users navigating from different hosts or environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->