### PR TITLE
♻️ Simplify E2E test trigger condition for preview deployments

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -46,7 +46,7 @@ jobs:
               if (environment_val.include?("Production") && target_url.include?("liam-app-git-main"))
                 "should_run=true"
               # Preview deployment
-              elsif environment_val.include?("Preview") && !target_url.include?("liam-erd-sample") && !target_url.include?("liam-docs") && !target_url.include?("liam-storybook") && !target_url.include?("liam-assets")
+              elsif environment_val.include?("Preview") && environment_val.include?("liam-app")
                 "should_run=true"
               else
                 "should_run=false"


### PR DESCRIPTION
## Issue

- resolve: N/A (code improvement)

## Why is this change needed?

The previous E2E test trigger condition for preview deployments used multiple negative checks to exclude specific apps (liam-erd-sample, liam-docs, liam-storybook, liam-assets). This approach was hard to maintain and could miss new apps that should also be excluded.

This change simplifies the logic by using a single positive condition that checks if the environment includes "liam-app", making it clearer and easier to maintain.



- https://github.com/liam-hq/liam/actions/runs/17461278999/job/49586322582
    - `environment_val = "Preview – liam-app"`
    -  <img width="1125" height="709" alt="スクリーンショット 2025-09-04 20 04 24" src="https://github.com/user-attachments/assets/7890e609-69bf-4906-a946-eedaafab2cda" />


