### PR TITLE
feat: add .env.local support to agent scriptUtils

### DIFF
--- a/frontend/internal-packages/agent/scripts/shared/scriptUtils.ts
+++ b/frontend/internal-packages/agent/scripts/shared/scriptUtils.ts
@@ -6,8 +6,9 @@ import type { Result } from 'neverthrow'
 import { err, errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
 import { createSupabaseRepositories } from '../../src/repositories/factory'
 
-// Load environment variables from ../../../../../.env
+// Load environment variables from ../../../../../.env and .env.local
 config({ path: resolve(__dirname, '../../../../../.env') })
+config({ path: resolve(__dirname, '../../../../../.env.local') })
 
 // Type guards for safe property access
 export const isObject = (value: unknown): value is Record<string, unknown> =>


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

Allow individual developers to configure personal environment settings (like `LOG_LEVEL=DEBUG`) through `.env.local` without affecting team-wide configurations or CI settings.

This change enables loading environment variables from both `.env` (shared) and `.env.local` (personal) files in the agent scriptUtils module.

## Changes Made

- Modified `frontend/internal-packages/agent/scripts/shared/scriptUtils.ts` to load from `.env.local` in addition to `.env`
- Added comment explaining the dual file loading purpose

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Agent scripts now load environment variables from both .env and .env.local, enabling local overrides without modifying shared configuration.
- Chores
  - Aligned environment loading behavior to improve developer setup flexibility and consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->