### PR TITLE
📝(ci): Clarify Trusted Publisher configuration requirements in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,8 @@
+# NOTE: This workflow is configured as a Trusted Publisher on npmjs.com
+# The workflow filename "release.yml" is registered in the Trusted Publisher settings.
+# If you rename this file, you must also update the Trusted Publisher configuration on npmjs.com
+# ex. https://www.npmjs.com/package/@liam-hq/cli/access
+
 name: release
 on:
   push:
@@ -42,7 +47,6 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Trigger released_package_test.yml via API
         if: ${{ steps.changesets-action.outputs.published == 'true' }}
         run: |


### PR DESCRIPTION
## Issue

- N/A

## Why is this change needed?

The release workflow uses npm's Trusted Publisher feature for authentication, which eliminates the need for NPM_TOKEN. The workflow filename "release.yml" is registered with npmjs.com as a Trusted Publisher.

This PR adds a clear comment explaining that if anyone renames the workflow file, they must also update the Trusted Publisher configuration on npmjs.com for each package. This prevents authentication failures during the release process.

🤖 Generated with [Claude Code](https://claude.ai/code)