### PR TITLE
🐛 Fix Supabase select parameter parse error in timeline items query

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts
+++ b/frontend/apps/app/components/SessionDetailPage/services/designSessionWithTimelineItems/fetchDesignSessionWithTimelineItems.ts
@@ -21,7 +21,6 @@ export const fetchDesignSessionWithTimelineItems = (
           organization_id,
           design_session_id,
           building_schema_version_id,
-          query_result_id,
           assistant_role,
           users (
             id,
@@ -32,7 +31,7 @@ export const fetchDesignSessionWithTimelineItems = (
             id,
             number,
             patch
-          ),
+          )
         )
       `)
       .eq('id', designSessionId)

--- a/frontend/internal-packages/agent/src/repositories/InMemoryRepository.ts
+++ b/frontend/internal-packages/agent/src/repositories/InMemoryRepository.ts
@@ -228,7 +228,6 @@ export class InMemoryRepository implements SchemaRepository {
       organization_id: 'test-org-id',
       design_session_id: params.designSessionId,
       building_schema_version_id: null,
-      query_result_id: null,
       assistant_role: null,
       type: 'user',
     }

--- a/frontend/internal-packages/db/src/schema.ts
+++ b/frontend/internal-packages/db/src/schema.ts
@@ -54,5 +54,4 @@ export const timelineItemsSchema: v.GenericSchema<Tables<'timeline_items'>> =
     updated_at: v.string(),
     organization_id: v.pipe(v.string(), v.uuid()),
     building_schema_version_id: v.nullable(v.pipe(v.string(), v.uuid())),
-    query_result_id: v.nullable(v.pipe(v.string(), v.uuid())),
   })


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

The timeline items query in SessionDetailPage was failing with a parse error due to a trailing comma in the Supabase select parameter. The comma after the last field (`patch`) in the `building_schema_versions` nested relation was causing the Supabase query parser to fail with:

```
Uncaught Error: "failed to parse select parameter (id,organization_id,timeline_items(id,content,type,user_id,created_at,organization_id,design_session_id,building_schema_version_id,assistant_role,users(id,name,email),building_schema_versions!building_schema_version_id(id,number,patch),))"
```

This fix removes the trailing comma to resolve the parse error.

| Before | After |
|--------|--------|
| <img width="1111" height="1037" alt="スクリーンショット 2025-09-17 17 25 24" src="https://github.com/user-attachments/assets/bf56ef87-b1e8-4097-a294-9999b9e9ff2c" /> | <img width="1110" height="1037" alt="スクリーンショット 2025-09-17 17 24 15" src="https://github.com/user-attachments/assets/b352abde-7210-401c-b9e3-42ed2ff10b13" /> | 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None; no visible UI changes.
* **Bug Fixes**
  * Improved timeline display reliability to reduce rare inconsistencies.
* **Performance**
  * Slightly faster timeline loading due to leaner data retrieval.
* **Refactor**
  * Removed an unused timeline field to streamline stored session data; no functional changes.
* **Chores**
  * Internal schema and data-shape cleanup to keep data consistent across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->