### PR TITLE
feat(agent): add LangSmith trace URL output for integration tests

### DIFF
--- a/frontend/internal-packages/agent/test-utils/workflowTestHelpers.ts
+++ b/frontend/internal-packages/agent/test-utils/workflowTestHelpers.ts
@@ -20,6 +20,32 @@ import {
 } from '../src/streaming/server/handlers'
 
 /**
+ * Generate LangSmith thread_id search URL
+ *
+ * Note: This function depends on LangSmith's implicit behavior of recording thread_id as metadata.
+ * When thread_id is set in LangChain RunnableConfig, LangSmith automatically records the following metadata:
+ * - metadata_key: "thread_id"
+ * - metadata_value: actual thread_id value
+ *
+ * If this implicit behavior changes, the generated URL may not be able to find traces.
+ */
+const generateLangSmithUrl = (threadId: string): string | null => {
+  const organizationId = process.env['LANGSMITH_ORGANIZATION_ID']
+  const projectId = process.env['LANGSMITH_PROJECT_ID']
+
+  if (!organizationId || !projectId) {
+    return null
+  }
+
+  const baseUrl = `https://smith.langchain.com/o/${organizationId}/projects/p/${projectId}`
+  const filter = `and(eq(is_root, true), and(eq(metadata_key, "thread_id"), eq(metadata_value, "${threadId}")))`
+  const searchModel = { filter }
+  const encodedSearchModel = encodeURIComponent(JSON.stringify(searchModel))
+
+  return `${baseUrl}?searchModel=${encodedSearchModel}`
+}
+
+/**
  * Gets the minimal configuration needed for integration tests
  * Directly sets up the test environment without creating unnecessary state
  */
@@ -62,6 +88,12 @@ export const getTestConfig = async (options?: {
 
   const { organization, buildingSchema, designSession, user, repositories } =
     setupResult.value
+
+  // Generate and log LangSmith trace URL if environment variables are set
+  const langSmithUrl = generateLangSmithUrl(designSession.id)
+  if (langSmithUrl) {
+    logger.info(`LangSmith Trace URL: ${langSmithUrl}`)
+  }
 
   return {
     config: {


### PR DESCRIPTION
## Issue

- resolve: Add LangSmith trace URL logging to integration tests for easier debugging

## Why is this change needed?

Integration tests for AI agents can be difficult to debug when they fail or behave unexpectedly. By outputting LangSmith trace URLs during test execution, developers can easily access detailed execution traces to understand what happened during the test run.

## Changes

- **Added `generateLangSmithUrl` function**: Generates LangSmith search URLs based on thread_id
- **Modified `getTestConfig` function**: Outputs LangSmith trace URL when environment variables are set
- **Environment variable support**: Requires `LANGSMITH_ORGANIZATION_ID` and `LANGSMITH_PROJECT_ID`
- **Documentation**: Includes comments about dependency on LangSmith's implicit metadata behavior

## Usage

Set the required environment variables:
```bash
export LANGSMITH_ORGANIZATION_ID="your-org-id"
export LANGSMITH_PROJECT_ID="your-project-id"
```

When running integration tests, the LangSmith trace URL will be logged:
```
LangSmith Trace URL: https://smith.langchain.com/o/org-id/projects/p/project-id?searchModel=...
```

## Test Plan

- [x] Integration test runs successfully with environment variables set
- [x] URL is logged and can be opened in browser
- [x] No URL is logged when environment variables are not set
- [x] Lint and type checking pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added runtime logging of trace URLs during test setup.
  * No changes to public APIs or test configuration signatures.

* **Chores**
  * Introduced an internal helper to generate trace URLs from environment configuration for use in tests.
  * Ensures URLs are only produced when required configuration is present.

* **Notes**
  * These updates are internal and do not affect user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->