### PR TITLE
🔒(app): Add returnTo parameter validation to prevent open redirects

### DIFF
--- a/frontend/apps/app/app/auth/callback/[provider]/route.ts
+++ b/frontend/apps/app/app/auth/callback/[provider]/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server'
 import { ensureUserHasOrganization } from '../../../../components/LoginPage/services/ensureUserHasOrganization'
+import { sanitizeReturnPath } from '../../../../components/LoginPage/services/validateReturnPath'
 import { createClient } from '../../../../libs/db/server'
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  // Use query parameter "next" to redirect after auth, defaults to "/"
-  const next = searchParams.get('next') ?? '/'
+  // Use query parameter "next" to redirect after auth, sanitize for security
+  const next = sanitizeReturnPath(searchParams.get('next'), '/')
 
   if (code) {
     const supabase = await createClient()

--- a/frontend/apps/app/app/confirm/route.ts
+++ b/frontend/apps/app/app/confirm/route.ts
@@ -1,13 +1,15 @@
 import type { EmailOtpType } from '@liam-hq/db'
 import { redirect } from 'next/navigation'
 import type { NextRequest } from 'next/server'
+import { sanitizeReturnPath } from '../../components/LoginPage/services/validateReturnPath'
 import { createClient } from '../../libs/db/server'
+import { urlgen } from '../../libs/routes/urlgen'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const token_hash = searchParams.get('token_hash')
   const type = searchParams.get('type') as EmailOtpType | null
-  const next = searchParams.get('next') ?? '/'
+  const next = sanitizeReturnPath(searchParams.get('next'), '/')
 
   if (token_hash && type) {
     const supabase = await createClient()
@@ -23,5 +25,5 @@ export async function GET(request: NextRequest) {
   }
 
   // redirect the user to an error page with some instructions
-  redirect('/error')
+  redirect(urlgen('error'))
 }

--- a/frontend/apps/app/components/LoginPage/services/loginByEmail.ts
+++ b/frontend/apps/app/components/LoginPage/services/loginByEmail.ts
@@ -3,17 +3,20 @@ import { redirect } from 'next/navigation'
 import * as v from 'valibot'
 
 import { createClient } from '../../../libs/db/server'
+import { urlgen } from '../../../libs/routes/urlgen'
 import { ensureUserHasOrganization } from './ensureUserHasOrganization'
+import { sanitizeReturnPath } from './validateReturnPath'
 
 export async function loginByEmail(formData: FormData) {
   const supabase = await createClient()
 
-  // Get the returnTo path from the form data
+  // Get the returnTo path from the form data and sanitize it
   // This will be set by the login page which reads from the cookie
   const formReturnTo = formData.get('returnTo')
-  const returnTo = formReturnTo
-    ? formReturnTo.toString()
-    : '/design_sessions/new'
+  const returnTo = sanitizeReturnPath(
+    formReturnTo?.toString(),
+    '/design_sessions/new',
+  )
 
   const loginFormSchema = v.object({
     email: v.pipe(v.string(), v.email('Please enter a valid email address')),
@@ -28,7 +31,7 @@ export async function loginByEmail(formData: FormData) {
 
   const parsedData = v.safeParse(loginFormSchema, formDataObject)
   if (!parsedData.success) {
-    redirect('/error')
+    redirect(urlgen('error'))
   }
 
   const data = parsedData.output
@@ -36,7 +39,7 @@ export async function loginByEmail(formData: FormData) {
   const { error } = await supabase.auth.signInWithPassword(data)
 
   if (error) {
-    redirect('/error')
+    redirect(urlgen('error'))
   }
 
   await ensureUserHasOrganization()

--- a/frontend/apps/app/components/LoginPage/services/loginByGithub.ts
+++ b/frontend/apps/app/components/LoginPage/services/loginByGithub.ts
@@ -3,6 +3,8 @@ import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '../../../libs/db/server'
+import { urlgen } from '../../../libs/routes/urlgen'
+import { sanitizeReturnPath } from './validateReturnPath'
 
 type OAuthProvider = 'github'
 
@@ -42,12 +44,13 @@ async function getAuthCallbackUrl({
 export async function loginByGithub(formData: FormData) {
   const supabase = await createClient()
 
-  // Get the returnTo path from the form data
+  // Get the returnTo path from the form data and sanitize it
   // This will be set by the login page which reads from the cookie
   const formReturnTo = formData.get('returnTo')
-  const returnTo = formReturnTo
-    ? formReturnTo.toString()
-    : '/design_sessions/new'
+  const returnTo = sanitizeReturnPath(
+    formReturnTo?.toString(),
+    '/design_sessions/new',
+  )
 
   // Clear the returnTo cookie since we've used it
   const cookieStore = await cookies()
@@ -65,7 +68,7 @@ export async function loginByGithub(formData: FormData) {
   })
 
   if (error) {
-    redirect('/error')
+    redirect(urlgen('error'))
   }
 
   if (data.url) {

--- a/frontend/apps/app/components/LoginPage/services/validateReturnPath.test.ts
+++ b/frontend/apps/app/components/LoginPage/services/validateReturnPath.test.ts
@@ -1,0 +1,175 @@
+import * as v from 'valibot'
+import { describe, expect, it } from 'vitest'
+import {
+  RelativeReturnPathSchema,
+  sanitizeReturnPath,
+} from './validateReturnPath'
+
+describe('validateReturnPath', () => {
+  describe('sanitizeReturnPath', () => {
+    const defaultPath = '/default'
+
+    describe('valid paths', () => {
+      it('should return valid relative paths unchanged', () => {
+        expect(sanitizeReturnPath('/', defaultPath)).toBe('/')
+        expect(sanitizeReturnPath('/home', defaultPath)).toBe('/home')
+        expect(sanitizeReturnPath('/projects/123', defaultPath)).toBe(
+          '/projects/123',
+        )
+        expect(sanitizeReturnPath('/design_sessions/new', defaultPath)).toBe(
+          '/design_sessions/new',
+        )
+      })
+
+      it('should accept paths with query parameters and hash fragments', () => {
+        expect(sanitizeReturnPath('/login?next=/dashboard', defaultPath)).toBe(
+          '/login?next=/dashboard',
+        )
+        expect(sanitizeReturnPath('/search?q=test&page=2', defaultPath)).toBe(
+          '/search?q=test&page=2',
+        )
+        expect(sanitizeReturnPath('/docs#section-1', defaultPath)).toBe(
+          '/docs#section-1',
+        )
+        expect(
+          sanitizeReturnPath('/search?q=http://example.com', defaultPath),
+        ).toBe('/search?q=http://example.com')
+      })
+
+      it('should accept nested paths', () => {
+        expect(sanitizeReturnPath('/projects/123/settings', defaultPath)).toBe(
+          '/projects/123/settings',
+        )
+        expect(
+          sanitizeReturnPath('/organizations/abc/members', defaultPath),
+        ).toBe('/organizations/abc/members')
+      })
+    })
+
+    describe('invalid paths', () => {
+      it('should return default for empty or null paths', () => {
+        expect(sanitizeReturnPath('', defaultPath)).toBe(defaultPath)
+        expect(sanitizeReturnPath(null, defaultPath)).toBe(defaultPath)
+        expect(sanitizeReturnPath(undefined, defaultPath)).toBe(defaultPath)
+      })
+
+      it('should return default for paths not starting with /', () => {
+        expect(sanitizeReturnPath('home', defaultPath)).toBe(defaultPath)
+        expect(sanitizeReturnPath('projects/123', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(sanitizeReturnPath('../parent', defaultPath)).toBe(defaultPath)
+        expect(sanitizeReturnPath('./current', defaultPath)).toBe(defaultPath)
+      })
+
+      it('should return default for absolute URLs', () => {
+        expect(sanitizeReturnPath('http://example.com', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(sanitizeReturnPath('https://example.com', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(sanitizeReturnPath('ftp://example.com', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(sanitizeReturnPath('javascript:alert(1)', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(
+          sanitizeReturnPath(
+            'data:text/html,<script>alert(1)</script>',
+            defaultPath,
+          ),
+        ).toBe(defaultPath)
+      })
+
+      it('should return default for protocol-relative URLs', () => {
+        expect(sanitizeReturnPath('//example.com', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(sanitizeReturnPath('//evil.com/phishing', defaultPath)).toBe(
+          defaultPath,
+        )
+        expect(sanitizeReturnPath('///triple-slash', defaultPath)).toBe(
+          defaultPath,
+        )
+      })
+    })
+
+    describe('default path behavior', () => {
+      it('should use custom default path when provided', () => {
+        expect(sanitizeReturnPath('', '/custom')).toBe('/custom')
+        expect(sanitizeReturnPath(null, '/custom')).toBe('/custom')
+        expect(sanitizeReturnPath('invalid', '/custom')).toBe('/custom')
+      })
+
+      it('should use /design_sessions/new as default when not specified', () => {
+        expect(sanitizeReturnPath('')).toBe('/design_sessions/new')
+        expect(sanitizeReturnPath(null)).toBe('/design_sessions/new')
+        expect(sanitizeReturnPath(undefined)).toBe('/design_sessions/new')
+      })
+    })
+  })
+
+  describe('RelativeReturnPathSchema', () => {
+    it('should validate correct paths', () => {
+      const validPaths = [
+        '/',
+        '/home',
+        '/projects/123',
+        '/search?q=test',
+        '/docs#section',
+        '/path/with/many/segments',
+      ]
+
+      validPaths.forEach((path) => {
+        const result = v.safeParse(RelativeReturnPathSchema, path)
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.output).toBe(path)
+        }
+      })
+    })
+
+    it('should reject invalid paths', () => {
+      const invalidPaths = [
+        '',
+        'home',
+        '//example.com',
+        'http://example.com',
+        'javascript:alert(1)',
+        '../parent',
+        './current',
+      ]
+
+      invalidPaths.forEach((path) => {
+        const result = v.safeParse(RelativeReturnPathSchema, path)
+        expect(result.success).toBe(false)
+      })
+    })
+
+    it('should provide meaningful error message', () => {
+      const result = v.safeParse(RelativeReturnPathSchema, '//evil.com')
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.issues[0].message).toBe(
+          'Path must be a relative path starting with /',
+        )
+      }
+    })
+
+    it('should be reusable in other schemas', () => {
+      // Demonstrate that the schema can be composed with other valibot schemas
+      const FormSchema = v.object({
+        returnTo: v.optional(RelativeReturnPathSchema),
+        username: v.string(),
+      })
+
+      const validForm = { username: 'john', returnTo: '/dashboard' }
+      const invalidForm = { username: 'john', returnTo: '//evil.com' }
+
+      expect(v.safeParse(FormSchema, validForm).success).toBe(true)
+      expect(v.safeParse(FormSchema, invalidForm).success).toBe(false)
+    })
+  })
+})

--- a/frontend/apps/app/components/LoginPage/services/validateReturnPath.ts
+++ b/frontend/apps/app/components/LoginPage/services/validateReturnPath.ts
@@ -1,0 +1,29 @@
+import * as v from 'valibot'
+
+/**
+ * Valibot schema for validating relative return paths.
+ * Only allows relative paths starting with "/" to prevent open redirect vulnerabilities.
+ */
+export const RelativeReturnPathSchema = v.pipe(
+  v.string(),
+  v.custom<string>((value) => {
+    const str = String(value)
+    // Must start with "/" (relative path) but not "//" (protocol-relative URL)
+    return str.startsWith('/') && !str.startsWith('//')
+  }, 'Path must be a relative path starting with /'),
+)
+
+/**
+ * Sanitizes a return path, returning a safe default if invalid.
+ * This is used for Next.js redirect() and NextResponse.redirect() to ensure
+ * only same-origin, relative paths are used for navigation.
+ */
+export function sanitizeReturnPath(
+  path: string | null | undefined,
+  defaultPath = '/design_sessions/new',
+): string {
+  if (!path) return defaultPath
+
+  const result = v.safeParse(RelativeReturnPathSchema, path)
+  return result.success ? result.output : defaultPath
+}

--- a/frontend/apps/app/libs/routes/routeDefinitions.ts
+++ b/frontend/apps/app/libs/routes/routeDefinitions.ts
@@ -2,6 +2,7 @@ import { ROUTE_PREFIXES } from './constants'
 
 export type RouteDefinitions = {
   login: string
+  error: string
   projects: string
   'projects/new': string
   'projects/[projectId]': (params: { projectId: string }) => string
@@ -36,6 +37,7 @@ export type RouteDefinitions = {
 
 export const routeDefinitions: RouteDefinitions = {
   login: '/login',
+  error: '/error',
   projects: '/projects',
   'projects/new': '/projects/new',
   'organizations/new': '/organizations/new',


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5616

## Why is this change needed?

This PR addresses a security vulnerability identified in code review where returnTo/next parameters could be exploited for open redirect attacks. The implementation adds minimal but sufficient validation to ensure only relative paths starting with '/' are accepted for redirects, preventing attackers from redirecting users to external malicious sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent error page route added and used across authentication flows.
  - Redirects after login, OAuth, and confirmation now use sanitized paths with sensible fallbacks.

- Bug Fixes
  - Prevented potential open redirects by validating next/returnTo parameters.
  - Preserves query and hash fragments for valid return paths to maintain user context.

- Refactor
  - Standardized redirect handling across authentication steps for reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->