### PR TITLE
Remove unused query_result_id field from timeline items

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts
+++ b/frontend/apps/app/components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts
@@ -21,7 +21,6 @@ export const fetchDesignSessionWithTimelineItems = (
           organization_id,
           design_session_id,
           building_schema_version_id,
-          query_result_id,
           assistant_role,
           users (
             id,

--- a/frontend/apps/app/components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts
+++ b/frontend/apps/app/components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts
@@ -31,7 +31,7 @@ export const fetchDesignSessionWithTimelineItems = (
             id,
             number,
             patch
-          ),
+          )
         )
       `)
       .eq('id', designSessionId)

--- a/frontend/internal-packages/agent/src/repositories/InMemoryRepository.ts
+++ b/frontend/internal-packages/agent/src/repositories/InMemoryRepository.ts
@@ -228,7 +228,6 @@ export class InMemoryRepository implements SchemaRepository {
       organization_id: 'test-org-id',
       design_session_id: params.designSessionId,
       building_schema_version_id: null,
-      query_result_id: null,
       assistant_role: null,
       type: 'user',
     }

--- a/frontend/internal-packages/db/src/schema.ts
+++ b/frontend/internal-packages/db/src/schema.ts
@@ -54,5 +54,4 @@ export const timelineItemsSchema: v.GenericSchema<Tables<'timeline_items'>> =
     updated_at: v.string(),
     organization_id: v.pipe(v.string(), v.uuid()),
     building_schema_version_id: v.nullable(v.pipe(v.string(), v.uuid())),
-    query_result_id: v.nullable(v.pipe(v.string(), v.uuid())),
   })


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?

The `query_result_id` field is no longer needed in the timeline items schema and related code. This change removes the unused field from:

- Database schema validation in `@liam-hq/db`
- Timeline items fetch query 
- InMemoryRepository test data

This cleanup improves code maintainability by removing unnecessary fields.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified timeline item data by removing unused fields (query result identifier and nested schema version details) to reduce payload size.
- Chores
  - Updated data handling and local representations to match the new, slimmer timeline item shape across the app.
- Bug Fixes
  - Eliminated sources of inconsistency from removed fields, improving reliability of session timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->