### PR TITLE
🐛 Fix Vercel preview environment baseUrl undefined issue

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/OutputPlaceholder/OutputPlaceholder.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/OutputPlaceholder/OutputPlaceholder.tsx
@@ -2,20 +2,9 @@ import { Fit, Layout, useRive } from '@rive-app/react-canvas'
 import type { FC } from 'react'
 import styles from './OutputPlaceholder.module.css'
 
-const baseUrl = () => {
-  switch (process.env.NEXT_PUBLIC_ENV_NAME) {
-    case 'production':
-      return process.env.NEXT_PUBLIC_BASE_URL // NEXT_PUBLIC_BASE_URL includes "https://"
-    case 'preview':
-      return `https://${process.env.VERCEL_BRANCH_URL}` // VERCEL_BRANCH_URL does not include "https://"
-    default:
-      return 'http://localhost:3001'
-  }
-}
-
 const RiveComponent = () => {
   const { RiveComponent } = useRive({
-    src: `${baseUrl()}/assets/loading_jack.riv`,
+    src: '/assets/loading_jack.riv',
     stateMachines: 'State Machine 1',
     layout: new Layout({
       fit: Fit.Contain,


### PR DESCRIPTION


## Issue

- resolve: Fix undefined baseUrl in Vercel preview environment for Rive asset loading https://github.com/route06/liam-internal/issues/5207

## Why is this change needed?

The OutputPlaceholder component was attempting to construct full URLs for the Rive animation asset using environment variables, which caused issues in Vercel preview environments where VERCEL_URL and VERCEL_BRANCH_URL are not accessible on the client-side.

The solution was to simplify the approach by using a relative path `/assets/loading_jack.riv` instead of constructing full URLs with environment-specific logic. This change:
- Removes complex environment variable handling that wasn't working reliably
- Uses a simple relative path that works across all environments (local, preview, production)
- Eliminates the undefined URL issue in Vercel preview deployments
- Makes the code more maintainable and less error-prone

## tested

- [x] in my local pc
- [x]  vercel preview env