### PR TITLE
🔧 chore: set `save-exact=true` to install packages with exact versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

We always manually remove `^` the package versions in package.json so that dependencies are installed with exact versions.
This PR will [set `save-exact=true` in .npmrc](https://docs.npmjs.com/cli/v9/using-npm/config?v=true#save-exact) to force exact version installs automatically.

When we run `pnpm install jest --workspace-root`, the package.json will be modified as like:

```jsonc
// before
"dependencies": {
  "jest": "^30.1.3"
}

// after
"dependencies": {
  "jest": "30.1.3"
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Configured package manager to save dependencies with exact versions, ensuring consistent installations across environments.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->