### PR TITLE
🔧 Remove legacy erd-web domain references

### DIFF
--- a/frontend/apps/app/.env.production
+++ b/frontend/apps/app/.env.production
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_ENV_NAME=production
-ASSET_PREFIX="https://liam-erd-web.vercel.app"
+ASSET_PREFIX="https://app.liambx.com"

--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
     serverActions: {
       allowedOrigins:
         process.env.VERCEL_ENV === 'production'
-          ? ['liambx.com', 'liam-erd-web.vercel.app', 'app.liambx.com']
+          ? ['liambx.com', 'app.liambx.com']
           : undefined,
     },
   },
@@ -32,10 +32,6 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
-      },
-      {
-        protocol: 'https',
-        hostname: 'liam-erd-web.vercel.app',
       },
       {
         protocol: 'https',


### PR DESCRIPTION
## Issue

- resolve: #5560

## Why is this change needed?
This PR removes all remaining references to the deprecated `liam-erd-web.vercel.app` domain from the production configuration. The changes include:
- Updated production asset prefix to use `app.liambx.com`
- Removed `liam-erd-web.vercel.app` from allowed origins in server actions
- Removed `liam-erd-web.vercel.app` from image domains configuration

These changes complete the migration from the legacy domain to the new production domain.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>