### PR TITLE
refactor: centralize useExhaustiveDependencies rule to root biome config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,8 +3,7 @@
   "linter": {
     "rules": {
       "correctness": {
-        "noUndeclaredDependencies": "off",
-        "useExhaustiveDependencies": "error"
+        "noUndeclaredDependencies": "off"
       }
     }
   }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,7 +3,8 @@
   "linter": {
     "rules": {
       "correctness": {
-        "noUndeclaredDependencies": "off"
+        "noUndeclaredDependencies": "off",
+        "useExhaustiveDependencies": "error"
       }
     }
   }

--- a/frontend/apps/app/biome.jsonc
+++ b/frontend/apps/app/biome.jsonc
@@ -3,9 +3,6 @@
   "root": false,
   "linter": {
     "rules": {
-      "correctness": {
-        "useExhaustiveDependencies": "error"
-      },
       "nursery": {
         "useUniqueElementIds": "error"
       }

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -26,7 +26,7 @@
         "noUndeclaredVariables": "error",
         "noUnusedImports": "error",
         "noUnusedVariables": "error",
-        "useExhaustiveDependencies": "off",
+        "useExhaustiveDependencies": "error",
         "useImportExtensions": "off"
       },
       "performance": {

--- a/frontend/packages/erd-core/biome.jsonc
+++ b/frontend/packages/erd-core/biome.jsonc
@@ -4,7 +4,6 @@
   "linter": {
     "rules": {
       "correctness": {
-        "useExhaustiveDependencies": "error",
         "noNodejsModules": "error"
       }
     }

--- a/frontend/packages/ui/biome.jsonc
+++ b/frontend/packages/ui/biome.jsonc
@@ -5,9 +5,6 @@
     "rules": {
       "nursery": {
         "useUniqueElementIds": "error"
-      },
-      "correctness": {
-        "useExhaustiveDependencies": "error"
       }
     }
   }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/2317

## Why is this change needed?

Previously, we had individually configured the `useExhaustiveDependencies` rule in three packages (`apps/app`, `erd-core`, and `ui`) to ensure proper React hook dependency tracking. Now that all three packages have successfully adapted to and are compliant with this rule, we can centralize the configuration.

By moving this rule to the root `biome.jsonc`, we:
- Eliminate duplicate configurations across the three package-level `biome.json`c files
- Establish a single source of truth for this rule that applies project-wide
- Reduce maintenance overhead and ensure consistent enforcement going forward

This centralization is now possible because all affected packages have completed their migration to comply with the `useExhaustiveDependencies` rule.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized linting settings across the frontend codebase for consistency.
  - Enforced stricter dependency checks in shared/internal configurations.
  - Removed a noisy dependency-related rule from app and package configs to reduce false positives.
  - No changes to runtime behavior, UI, or user workflows.
  - Improves developer experience and code quality without affecting end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->