### PR TITLE
Configure LangChain callbacks for integration tests

### DIFF
--- a/frontend/internal-packages/agent/vitest.config.integration.ts
+++ b/frontend/internal-packages/agent/vitest.config.integration.ts
@@ -7,5 +7,13 @@ export default defineConfig({
     include: ['**/*.integration.test.ts'],
     testTimeout: 300000,
     reporters: ['dot'],
+    env: {
+      // Disable background callbacks for LangChain to ensure proper tracing in tests
+      // When running LangGraph in tests, we need to send traces to LangSmith synchronously
+      // If callbacks complete in the background, test execution may end before traces are sent
+      // Setting this to 'false' ensures callbacks complete before test finishes
+      // Reference: https://js.langchain.com/docs/how_to/callbacks_serverless
+      LANGCHAIN_CALLBACKS_BACKGROUND: 'false',
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Add `LANGCHAIN_CALLBACKS_BACKGROUND=false` to vitest integration test configuration
- Ensures synchronous callback execution for proper LangSmith trace transmission
- Prevents test completion before traces are sent, improving test reliability

## Testing
|before|after|
| --- | --- |
|<img width="1831" height="1337" alt="Pasted_Image_2025_09_04__17_18" src="https://github.com/user-attachments/assets/5b707f86-b95f-4cf2-8caf-4518808f844c" />|<img width="1831" height="1337" alt="c4c215928bd704d6d417af9d45a9e5be340fd4e2d3d4ac59bbfb763c77723784" src="https://github.com/user-attachments/assets/41898eca-9f17-4ee7-83b1-bc0d59241a61" />|
| [link](https://smith.langchain.com/o/eed4d2d8-0bd8-4ca4-a452-4da88ef63fd6/projects/p/99d63e81-58f9-475a-8985-409b591e26b0?timeModel=%7B%22duration%22%3A%227d%22%7D&runtab=0&searchModel=%7B%22filter%22%3A%22eq%28is_root%2C+true%29%22%7D&peek=d0166ef4-76fc-4137-8b5c-ef05fad71f5d&peeked_trace=d0166ef4-76fc-4137-8b5c-ef05fad71f5d) | [link](https://smith.langchain.com/o/eed4d2d8-0bd8-4ca4-a452-4da88ef63fd6/projects/p/99d63e81-58f9-475a-8985-409b591e26b0?timeModel=%7B%22duration%22%3A%227d%22%7D&runtab=0&searchModel=%7B%22filter%22%3A%22eq%28is_root%2C+true%29%22%7D&peek=fe7c28f1-aa31-4df4-bc8f-04ee750c3c49&peeked_trace=fe7c28f1-aa31-4df4-bc8f-04ee750c3c49) |









🤖 Generated with [Claude Code](https://claude.ai/code)