### PR TITLE
🔒(app): Enable blocking of direct /erd/* access on app.liambx.com

### DIFF
--- a/frontend/apps/app/middleware.ts
+++ b/frontend/apps/app/middleware.ts
@@ -107,26 +107,19 @@ export async function middleware(request: NextRequest) {
         expected: allowedSource,
       })
 
-      // TODO: Enable this
-      // return new NextResponse(
-      //   `Direct access to /erd/* is not allowed. Please access via https://${allowedSource}/erd/`,
-      //   {
-      //     status: 403,
-      //     headers: {
-      //       'Content-Type': 'text/plain',
-      //       'Cache-Control': 'no-store, no-cache, must-revalidate, private',
-      //       Pragma: 'no-cache',
-      //       'X-Content-Type-Options': 'nosniff',
-      //       'X-Frame-Options': 'DENY',
-      //     },
-      //   },
-      // )
-    } else {
-      // TODO: delete this block after test
-      console.info('ERD access allowed: Valid rewrite source', {
-        path: request.nextUrl.pathname,
-        source: rewriteSource,
-      })
+      return new NextResponse(
+        `Direct access to /erd/* is not allowed. Please access via https://${allowedSource}/erd/`,
+        {
+          status: 403,
+          headers: {
+            'Content-Type': 'text/plain',
+            'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+            Pragma: 'no-cache',
+            'X-Content-Type-Options': 'nosniff',
+            'X-Frame-Options': 'DENY',
+          },
+        },
+      )
     }
   }
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5578

## Why is this change needed?

This change activates the previously disabled middleware protection that prevents users from directly accessing `/erd/*` paths on app.liambx.com. The ERD viewer should only be accessible through the main liambx.com domain to avoid user confusion and maintain a single entry point for the ERD functionality.

The middleware was already implemented but had been temporarily disabled with TODO comments. This PR removes those TODOs and enables the 403 Forbidden response for unauthorized direct access attempts in production.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Blocked direct access to ERD pages (/erd/*) in production unless requests originate from the approved source. Disallowed requests now receive a 403 (Forbidden), tightening access control and preventing unintended exposure.
  * Legitimate rewrites continue to function normally; standard session handling is unaffected.
  * Users navigating via intended entry points will see no change, while direct links or bookmarks to ERD pages may be denied with a clear forbidden response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->