### PR TITLE
🐛 Fix ToolMessage streaming in chat UI

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -1,18 +1,12 @@
 'use client'
 
 import {
-  AIMessage,
-  type BaseMessage,
-  FunctionMessage,
-  HumanMessage,
+  mapStoredMessagesToChatMessages,
   type StoredMessage,
-  SystemMessage,
-  ToolMessage,
 } from '@langchain/core/messages'
 import type { Schema } from '@liam-hq/schema'
 import clsx from 'clsx'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
-import { match } from 'ts-pattern'
 import { Chat } from './components/Chat'
 import { Output } from './components/Output'
 import { useRealtimeArtifact } from './components/Output/components/Artifact/hooks/useRealtimeArtifact'
@@ -29,39 +23,6 @@ import type {
   Version,
   WorkflowRunStatus,
 } from './types'
-
-const reviveMessage = (stored: StoredMessage): BaseMessage => {
-  return match(stored.type)
-    .with('ai', () => new AIMessage(stored.data))
-    .with('human', () => new HumanMessage(stored.data))
-    .with('system', () => new SystemMessage(stored.data))
-    .with(
-      'tool',
-      () =>
-        new ToolMessage({
-          ...stored.data,
-          tool_call_id: stored.data.tool_call_id || '',
-        }),
-    )
-    .with(
-      'function',
-      () =>
-        new FunctionMessage({
-          ...stored.data,
-          name: stored.data.name || 'unknown',
-        }),
-    )
-    .otherwise(() => {
-      console.warn(
-        `Unsupported message type: ${stored.type}, falling back to HumanMessage`,
-      )
-      return new HumanMessage(stored.data)
-    })
-}
-
-const reviveMessages = (list: StoredMessage[]): BaseMessage[] => {
-  return list.map(reviveMessage)
-}
 
 type Props = {
   buildingSchemaId: string
@@ -142,10 +103,9 @@ export const SessionDetailPageClient: FC<Props> = ({
     initialWorkflowRunStatus,
   )
 
-  // Revive stored messages to BaseMessage instances
-  const revivedMessages = reviveMessages(initialMessages)
+  const chatMessages = mapStoredMessagesToChatMessages(initialMessages)
   const { isStreaming, messages, start } = useStream({
-    initialMessages: revivedMessages,
+    initialMessages: chatMessages,
   })
   // Track if initial workflow has been triggered to prevent multiple executions
   const hasTriggeredInitialWorkflow = useRef(false)

--- a/frontend/apps/app/components/SessionDetailPage/hooks/useStream/MessageTupleManager.ts
+++ b/frontend/apps/app/components/SessionDetailPage/hooks/useStream/MessageTupleManager.ts
@@ -4,6 +4,8 @@ import {
   coerceMessageLikeToMessage,
   convertToChunk,
   isBaseMessageChunk,
+  isToolMessage,
+  ToolMessageChunk,
 } from '@langchain/core/messages'
 
 function tryConvertToChunk(message: BaseMessage) {
@@ -33,7 +35,15 @@ export class MessageTupleManager {
 
   add(serialized: BaseMessage, metadata: Record<string, unknown> | undefined) {
     const message = coerceMessageLikeToMessage(serialized)
-    const chunk = tryConvertToChunk(message)
+
+    // Handle ToolMessage separately since convertToChunk doesn't support it
+    let chunk: BaseMessageChunk | null
+    if (isToolMessage(message)) {
+      chunk = new ToolMessageChunk(message)
+    } else {
+      chunk = tryConvertToChunk(message)
+    }
+
     const { id } = chunk ?? message
     if (!id) return null
 

--- a/frontend/internal-packages/agent/src/db-agent/invokeDesignAgent.ts
+++ b/frontend/internal-packages/agent/src/db-agent/invokeDesignAgent.ts
@@ -8,6 +8,7 @@ import {
 import { ChatOpenAI } from '@langchain/openai'
 import { fromAsyncThrowable } from '@liam-hq/neverthrow'
 import { ResultAsync } from 'neverthrow'
+import { v4 as uuidv4 } from 'uuid'
 import * as v from 'valibot'
 import { SSE_EVENTS } from '../client'
 import { reasoningSchema } from '../langchain/utils/schema'
@@ -48,7 +49,7 @@ export const invokeDesignAgent = (
       (async () => {
         // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
         // so we overwrite with a UUID to unify chunk ids for consistent handling.
-        const id = crypto.randomUUID()
+        const id = uuidv4()
         let accumulatedChunk: AIMessageChunk | null = null
 
         for await (const _chunk of stream) {

--- a/frontend/internal-packages/agent/src/lead-agent/classifyMessage/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/classifyMessage/index.ts
@@ -54,7 +54,7 @@ export async function classifyMessage(
         (async () => {
           // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
           // so we overwrite with a UUID to unify chunk ids for consistent handling.
-          const id = crypto.randomUUID()
+          const id = uuidv4()
           let accumulatedChunk: AIMessageChunk | null = null
 
           for await (const _chunk of stream) {

--- a/frontend/internal-packages/agent/src/lead-agent/classifyMessage/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/classifyMessage/index.ts
@@ -10,6 +10,7 @@ import { Command, END } from '@langchain/langgraph'
 import { ChatOpenAI } from '@langchain/openai'
 import { fromAsyncThrowable } from '@liam-hq/neverthrow'
 import { ResultAsync } from 'neverthrow'
+import { v4 as uuidv4 } from 'uuid'
 import { getConfigurable } from '../../chat/workflow/shared/getConfigurable'
 import type {
   WorkflowConfigurable,
@@ -100,11 +101,14 @@ export async function classifyMessage(
   // 3. Check if database design request (tool call to routeToAgent)
   if (response.tool_calls?.[0]?.name === 'routeToAgent') {
     // Create ToolMessage to properly complete the tool call
+    const id = uuidv4()
     const toolMessage = new ToolMessage({
+      id,
       status: 'success',
       content: response.tool_calls[0].args?.['targetAgent'] || 'pmAgent',
       tool_call_id: response.tool_calls[0].id ?? '',
     })
+    await dispatchCustomEvent(SSE_EVENTS.MESSAGES, toolMessage)
 
     // Route to PM Agent with both the AI response and tool completion
     return new Command({

--- a/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
@@ -7,6 +7,7 @@ import {
 import { END } from '@langchain/langgraph'
 import { ChatOpenAI } from '@langchain/openai'
 import { ResultAsync } from 'neverthrow'
+import { v4 as uuidv4 } from 'uuid'
 import type { WorkflowState } from '../../chat/workflow/types'
 import { SSE_EVENTS } from '../../client'
 
@@ -66,7 +67,7 @@ Keep the summary informative but concise, focusing on the key achievements and d
       (async () => {
         // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
         // so we overwrite with a UUID to unify chunk ids for consistent handling.
-        const id = crypto.randomUUID()
+        const id = uuidv4()
         let accumulatedChunk: AIMessageChunk | null = null
 
         for await (const _chunk of stream) {

--- a/frontend/internal-packages/agent/src/lead-agent/tools/routeToAgent.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/tools/routeToAgent.ts
@@ -4,6 +4,7 @@ import { type StructuredTool, tool } from '@langchain/core/tools'
 import { Command } from '@langchain/langgraph'
 import { fromValibotSafeParse } from '@liam-hq/neverthrow'
 import { ok, type Result } from 'neverthrow'
+import { v4 as uuidv4 } from 'uuid'
 import * as v from 'valibot'
 import { WorkflowTerminationError } from '../../shared/errorHandling'
 import { toJsonSchema } from '../../shared/jsonSchema'
@@ -65,6 +66,7 @@ export const routeToAgent: StructuredTool = tool(
         next: inputParseResult.output.targetAgent,
         messages: [
           new ToolMessage({
+            id: uuidv4(),
             content: `Routing request to ${inputParseResult.output.targetAgent}`,
             tool_call_id: toolCallId,
           }),

--- a/frontend/internal-packages/agent/src/pm-agent/invokePmAnalysisAgent.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/invokePmAnalysisAgent.ts
@@ -8,6 +8,7 @@ import {
 import { ChatOpenAI } from '@langchain/openai'
 import { fromAsyncThrowable } from '@liam-hq/neverthrow'
 import { ResultAsync } from 'neverthrow'
+import { v4 as uuidv4 } from 'uuid'
 import * as v from 'valibot'
 import type { WorkflowConfigurable } from '../chat/workflow/types'
 import { SSE_EVENTS } from '../client'
@@ -66,7 +67,7 @@ export const invokePmAnalysisAgent = (
       (async () => {
         // OpenAI ("chatcmpl-...") and LangGraph ("run-...") use different id formats,
         // so we overwrite with a UUID to unify chunk ids for consistent handling.
-        const id = crypto.randomUUID()
+        const id = uuidv4()
         let accumulatedChunk: AIMessageChunk | null = null
 
         for await (const _chunk of stream) {

--- a/frontend/internal-packages/agent/src/pm-agent/tools/saveRequirementsToArtifactTool.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/tools/saveRequirementsToArtifactTool.ts
@@ -1,3 +1,4 @@
+import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch'
 import { ToolMessage } from '@langchain/core/messages'
 import type { RunnableConfig } from '@langchain/core/runnables'
 import { type StructuredTool, tool } from '@langchain/core/tools'
@@ -9,8 +10,10 @@ import type {
 } from '@liam-hq/artifact'
 import { fromValibotSafeParse } from '@liam-hq/neverthrow'
 import { err, ok, type Result } from 'neverthrow'
+import { v4 as uuidv4 } from 'uuid'
 import * as v from 'valibot'
 import { getConfigurable } from '../../chat/workflow/shared/getConfigurable'
+import { SSE_EVENTS } from '../../client'
 import type { Repositories } from '../../repositories'
 import { WorkflowTerminationError } from '../../shared/errorHandling'
 import { toJsonSchema } from '../../shared/jsonSchema'
@@ -132,10 +135,12 @@ export const saveRequirementsToArtifactTool: StructuredTool = tool(
     }
 
     const toolMessage = new ToolMessage({
+      id: uuidv4(),
       status: 'success',
       content: 'Requirements saved successfully to artifact',
       tool_call_id: toolCallId,
     })
+    await dispatchCustomEvent(SSE_EVENTS.MESSAGES, toolMessage)
 
     return new Command({
       update: {


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

ToolMessage instances were not being properly converted to ToolMessageChunk during streaming, causing them to be excluded from the chat UI. This affected the display of tool execution results in real-time chat interactions.

| Streaming | Reload |
|--------|--------|
| <img width="1691" height="993" alt="スクリーンショット 2025-09-01 21 55 57" src="https://github.com/user-attachments/assets/bbf55625-b249-45ae-938c-f1040156d828" /> | <img width="1689" height="997" alt="スクリーンショット 2025-09-01 21 56 21" src="https://github.com/user-attachments/assets/b12181db-3584-45ab-b08e-e7e158fd5394" /> | 

## Summary

This PR fixes the handling of ToolMessage in the streaming chat implementation:

1. **MessageTupleManager enhancement**: Added special handling for ToolMessage to manually convert it to ToolMessageChunk, since LangChain's `convertToChunk` doesn't support ToolMessage
2. **Agent tool improvements**: Added unique IDs to all ToolMessage instances and dispatch them through SSE events for proper streaming
3. **Code consistency**: Unified UUID generation across all agent modules to use the uuid package

## Changes

- Modified `MessageTupleManager` to detect and handle ToolMessage instances
- Updated agent tools (lead, PM, QA) to properly dispatch ToolMessage events
- Replaced `crypto.randomUUID()` with `uuidv4()` for consistent UUID generation

## Test

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e3bb0e75-f330-4dac-bc03-034483b4778a" /> | <video src="https://github.com/user-attachments/assets/3990cf4d-9282-4522-99ef-2c1f31cfb2ef" /> | 

