### PR TITLE
🔧 Update Claude Code Action to v1.0.5

### DIFF
--- a/.github/workflows/claude-pr-creator.yml
+++ b/.github/workflows/claude-pr-creator.yml
@@ -42,7 +42,7 @@ jobs:
         run: bash .github/scripts/setup-claude.sh
 
       - name: Run Claude Code Action
-        uses: anthropics/claude-code-action@fd2c17f101639b10696381c1fd85fa735239090a # v1
+        uses: anthropics/claude-code-action@fd2c17f101639b10696381c1fd85fa735239090a # v1.0.5
         id: claude-code
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,7 +42,7 @@ jobs:
         run: bash .github/scripts/setup-claude.sh
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@fd2c17f101639b10696381c1fd85fa735239090a # v1
+        uses: anthropics/claude-code-action@fd2c17f101639b10696381c1fd85fa735239090a # v1.0.5
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |

--- a/.github/workflows/renovate-review.yml
+++ b/.github/workflows/renovate-review.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Auto review Renovate PR
-        uses: anthropics/claude-code-action@69dec299f882fef0fff1652a1309b7e9771b9f98 # beta
+        uses: anthropics/claude-code-action@fd2c17f101639b10696381c1fd85fa735239090a # v1.0.5
         with:
           direct_prompt: |
             Review this Renovate PR for dependency updates. Analyze regression risks by examining:


### PR DESCRIPTION
## Issue

- resolve: N/A (dependency update)
- for https://github.com/liam-hq/liam/pull/3360#pullrequestreview-3194782295

## Why is this change needed?
Updated Claude Code Action references from generic v1 tag to specific v1.0.5 tag for better version control and reproducibility across all GitHub workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Bug Fixes
  - Corrected a tool name in Renovate review automation to ensure comments post correctly during pending reviews.

- Chores
  - Updated internal workflow annotations to reference v1.0.5 for clarity.
  - Upgraded Renovate review automation to the stable Claude code-action v1.0.5.
  - No changes to workflow behavior, inputs, or execution flow; builds and reviews continue to run as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->