### PR TITLE
✨ Add comprehensive format tests to released package workflow

### DIFF
--- a/.github/workflows/released_package_test.yml
+++ b/.github/workflows/released_package_test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "Starting after ${{ github.event.inputs.delay_seconds }} seconds"
           sleep ${{ github.event.inputs.delay_seconds }}
-      - name: check @liam-hq/cli exit code
+      - name: "check @liam-hq/cli exit code 1: version check"
         shell: bash
         run: |
           version="${{ github.event.inputs.version }}"
@@ -41,6 +41,22 @@ jobs:
             exit 1
           fi
           npx --yes @liam-hq/cli@${version} --version
+
+      - name: "check @liam-hq/cli exit code 2: --format postgres check"
+        run: |
+          version="${{ github.event.inputs.version }}"
+          npx --yes @liam-hq/cli@${version} erd build --input https://github.com/liam-hq/liam/blob/main/frontend/internal-packages/db/schema/schema.sql --format postgres
+
+      - name: "check @liam-hq/cli exit code 3: --format schemarb check"
+        run: |
+          version="${{ github.event.inputs.version }}"
+          npx --yes @liam-hq/cli@${version} erd build --input https://github.com/mastodon/mastodon/blob/e2f085e2b2cec08dc1f5ae825730c2a3bf62e054/db/schema.rb --format schemarb
+
+      - name: "check @liam-hq/cli exit code 4: --format prisma check"
+        run: |
+          version="${{ github.event.inputs.version }}"
+          npx --yes @liam-hq/cli@${version} erd build --input https://github.com/langfuse/langfuse/blob/cf29c6b7e447cf1aec7a8d50ae6a877c3844b7cd/packages/shared/prisma/schema.prisma --format prisma
+
 
       # derived from https://github.com/route06/actions/blob/8e3ac6855302a4fe3bd621ebd16c7a0da261948a/.github/workflows/notify_slack_on_ci_failed.yml
       - name: Slack Notification on Success


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

The released package test workflow was missing comprehensive tests for different schema formats. This PR adds tests for PostgreSQL, Schema.rb, and Prisma formats to ensure the CLI properly handles all supported formats in production releases.

The workflow now tests:
- PostgreSQL format with actual schema files
- Schema.rb format with Mastodon schema
- Prisma format with Langfuse schema

This improves our release testing coverage and helps catch format-specific issues before they reach users.

🤖 Generated with [Claude Code](https://claude.ai/code)


## tested

✅  manually kicked(workflow dispatch)
<img width="903" height="790" alt="スクリーンショット 2025-09-05 15 12 47" src="https://github.com/user-attachments/assets/e899ca58-e308-460d-8259-69a816e88166" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded release validation to run the CLI against multiple schema formats (Postgres, Rails schema.rb, Prisma) to ensure consistent ERD generation before publishing.
  - Clarified the version validation step name to improve workflow readability and intent.
  - All checks use the provided release version to mirror real-world usage via npx.
- Chores
  - Minor workflow naming improvements to make CI logs clearer for release verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->