### PR TITLE
🐛 Fix GitHub OAuth callback URL path in production

### DIFF
--- a/frontend/apps/app/components/LoginPage/services/loginByGithub.ts
+++ b/frontend/apps/app/components/LoginPage/services/loginByGithub.ts
@@ -36,7 +36,7 @@ async function getAuthCallbackUrl({
   }
 
   url = url.endsWith('/') ? url : `${url}/`
-  return `${url}app/auth/callback/${provider}?next=${encodeURIComponent(next)}`
+  return `${url}auth/callback/${provider}?next=${encodeURIComponent(next)}`
 }
 
 export async function loginByGithub(formData: FormData) {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5614

## Why is this change needed?

The GitHub OAuth callback URL was incorrectly constructed with a duplicate 'app' segment in the path. This caused the authentication flow to fail in production environments where the application is deployed at the root path.

The URL was building `/app/auth/callback/github` instead of the correct `/auth/callback/github`, causing a 404 error when GitHub redirected users back after authentication.

## Changes

- Fixed the callback URL construction in `loginByGithub.ts` by removing the redundant 'app' segment
- The callback now correctly points to `/auth/callback/[provider]` which matches the Next.js route handler location

## Test plan

- [ ] Test GitHub login in local development environment
- [ ] Verify the callback URL is correctly formed as `/auth/callback/github`
- [ ] Ensure successful authentication and redirect after GitHub OAuth flow
- [ ] Test in staging environment to confirm the fix works in production-like settings

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub login redirects to use the correct OAuth callback path, preventing failed or looping sign-ins.
  * Ensures a consistent sign-in experience across environments (local, staging, production).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->