### PR TITLE
publish neverthrow package

### DIFF
--- a/.changeset/cold-pens-live.md
+++ b/.changeset/cold-pens-live.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/neverthrow": patch
+---
+
+publish package because dependent from schema package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Trigger released_package_test.yml via API
         if: ${{ steps.changesets-action.outputs.published == 'true' }}
         run: |

--- a/frontend/internal-packages/neverthrow/package.json
+++ b/frontend/internal-packages/neverthrow/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@liam-hq/neverthrow",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/liam-hq/liam.git"
+  },
+  "license": "Apache-2.0",
   "version": "0.0.0",
   "type": "module",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "main": "src/index.ts",
   "exports": {
@@ -30,5 +34,11 @@
     "lint:biome": "biome check .",
     "lint:eslint": "eslint .",
     "lint:tsc": "tsc --noEmit"
-  }
+  },
+  "files": [
+    "src/**/*",
+    "README.md",
+    "package.json",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Prepared @liam-hq/neverthrow for public npm publishing, including a patch release changeset.
  - Added license and repository metadata to improve package transparency on npm.
  - Defined published artifacts via a files list to control what ships.
  - Updated release workflow to include an npm token for publishing.
- Documentation
  - Exposed license and repository details in the package metadata for end-user visibility on npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->