### PR TITLE
🔧 Add npm update workaround for trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # NOTE: Temporary workaround
-      # - "Trusted publishing" requires npm 11.5.1+.
-      #   See: https://docs.npmjs.com/trusted-publishers
-      - name: Update npm
-        run: npm update -g npm
-
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         id: app-token
@@ -46,6 +40,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
+
+      # NOTE: Temporary workaround
+      # - "Trusted publishing" requires npm 11.5.1+.
+      #   See: https://docs.npmjs.com/trusted-publishers
+      - name: Update npm
+        run: npm update -g npm
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets-action
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # NOTE: Temporary workaround
+      # - "Trusted publishing" requires npm 11.5.1+.
+      #   See: https://docs.npmjs.com/trusted-publishers
+      - name: Update npm
+        run: npm update -g npm
+
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         id: app-token


### PR DESCRIPTION
## Issue

- resolve:N/A

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensured the release pipeline updates npm to a compatible version before publishing, reducing publishing failures and improving release reliability.
  * No user-facing changes; app behavior and APIs remain unchanged.
  * This is a temporary workaround to meet trusted-publishing requirements and does not affect local development or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->