### PR TITLE
Add LangSmith environment variables to agent-deep-modeling workflow

### DIFF
--- a/.github/workflows/agent-deep-modeling.yml
+++ b/.github/workflows/agent-deep-modeling.yml
@@ -52,6 +52,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
           LANGSMITH_PROJECT: "liam-app"
+          LANGSMITH_ORGANIZATION_ID: ${{ secrets.LANGSMITH_ORGANIZATION_ID }}
+          LANGSMITH_PROJECT_ID: ${{ secrets.LANGSMITH_PROJECT_ID }}
           NO_COLOR: 1
         shell: bash
         run: |


### PR DESCRIPTION
## Issue

- resolve: Support LangSmith trace URL generation in CI workflow

## Why is this change needed?

This adds the `LANGSMITH_ORGANIZATION_ID` and `LANGSMITH_PROJECT_ID` environment variables to the agent-deep-modeling GitHub workflow, enabling the LangSmith trace URL generation functionality that was introduced in PR #3439.

Without these environment variables, the `generateLangSmithUrl` function cannot construct proper trace URLs for debugging and monitoring agent execution in CI environments.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation for the deep modeling workflow to include organization and project identifiers via environment variables, improving observability and traceability of runs.
  * Existing credentials continue to be passed; workflow behavior remains unchanged.
  * This is a CI configuration update only—no user-facing features, UI changes, or runtime behavior modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->