### PR TITLE
✨ Add CodeRabbit local review custom command

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,32 @@
+---
+description: Run CodeRabbit CLI directly on local changes and create actionable tasks
+allowed-tools: Bash(coderabbit:*), BashOutput, TodoWrite
+---
+
+# CodeRabbit CLI Review (Local changes only)
+
+Do NOT check or review pull requests. Do NOT call `gh` commands.
+Run CodeRabbit locally against the working repository only.
+
+## Run
+
+Execute exactly:
+
+```bash
+coderabbit --plain -t all --base origin/main -c claude.md coderabbit.yaml
+```
+
+## Parse → Tasks
+
+From the output, extract for each finding:
+
+* Severity: Critical | Warning | Info
+* File and line
+* Description
+* Suggested fix
+
+Create one TodoWrite per finding:
+
+* `title`: `[Severity] <file>:<line> <short description>`
+* `body`: `<Suggested fix>`
+* `metadata`: `{ "file": "<file>", "line": <line>, "severity": "<Severity>" }`


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This change adds a Claude custom command that enables running CodeRabbit CLI reviews locally before creating pull requests. The command automatically converts review findings into actionable tasks using TodoWrite, allowing developers to address issues proactively during development rather than after PR submission.

### Benefits:
- Early detection of code issues before PR creation
- Automatic conversion of review findings to actionable tasks
- Reduced CI/CD load by catching issues locally
- Improved developer workflow with immediate feedback

<img width="685" height="461" alt="スクリーンショット 2025-09-17 15 05 00" src="https://github.com/user-attachments/assets/840991b6-55b5-4270-9951-092936229c7f" />


### Implementation:
The command executes CodeRabbit CLI against local changes, parses the output to extract findings (severity, file, line, description, and suggested fixes), and creates structured todos for each finding. This integration streamlines the code review process and makes it easier to track and resolve issues systematically.

### Prerequisites:
Each developer needs to set up CodeRabbit CLI on their local machine. Please follow the setup instructions in the CodeRabbit CLI documentation: https://docs.coderabbit.ai/cli/overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a step-by-step guide for running a local-only code review workflow using the CLI.
  - Clarifies permitted tools and disallows remote/PR commands.
  - Provides the exact execution flow and how to parse results into actionable tasks (including severity, file/line, description, and suggested fix).
  - Details creating structured to-dos from findings with titles, bodies, and metadata for easy follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->