### PR TITLE
🐛(schema): Fix jsonb default value escaping in PostgreSQL deparser

### DIFF
--- a/frontend/packages/schema/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/utils.ts
@@ -62,7 +62,24 @@ function generateColumnDefinition(
   }
 
   if (column.default !== null) {
-    definition += ` DEFAULT ${formatDefaultValue(column.default)}`
+    // Special handling for jsonb type to prevent double-escaping
+    if (column.type === 'jsonb' && typeof column.default === 'string') {
+      const trimmed = column.default.trim()
+      // If it's a cast expression (contains ::), use as-is
+      if (trimmed.includes('::')) {
+        definition += ` DEFAULT ${column.default}`
+      }
+      // If already quoted (but not a cast expression), use as-is
+      else if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+        definition += ` DEFAULT ${column.default}`
+      }
+      // Unquoted JSON, let formatDefaultValue handle it
+      else {
+        definition += ` DEFAULT ${formatDefaultValue(column.default)}`
+      }
+    } else {
+      definition += ` DEFAULT ${formatDefaultValue(column.default)}`
+    }
   }
 
   return definition

--- a/frontend/packages/schema/src/deparser/postgresql/utils.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/utils.ts
@@ -63,6 +63,8 @@ function generateColumnDefinition(
 
   if (column.default !== null) {
     // Special handling for jsonb type to prevent double-escaping
+    // NOTE: This is a workaround for issues that have surfaced with default values.
+    // A simpler approach with type-specific handling might be possible.
     if (column.type === 'jsonb' && typeof column.default === 'string') {
       const trimmed = column.default.trim()
       // If it's a cast expression (contains ::), use as-is


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5682

## Why is this change needed?

The PostgreSQL deparser was incorrectly handling jsonb default values, causing syntax errors when generating DDL. The issue occurred with different jsonb default value formats that LLMs might generate:

1. Cast expressions like `'{}'::jsonb` were being double-escaped
2. Pre-quoted values like `'{}'` were being double-escaped
3. Unquoted values like `{}` needed proper quoting

This fix ensures all three formats are handled correctly without double-escaping, preventing SQL syntax errors during DDL execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly deparses JSONB default values in generated DDL, respecting cast expressions and already-quoted literals to prevent double-escaping.
  * Ensures function-based defaults (e.g., UUID generators) remain unquoted in output.

* **Tests**
  * Added comprehensive tests for JSONB defaults (objects, arrays, and cast expressions) in table definitions.
  * Verifies zero deparser errors and exact SQL output matching the expected DDL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->