### PR TITLE
fix(storybook): Add appDirectory config for Next.js App Router support

### DIFF
--- a/frontend/internal-packages/storybook/.storybook/preview.ts
+++ b/frontend/internal-packages/storybook/.storybook/preview.ts
@@ -32,6 +32,12 @@ const preview: Preview = {
       },
     },
     layout: 'centered',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/',
+      }
+    },
   },
   initialGlobals: {
     backgrounds: { value: 'dark' },

--- a/frontend/internal-packages/storybook/.storybook/preview.ts
+++ b/frontend/internal-packages/storybook/.storybook/preview.ts
@@ -34,9 +34,6 @@ const preview: Preview = {
     layout: 'centered',
     nextjs: {
       appDirectory: true,
-      navigation: {
-        pathname: '/',
-      }
     },
   },
   initialGlobals: {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5587

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

The GitHubSessionFormPresenter Storybook stories were failing with the error:

<img width="1301" height="449" alt="ss 3846" src="https://github.com/user-attachments/assets/8c580290-0a16-44e7-901e-8ca4ae8c883b" />

This occurred because Storybook wasn't properly recognizing the Next.js App Router environment, causing `next/navigation` hooks to be unavailable during story rendering.

By adding appDirectory: true to the Storybook parameters, we enable proper Next.js App Router support, which automatically provides the necessary next/navigation mocks and resolves the router access errors.

📚 
https://storybook.js.org/docs/get-started/frameworks/nextjs#set-nextjsappdirectory-to-true


## Testing

I have verified this in both the local environment and the preview environment.

https://liam-storybook-git-fix-storybook-app-directory-config-re-liambx.vercel.app/?path=/docs/app-features-sessions-components-githubsessionform-githubsessionformpresenter--docs

<img width="1355" height="586" alt="ss 3853" src="https://github.com/user-attachments/assets/7f14306a-37c1-4d8f-adbd-fc9b94c5a9a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storybook now includes Next.js App Router support (enables app-directory behavior) for more accurate previews.
  * Preserves the centered layout for a familiar viewing experience.
  * Improves reliability and predictability of Storybook previews and interactions that depend on Next.js routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->