### PR TITLE
🔍(middleware): Change debug logging for /erd/* access control

### DIFF
--- a/frontend/apps/app/middleware.ts
+++ b/frontend/apps/app/middleware.ts
@@ -97,7 +97,7 @@ export async function middleware(request: NextRequest) {
     process.env.VERCEL_ENV === 'production'
   ) {
     const allowedSource = 'liambx.com'
-    const rewriteSource = request.headers.get('x-forwarded-host')
+    const rewriteSource = request.headers.get('x-liam-rewrite-source')
 
     // Block direct access to /erd/* - only allow access via rewrite in production
     if (rewriteSource !== allowedSource) {


### PR DESCRIPTION
revert https://github.com/liam-hq/liam/commit/1a62bb53584681ee11d5e7e1a46612d9cfd1f28c 🙏 

## Issue

- ref: https://github.com/route06/liam-internal/issues/5578



## Why is this change needed?

In testing, I found that `x-forwarded-host` was unstable. It didn’t always contain the expected value `liambx.com`.
To address this, I want to switch to using a custom header `x-liam-rewrite-source`.



Note: This uses x-liam-rewrite-source header (not x-forwarded-host) as per the latest decision.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced request validation in production to ensure correct origin checks before proceeding.
- Bug Fixes
  - Fixed cases where legitimate requests could be incorrectly denied due to misidentified rewrite origins.
  - Improved reliability of access checks, reducing unexpected blocks for valid traffic.
- Chores
  - Updated middleware to use a more accurate header for determining request origin.
  - Added clearer logging for denied requests to aid in monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->