### PR TITLE
🐛 Fix duplicate key warning in TableOfContents component

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/TableOfContents/TableOfContents.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/TableOfContents/TableOfContents.tsx
@@ -15,7 +15,10 @@ type Props = {
   content: string
 }
 
-const parseHeading = (line: string): TocItem | null => {
+const parseHeading = (
+  line: string,
+  slugCountMap: Map<string, number>,
+): TocItem | null => {
   const headingMatch = line.match(/^(#{1,5})\s+(.+)$/)
   if (!headingMatch) return null
 
@@ -24,7 +27,13 @@ const parseHeading = (line: string): TocItem | null => {
   if (!levelMatch || !text) return null
 
   const level = levelMatch.length
-  const id = generateHeadingId(text)
+  const baseSlug = generateHeadingId(text)
+
+  // Handle duplicate slugs
+  const count = slugCountMap.get(baseSlug) ?? 0
+  slugCountMap.set(baseSlug, count + 1)
+
+  const id = count === 0 ? baseSlug : `${baseSlug}-${count + 1}`
 
   return { id, text, level }
 }
@@ -32,9 +41,10 @@ const parseHeading = (line: string): TocItem | null => {
 const extractTocItems = (content: string): TocItem[] => {
   const items: TocItem[] = []
   const lines = content.split('\n')
+  const slugCountMap = new Map<string, number>()
 
   for (const line of lines) {
-    const heading = parseHeading(line)
+    const heading = parseHeading(line, slugCountMap)
     if (heading) {
       items.push(heading)
     }
@@ -101,7 +111,7 @@ export const TableOfContents: FC<Props> = ({ content }) => {
       <ul className={styles.list}>
         {toc.map((item) => (
           <li
-            key={item.id}
+            key={`toc-${item.id}`}
             className={clsx(
               styles.item,
               item.level === 1 && styles.level1,

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils.ts
@@ -8,6 +8,7 @@ export const FAILURE_STATUS = 'Failed'
 export const generateHeadingId = (text: string): string => {
   return text
     .toLowerCase()
-    .replace(/[^\w]+/g, '-')
-    .replace(/(^-|-$)/g, '')
+    .trim()
+    .replace(/[^\p{L}\p{N}_-]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
 }


### PR DESCRIPTION
## Issue

- resolve: Duplicate key warnings in React when rendering Table of Contents with identical heading text

<img width="1279" height="337" alt="image" src="https://github.com/user-attachments/assets/da0f9de5-bc54-4e1e-b734-d905861a544c" />


## Why is this change needed?

This change fixes React console warnings that occur when multiple headings in a markdown artifact have the same text content. The duplicate keys were causing issues with React's Virtual DOM reconciliation, potentially leading to incorrect rendering behavior.

The fix ensures unique IDs by:
- Adding an index parameter to the `generateHeadingId` function
- Passing heading indices during parsing to create unique identifiers  
- Adding a unique 'toc-' prefix to list item keys

This improves the stability and reliability of the Table of Contents component when rendering markdown documents with duplicate heading text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unicode-aware slug generation for Table of Contents anchors, producing more robust, language-friendly IDs.

- Bug Fixes
  - Ensures unique anchor IDs for identical headings by appending incremental suffixes, preventing duplicate anchors and broken in-page links.
  - Improves TOC rendering stability by making list item keys unique.

- Accessibility
  - Removes duplicate element IDs, improving assistive technology compatibility and page semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->