### PR TITLE
🔧 Exclude liam-assets from E2E test triggers

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -46,7 +46,7 @@ jobs:
               if (environment_val.include?("Production") && target_url.include?("liam-app-git-main"))
                 "should_run=true"
               # Preview deployment
-              elsif environment_val.include?("Preview") && !target_url.include?("liam-erd-sample") && !target_url.include?("liam-docs") && !target_url.include?("liam-storybook")
+              elsif environment_val.include?("Preview") && !target_url.include?("liam-erd-sample") && !target_url.include?("liam-docs") && !target_url.include?("liam-storybook") && !target_url.include?("liam-assets")
                 "should_run=true"
               else
                 "should_run=false"


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
Add liam-assets to the exclusion list for E2E test deployment triggers to prevent unnecessary test runs for asset-only deployments. This optimizes the CI pipeline by avoiding E2E tests when only asset files are deployed.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined preview deployment criteria for E2E runs to exclude asset-only previews, reducing unnecessary test executions.
  * Improves CI efficiency and speeds up feedback on relevant previews.
  * No impact on production test gating or behavior.
* **Chores**
  * Updated workflow conditions to better target meaningful preview environments for automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->