### PR TITLE
Enable noUnusedVariables rule for schema-bench package

### DIFF
--- a/frontend/internal-packages/schema-bench/biome.jsonc
+++ b/frontend/internal-packages/schema-bench/biome.jsonc
@@ -1,3 +1,10 @@
 {
-  "extends": ["../../internal-packages/configs/biome.jsonc"]
+  "extends": ["../../internal-packages/configs/biome.jsonc"],
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUnusedVariables": "error"
+      }
+    }
+  }
 }

--- a/frontend/internal-packages/schema-bench/src/cli/evaluateSchemaMulti.ts
+++ b/frontend/internal-packages/schema-bench/src/cli/evaluateSchemaMulti.ts
@@ -80,13 +80,10 @@ async function main() {
 
   // Collect statistics
   let allSuccess = true
-  let totalEvaluated = 0
   const failedDatasets = []
 
   for (const result of evaluationResults) {
-    if (result.success && result.results) {
-      totalEvaluated += result.results.length
-    } else if (!result.success) {
+    if (!result.success) {
       allSuccess = false
       failedDatasets.push(result.datasetName)
     }

--- a/frontend/internal-packages/schema-bench/src/cli/executeOpenai.ts
+++ b/frontend/internal-packages/schema-bench/src/cli/executeOpenai.ts
@@ -158,7 +158,6 @@ async function main() {
 
   // Process each case with max 5 concurrent requests
   const MAX_CONCURRENT = 5
-  let successCount = 0
   let failureCount = 0
 
   const getErrorMessage = (
@@ -187,7 +186,7 @@ async function main() {
 
       const { caseId } = batchItem
       if (result.status === 'fulfilled' && result.value.isOk()) {
-        successCount++
+        // Case executed successfully
       } else {
         failureCount++
         const error = getErrorMessage(result)


### PR DESCRIPTION
## Issue

- resolve: #3342

## Why is this change needed?

This change enables the `noUnusedVariables` biome rule for the @liam-hq/schema-bench package to maintain code quality by identifying and removing unused variables. This helps keep the benchmarking code clean and maintainable.

## Changes

- Updated `biome.jsonc` to enable `noUnusedVariables: "error"` rule
- Removed unused `totalEvaluated` variable in `evaluateSchemaMulti.ts`
- Removed unused `successCount` variable in `executeOpenai.ts`
- All biome lint violations now resolved while maintaining functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced stricter linting to flag unused variables as errors, improving code quality and consistency.

* **Refactor**
  * Streamlined CLI flows by removing unused success/total counters and simplifying control logic.
  * Preserved failure reporting and overall behavior; no user-visible output changes aside from eliminating unused metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->