### PR TITLE
✅ chore(erd-core): add `ColumnsItem` component test

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.test.tsx
@@ -1,0 +1,128 @@
+import { aColumn, aPrimaryKeyConstraint } from '@liam-hq/schema'
+import { render, screen } from '@testing-library/react'
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
+import type { FC, PropsWithChildren } from 'react'
+import { describe, expect, it } from 'vitest'
+import {
+  SchemaProvider,
+  UserEditingProvider,
+} from '../../../../../../../../../stores'
+import { ColumnsItem } from './ColumnsItem'
+
+const wrapper: FC<PropsWithChildren> = ({ children }) => (
+  <NuqsTestingAdapter>
+    <SchemaProvider current={{ enums: {}, extensions: {}, tables: {} }}>
+      <UserEditingProvider>{children}</UserEditingProvider>
+    </SchemaProvider>
+  </NuqsTestingAdapter>
+)
+
+describe('id', () => {
+  it('renders column name as a heading', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id', type: 'bigserial' })}
+        constraints={{}}
+      />,
+      { wrapper },
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'id', level: 3 }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('type', () => {
+  it('renders column type', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id', type: 'bigserial' })}
+        constraints={{}}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByText('bigserial')).toBeInTheDocument()
+  })
+})
+
+describe('default value', () => {
+  it('does not render default value if default is null', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ default: null })}
+        constraints={{}}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.queryByText('Default')).not.toBeInTheDocument()
+  })
+
+  it('renders the default value when provided', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ default: 100 })}
+        constraints={{}}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByText('Default')).toBeInTheDocument()
+    expect(screen.getByText('100')).toBeInTheDocument()
+  })
+})
+
+describe('primary key constraint', () => {
+  it('renders a "Primary Key" indicator', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id' })}
+        constraints={{
+          idPrimary: aPrimaryKeyConstraint({
+            name: 'idPrimary',
+            columnNames: ['id'],
+          }),
+        }}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByText('Primary Key')).toBeInTheDocument()
+  })
+})
+
+describe('not null', () => {
+  it('renders a "Not-null" indicator when a column is non-null', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id', notNull: true })}
+        constraints={{}}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByText('Not-null')).toBeInTheDocument()
+  })
+
+  it('renders a "Nullable" indicator when a column is non-null', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id', notNull: false })}
+        constraints={{}}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByText('Nullable')).toBeInTheDocument()
+  })
+})

--- a/frontend/packages/schema/src/index.ts
+++ b/frontend/packages/schema/src/index.ts
@@ -37,6 +37,7 @@ export {
   aColumn,
   aForeignKeyConstraint,
   anIndex,
+  aPrimaryKeyConstraint,
   aSchema,
   aTable,
   aUniqueConstraint,


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->


To make it easy to test in https://github.com/liam-hq/liam/pull/3479, I added some tests for `ColumnsItem` component in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive tests for column details display, covering name, type, default values, primary key indicator, and nullability status.

- Chores
  - Exposed a new schema helper for primary key constraints to support internal integrations and consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->