### PR TITLE
Add debug script to verify LangGraph messagesStateReducer behavior

### DIFF
--- a/frontend/internal-packages/agent/scripts/debug-message-reducer.ts
+++ b/frontend/internal-packages/agent/scripts/debug-message-reducer.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+// === Debug LangGraph messagesStateReducer Behavior ===
+// This script tests different approaches to adding messages with messagesStateReducer
+// to observe the actual behavior and compare it with documented expectations.
+// Reference: https://langchain-ai.github.io/langgraphjs/concepts/low_level/#reducers
+
+import { Annotation, MessagesAnnotation, StateGraph, START, END } from '@langchain/langgraph'
+import { HumanMessage, AIMessage } from '@langchain/core/messages'
+
+// === Test State Definition ===
+const TestState = Annotation.Root({
+  ...MessagesAnnotation.spec,
+  testCase: Annotation<string>,
+})
+
+type TestStateType = typeof TestState.State
+
+// === Helper Functions ===
+function logMessages(label: string, messages: any[]) {
+  console.log(`\n📋 ${label}`)
+  console.log(`   Count: ${messages.length}`)
+  messages.forEach((msg, i) => {
+    const type = msg.constructor.name
+    const content = typeof msg.content === 'string' ? msg.content.slice(0, 30) : 'complex'
+    console.log(`   [${i}] ${type}: "${content}${content.length === 30 ? '...' : ''}"`)
+  })
+}
+
+// === Test Nodes ===
+const spreadApproachNode = (state: TestStateType) => {
+  console.log('\n🧪 APPROACH A: Manually spreading existing messages')
+  console.log('   Code: [...state.messages, newMessage]')
+
+  const newMessage = new AIMessage('Added via spread approach')
+
+  return {
+    messages: [...state.messages, newMessage],
+    testCase: 'spread'
+  }
+}
+
+const directApproachNode = (state: TestStateType) => {
+  console.log('\n🧪 APPROACH B: Let reducer handle concatenation')
+  console.log('   Code: newMessage')
+
+  const newMessage = new AIMessage('Added via direct approach')
+
+  return {
+    messages: newMessage,
+    testCase: 'direct'
+  }
+}
+
+const multipleMessagesNode = (state: TestStateType) => {
+  console.log('\n🧪 APPROACH C: Adding multiple new messages')
+  console.log('   Code: [message1, message2]')
+
+  const messages = [
+    new HumanMessage('First new message'),
+    new AIMessage('Second new message')
+  ]
+
+  return {
+    messages: messages,
+    testCase: 'multiple'
+  }
+}
+
+// === Debug Function ===
+async function debug() {
+  console.log('🔍 Starting LangGraph messagesStateReducer debug')
+  console.log('─'.repeat(60))
+
+  // Initial state with some existing messages
+  const initialMessages = [
+    new HumanMessage('Hello, I need help with my database'),
+    new AIMessage('I can help you with database design. What do you need?')
+  ]
+
+  console.log('🏁 Initial State:')
+  logMessages('Starting messages', initialMessages)
+
+  // === Test Case 1: Spread Approach ===
+  console.log('\n' + '='.repeat(60))
+  console.log('TEST CASE 1: SPREAD APPROACH')
+  console.log('='.repeat(60))
+
+  const spreadGraph = new StateGraph(TestState)
+    .addNode('process', spreadApproachNode)
+    .addEdge(START, 'process')
+    .addEdge('process', END)
+    .compile()
+
+  const spreadResult = await spreadGraph.invoke({
+    messages: initialMessages,
+    testCase: 'start'
+  })
+
+  logMessages('After spread approach', spreadResult.messages)
+
+  // === Test Case 2: Direct Approach ===
+  console.log('\n' + '='.repeat(60))
+  console.log('TEST CASE 2: DIRECT APPROACH')
+  console.log('='.repeat(60))
+
+  const directGraph = new StateGraph(TestState)
+    .addNode('process', directApproachNode)
+    .addEdge(START, 'process')
+    .addEdge('process', END)
+    .compile()
+
+  const directResult = await directGraph.invoke({
+    messages: initialMessages,
+    testCase: 'start'
+  })
+
+  logMessages('After direct approach', directResult.messages)
+
+  // === Test Case 3: Multiple Messages Approach ===
+  console.log('\n' + '='.repeat(60))
+  console.log('TEST CASE 3: MULTIPLE MESSAGES APPROACH')
+  console.log('='.repeat(60))
+
+  const multipleGraph = new StateGraph(TestState)
+    .addNode('process', multipleMessagesNode)
+    .addEdge(START, 'process')
+    .addEdge('process', END)
+    .compile()
+
+  const multipleResult = await multipleGraph.invoke({
+    messages: initialMessages,
+    testCase: 'start'
+  })
+
+  logMessages('After multiple messages approach', multipleResult.messages)
+
+  // === Analysis ===
+  console.log('\n' + '='.repeat(60))
+  console.log('ANALYSIS')
+  console.log('='.repeat(60))
+
+  console.log('📊 Results comparison:')
+  console.log(`   Spread approach:    ${spreadResult.messages.length} messages`)
+  console.log(`   Direct approach:    ${directResult.messages.length} messages`)
+  console.log(`   Multiple approach:  ${multipleResult.messages.length} messages`)
+  console.log(`   Initial count:      ${initialMessages.length} messages`)
+
+  console.log('\n🔍 Observations:')
+  const hasDuplication = spreadResult.messages.length > directResult.messages.length
+  if (hasDuplication) {
+    console.log('   ⚠️  Spread approach resulted in different message count')
+    console.log('   📖 Documentation suggestion appears correct')
+  } else {
+    console.log('   ✨ Both approaches resulted in same message count')
+    console.log('   🤔 No observable duplication in this test case')
+  }
+
+  console.log('\n📖 Documentation recommends: Use direct message passing')
+  console.log('🔗 Reference: https://langchain-ai.github.io/langgraphjs/concepts/low_level/#reducers')
+
+  console.log('\n─'.repeat(60))
+  console.log('✅ Debug completed')
+}
+
+// === Execute ===
+debug().catch(err => {
+  console.error('❌ Debug failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Issue

- resolve: Verify LangGraph messagesStateReducer behavior regarding message duplication

## Why is this change needed?

This debug script was created to test and verify the actual behavior of LangGraph's messagesStateReducer when using different approaches to add messages. The LangGraph documentation suggests that manually spreading existing messages (`[...state.messages, newMessage]`) may cause duplication due to the reducer's internal concatenation behavior.

The script tests three different approaches:
1. **Spread approach**: `[...state.messages, newMessage]`
2. **Direct approach**: `newMessage` (recommended by documentation)
3. **Multiple messages**: `[message1, message2]`

**Key findings**: Both the spread and direct approaches resulted in identical behavior with no observable message duplication in the current LangGraph version being used. This provides clarity that either approach works correctly, although the documentation's recommendation to use direct message passing should still be followed for consistency.

The script provides objective, data-driven analysis rather than assuming outcomes, making it a useful tool for future LangGraph behavior verification.

<details><summary>Result</summary>
<p>

```
$ cd frontend/internal-packages/agent && pnpm dlx tsx scripts/debug-message-reducer.ts

🔍 Starting LangGraph messagesStateReducer debug
────────────────────────────────────────────────────────────
🏁 Initial State:

📋 Starting messages
   Count: 2
   [0] HumanMessage: "Hello, I need help with my dat..."
   [1] AIMessage: "I can help you with database d..."

============================================================
TEST CASE 1: SPREAD APPROACH
============================================================

🧪 APPROACH A: Manually spreading existing messages
   Code: [...state.messages, newMessage]

📋 After spread approach
   Count: 3
   [0] HumanMessage: "Hello, I need help with my dat..."
   [1] AIMessage: "I can help you with database d..."
   [2] AIMessage: "Added via spread approach"

============================================================
TEST CASE 2: DIRECT APPROACH
============================================================

🧪 APPROACH B: Let reducer handle concatenation
   Code: newMessage

📋 After direct approach
   Count: 3
   [0] HumanMessage: "Hello, I need help with my dat..."
   [1] AIMessage: "I can help you with database d..."
   [2] AIMessage: "Added via direct approach"

============================================================
TEST CASE 3: MULTIPLE MESSAGES APPROACH
============================================================

🧪 APPROACH C: Adding multiple new messages
   Code: [message1, message2]

📋 After multiple messages approach
   Count: 4
   [0] HumanMessage: "Hello, I need help with my dat..."
   [1] AIMessage: "I can help you with database d..."
   [2] HumanMessage: "First new message"
   [3] AIMessage: "Second new message"

============================================================
ANALYSIS
============================================================
📊 Results comparison:
   Spread approach:    3 messages
   Direct approach:    3 messages
   Multiple approach:  4 messages
   Initial count:      2 messages

🔍 Observations:
   ✨ Both approaches resulted in same message count
   🤔 No observable duplication in this test case

📖 Documentation recommends: Use direct message passing
🔗 Reference: https://langchain-ai.github.io/langgraphjs/concepts/low_level/#reducers

─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
─
✅ Debug completed
```

</p>
</details> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a developer debug utility to exercise and compare message reducer behaviors in graph-based workflows.
  * Includes sample execution paths illustrating single-message, appended-message, and multi-message outcomes with console summaries.
  * Provides error-handled runner for quick local checks and verbose logging to aid troubleshooting.
  * No user-facing changes; no impact on application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->