### PR TITLE
💄 show `BlinkCircle` indicator when column element is selected in `TableDetail`

### DIFF
--- a/.changeset/pretty-hats-ask.md
+++ b/.changeset/pretty-hats-ask.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+- 💄 show BlinkCircle indicator when column element is selected in TableDetail

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/BlinkCircle/BlinkCircle.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/BlinkCircle/BlinkCircle.module.css
@@ -1,0 +1,69 @@
+.container {
+  position: relative;
+}
+
+.container:before {
+  position: absolute;
+  display: block;
+  content: '';
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background-color: var(--primary-accent);
+  animation: sizePulse 2700ms forwards;
+}
+
+@keyframes sizePulse {
+  /* 0/7 */
+  0% {
+    width: 0;
+    height: 0;
+  }
+
+  /* 1/7 */
+  14% {
+    width: 10px;
+    height: 10px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 2/7 */
+  28% {
+    width: 10px;
+    height: 10px;
+  }
+
+  /* 3/7 */
+  43% {
+    width: 3px;
+    height: 3px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 4/7 */
+  57% {
+    width: 3px;
+    height: 3px;
+  }
+
+  /* 5/7 */
+  71% {
+    width: 10px;
+    height: 10px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 6/7 */
+  86% {
+    width: 10px;
+    height: 10px;
+    opacity: 1;
+  }
+
+  /* 7/7 */
+  100% {
+    width: 0px;
+    height: 0px;
+    opacity: 0;
+    animation-timing-function: ease-out;
+  }
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/BlinkCircle/BlinkCircle.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/BlinkCircle/BlinkCircle.module.css
@@ -9,7 +9,7 @@
   border-radius: 50%;
   transform: translate(-50%, -50%);
   background-color: var(--primary-accent);
-  animation: sizePulse 2700ms forwards;
+  animation: sizePulse 5400ms forwards;
 }
 
 @keyframes sizePulse {
@@ -60,6 +60,114 @@
   }
 
   /* 7/7 */
+  100% {
+    width: 0px;
+    height: 0px;
+    opacity: 0;
+    animation-timing-function: ease-out;
+  }
+}
+
+@keyframes sizePulse {
+  /* 0/15 */
+  0% {
+    width: 0;
+    height: 0;
+  }
+
+  /* 1/15 */
+  6.7% {
+    width: 10px;
+    height: 10px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 2/15 */
+  13.3% {
+    width: 10px;
+    height: 10px;
+  }
+
+  /* 3/15 */
+  20% {
+    width: 3px;
+    height: 3px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 4/15 */
+  26.7% {
+    width: 3px;
+    height: 3px;
+  }
+
+  /* 5/15 */
+  33.3% {
+    width: 10px;
+    height: 10px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 6/15 */
+  40% {
+    width: 10px;
+    height: 10px;
+  }
+
+  /* 7/15 */
+  46.6% {
+    width: 3px;
+    height: 3px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 8/15 */
+  53.3% {
+    width: 3px;
+    height: 3px;
+  }
+
+  /* 9/15 */
+  60% {
+    width: 10px;
+    height: 10px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 10/15 */
+  66.6% {
+    width: 10px;
+    height: 10px;
+  }
+
+  /* 11/15 */
+  73.3% {
+    width: 3px;
+    height: 3px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 12/15 */
+  80% {
+    width: 3px;
+    height: 3px;
+  }
+
+  /* 13/15 */
+  86.6% {
+    width: 10px;
+    height: 10px;
+    animation-timing-function: ease-out;
+  }
+
+  /* 14/15 */
+  93.3% {
+    width: 10px;
+    height: 10px;
+    opacity: 1;
+  }
+
+  /* 15/15 */
   100% {
     width: 0px;
     height: 0px;

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/BlinkCircle/BlinkCircle.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/BlinkCircle/BlinkCircle.tsx
@@ -1,0 +1,6 @@
+import type { FC } from 'react'
+import styles from './BlinkCircle.module.css'
+
+export const BlinkCircle: FC = () => {
+  return <span className={styles.container} />
+}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/CollapsibleHeader/CollapsibleHeader.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/CollapsibleHeader/CollapsibleHeader.module.css
@@ -51,6 +51,6 @@
   transition: max-height 0.1s var(--default-timing-function);
 
   /* enable to scroll to the top children element, */
-  padding-top: 40px;
-  margin-top: -40px;
+  padding-top: 41px;
+  margin-top: -41px;
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/Columns.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/Columns.tsx
@@ -1,6 +1,6 @@
 import type { Table } from '@liam-hq/schema'
 import { Rows3 as Rows3Icon } from '@liam-hq/ui'
-import type { FC } from 'react'
+import { type FC, useEffect, useState } from 'react'
 import { CollapsibleHeader } from '../CollapsibleHeader'
 import styles from './Columns.module.css'
 import { ColumnsItem } from './ColumnsItem'
@@ -10,6 +10,22 @@ type Props = {
 }
 
 export const Columns: FC<Props> = ({ table }) => {
+  const [focusedElementId, setFocusedElementId] = useState(
+    // location.hash starts with '#'; decode to match actual DOM id
+    location.hash.slice(1),
+  )
+
+  // update focusedElementId when hash changes
+  useEffect(() => {
+    const updateState = () => {
+      const elementId = location.hash.slice(1)
+      setFocusedElementId(elementId)
+    }
+
+    window.addEventListener('hashchange', updateState)
+    return () => window.removeEventListener('hashchange', updateState)
+  }, [])
+
   // NOTE: 300px is the height of one item in the list(when comments are lengthy)
   const contentMaxHeight = Object.keys(table.columns).length * 300
   return (
@@ -26,6 +42,7 @@ export const Columns: FC<Props> = ({ table }) => {
             tableId={table.name}
             column={column}
             constraints={table.constraints}
+            focusedElementId={focusedElementId}
           />
         </div>
       ))}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
@@ -12,8 +12,8 @@
 
 .blinkCircleWrapper {
   position: relative;
-  top: var(--spacing-6);
-  left: var(--spacing-2);
+  top: 22px;
+  left: 9px;
 }
 
 .heading {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
@@ -2,7 +2,12 @@
   display: grid;
   gap: var(--spacing-2);
   padding: var(--spacing-4);
-  scroll-margin-top: 40px;
+  scroll-margin-top: 41px;
+}
+
+.focused {
+  outline: 1px solid var(--button-primary-background);
+  outline-offset: -1px;
 }
 
 .blinkCircleWrapper {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.module.css
@@ -5,6 +5,12 @@
   scroll-margin-top: 40px;
 }
 
+.blinkCircleWrapper {
+  position: relative;
+  top: var(--spacing-6);
+  left: var(--spacing-2);
+}
+
 .heading {
   color: var(--global-foreground);
   font-size: var(--font-size-2);

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.test.tsx
@@ -24,6 +24,7 @@ describe('id', () => {
         tableId="users"
         column={aColumn({ name: 'id', type: 'bigserial' })}
         constraints={{}}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )
@@ -45,6 +46,7 @@ describe('type', () => {
         tableId="users"
         column={aColumn({ name: 'id', type: 'bigserial' })}
         constraints={{}}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )
@@ -61,6 +63,7 @@ describe('default value', () => {
         tableId="users"
         column={aColumn({ default: null })}
         constraints={{}}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )
@@ -74,6 +77,7 @@ describe('default value', () => {
         tableId="users"
         column={aColumn({ default: 100 })}
         constraints={{}}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )
@@ -95,6 +99,7 @@ describe('primary key constraint', () => {
             columnNames: ['id'],
           }),
         }}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )
@@ -110,6 +115,7 @@ describe('not null', () => {
         tableId="users"
         column={aColumn({ name: 'id', notNull: true })}
         constraints={{}}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )
@@ -123,6 +129,7 @@ describe('not null', () => {
         tableId="users"
         column={aColumn({ name: 'id', notNull: false })}
         constraints={{}}
+        focusedElementId={'users__columns__created_at'}
       />,
       { wrapper },
     )

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.test.tsx
@@ -137,3 +137,35 @@ describe('not null', () => {
     expect(screen.getByText('Nullable')).toBeInTheDocument()
   })
 })
+
+describe('blink circle indicator', () => {
+  it('renders a blink circle indicator when the "focusedElementId" is same with its element id', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id', type: 'bigserial' })}
+        constraints={{}}
+        focusedElementId={'users__columns__id'}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByTestId('blink-circle-indicator')).toBeInTheDocument()
+  })
+
+  it('does not render a blink circle indicator when the "focusedElementId" is different than its element id', () => {
+    render(
+      <ColumnsItem
+        tableId="users"
+        column={aColumn({ name: 'id', type: 'bigserial' })}
+        constraints={{}}
+        focusedElementId={'users__columns__created_at'}
+      />,
+      { wrapper },
+    )
+
+    expect(
+      screen.queryByTestId('blink-circle-indicator'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -7,6 +7,7 @@ import {
   useUserEditingOrThrow,
 } from '../../../../../../../../../stores'
 import { useDiffStyle } from '../../../../../../../../diff/hooks/useDiffStyle'
+import { BlinkCircle } from '../../BlinkCircle/BlinkCircle'
 import styles from './ColumnsItem.module.css'
 import { Comment } from './Comment'
 import { Default } from './Default'
@@ -58,27 +59,33 @@ export const ColumnsItem: FC<Props> = ({
   )
 
   return (
-    <div id={elementId} className={clsx(styles.wrapper, diffStyle)}>
-      {elementId === focusedElementId && <span>blink circle</span>}
-      <h3 className={styles.heading}>
-        <a className={styles.link} href={`#${elementId}`}>
-          {column.name}
-        </a>
-        <Link className={styles.linkIcon} />
-      </h3>
-      {column.comment && <Comment tableId={tableId} column={column} />}
-      <GridTableRoot>
-        <Type tableId={tableId} column={column} />
-        <Default tableId={tableId} column={column} />
-        {constraint && (
-          <PrimaryKey
-            tableId={tableId}
-            columnName={column.name}
-            constraintName={constraint.name}
-          />
-        )}
-        <NotNull tableId={tableId} column={column} />
-      </GridTableRoot>
-    </div>
+    <>
+      {elementId === focusedElementId && (
+        <div className={styles.blinkCircleWrapper}>
+          <BlinkCircle />
+        </div>
+      )}
+      <div id={elementId} className={clsx(styles.wrapper, diffStyle)}>
+        <h3 className={styles.heading}>
+          <a className={styles.link} href={`#${elementId}`}>
+            {column.name}
+          </a>
+          <Link className={styles.linkIcon} />
+        </h3>
+        {column.comment && <Comment tableId={tableId} column={column} />}
+        <GridTableRoot>
+          <Type tableId={tableId} column={column} />
+          <Default tableId={tableId} column={column} />
+          {constraint && (
+            <PrimaryKey
+              tableId={tableId}
+              columnName={column.name}
+              constraintName={constraint.name}
+            />
+          )}
+          <NotNull tableId={tableId} column={column} />
+        </GridTableRoot>
+      </div>
+    </>
   )
 }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -22,9 +22,15 @@ type Props = {
   tableId: string
   column: Column
   constraints: Constraints
+  focusedElementId: string
 }
 
-export const ColumnsItem: FC<Props> = ({ tableId, column, constraints }) => {
+export const ColumnsItem: FC<Props> = ({
+  tableId,
+  column,
+  constraints,
+  focusedElementId,
+}) => {
   const elementId = columnElementId(tableId, column.name)
 
   const { operations } = useSchemaOrThrow()
@@ -53,6 +59,7 @@ export const ColumnsItem: FC<Props> = ({ tableId, column, constraints }) => {
 
   return (
     <div id={elementId} className={clsx(styles.wrapper, diffStyle)}>
+      {elementId === focusedElementId && <span>blink circle</span>}
       <h3 className={styles.heading}>
         <a className={styles.link} href={`#${elementId}`}>
           {column.name}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -61,7 +61,10 @@ export const ColumnsItem: FC<Props> = ({
   return (
     <>
       {elementId === focusedElementId && (
-        <div className={styles.blinkCircleWrapper}>
+        <div
+          className={styles.blinkCircleWrapper}
+          data-testid="blink-circle-indicator"
+        >
           <BlinkCircle />
         </div>
       )}

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Columns/ColumnsItem/ColumnsItem.tsx
@@ -58,9 +58,11 @@ export const ColumnsItem: FC<Props> = ({
     [constraints, column.name],
   )
 
+  const isFocused = focusedElementId === elementId
+
   return (
     <>
-      {elementId === focusedElementId && (
+      {isFocused && (
         <div
           className={styles.blinkCircleWrapper}
           data-testid="blink-circle-indicator"
@@ -68,7 +70,10 @@ export const ColumnsItem: FC<Props> = ({
           <BlinkCircle />
         </div>
       )}
-      <div id={elementId} className={clsx(styles.wrapper, diffStyle)}>
+      <div
+        id={elementId}
+        className={clsx(styles.wrapper, diffStyle, isFocused && styles.focused)}
+      >
         <h3 className={styles.heading}>
           <a className={styles.link} href={`#${elementId}`}>
             {column.name}


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

This PR introduces BlinkCircle and show emphasized boarders to clearly indicate when a column element is selected. I think it’s especially helpful when users open a page via a URL that contains a hash value.

### demo

preview URL: https://liam-erd-sample-ef7r5609z-liambx.vercel.app/?active=tags#tags__columns__name

When you open a page via a URL that contains a hash value.

https://github.com/user-attachments/assets/7ff1a9da-086e-46e9-97e7-4b0b57b5a10d



When you select a column element


https://github.com/user-attachments/assets/2e2090fd-ad3b-416d-ac3a-ba196be75c80



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an animated circular indicator that appears next to a selected column in Table Details.
  * Selection highlighting follows the URL fragment (hash) and updates when the fragment changes.

* **Style**
  * Minor spacing and layout tweaks for column and collapsible header alignment.
  * Adds animation styles for the blink indicator.

* **Tests**
  * Adds tests verifying the indicator renders for the focused column and not for others.

* **Chores**
  * Adds a changeset entry for a patch release of the ERD core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->