### PR TITLE
🐛(schema): Fix default value escaping for enum types in PostgreSQL deparser

### DIFF
--- a/frontend/packages/schema/src/deparser/postgresql/operationDeparser.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/operationDeparser.ts
@@ -489,10 +489,13 @@ function generateAlterColumnDefaultFromOperation(
     return err(new Error(`Invalid column default path: ${operation.path}`))
   }
 
+  // Note: Column type is not available in the operation context
+  // Using null to fallback to basic formatting
   return ok(
     generateAlterColumnDefaultStatement(
       pathInfo.tableName,
       pathInfo.columnName,
+      null, // TODO: Pass column type when schema context is available
       operation.value,
     ),
   )

--- a/frontend/packages/schema/src/deparser/postgresql/schemaDeparser.test.ts
+++ b/frontend/packages/schema/src/deparser/postgresql/schemaDeparser.test.ts
@@ -1372,7 +1372,7 @@ describe('postgresqlSchemaDeparser', () => {
 
         CREATE TABLE "users" (
           "id" bigint NOT NULL,
-          "status" user_status NOT NULL
+          "status" "user_status" NOT NULL
         );
 
         ALTER TABLE "users" ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");"
@@ -1825,6 +1825,72 @@ describe('postgresqlSchemaDeparser', () => {
   "metadata" jsonb DEFAULT '{}'::jsonb,
   "settings" jsonb DEFAULT '{"theme": "dark"}'::jsonb,
   "tags" jsonb DEFAULT '[]'::jsonb
+);
+
+ALTER TABLE "users" ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");`
+
+        expect(result.value).toBe(expectedDDL)
+      })
+
+      it('should handle enum default values with cast expressions correctly', () => {
+        const schema = aSchema({
+          enums: {
+            user_status: anEnum({
+              name: 'user_status',
+              values: ['active', 'inactive', 'invited', 'suspended'],
+            }),
+          },
+          tables: {
+            users: aTable({
+              name: 'users',
+              columns: {
+                id: aColumn({
+                  name: 'id',
+                  type: 'uuid',
+                  notNull: true,
+                  default: 'gen_random_uuid()',
+                }),
+                status: aColumn({
+                  name: 'status',
+                  type: 'user_status',
+                  notNull: true,
+                  default: "'invited'::user_status", // Cast expression for enum
+                }),
+                role: aColumn({
+                  name: 'role',
+                  type: 'user_status',
+                  notNull: false,
+                  default: "'active'", // Pre-quoted enum value
+                }),
+                state: aColumn({
+                  name: 'state',
+                  type: 'user_status',
+                  notNull: false,
+                  default: 'inactive', // Unquoted enum value
+                }),
+              },
+              constraints: {
+                users_pkey: aPrimaryKeyConstraint({
+                  name: 'users_pkey',
+                  columnNames: ['id'],
+                }),
+              },
+            }),
+          },
+        })
+
+        const result = postgresqlSchemaDeparser(schema)
+
+        expect(result.errors).toHaveLength(0)
+
+        // Verify the exact DDL output
+        const expectedDDL = `CREATE TYPE "user_status" AS ENUM ('active', 'inactive', 'invited', 'suspended');
+
+CREATE TABLE "users" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "status" "user_status" NOT NULL DEFAULT 'invited'::user_status,
+  "role" "user_status" DEFAULT 'active',
+  "state" "user_status" DEFAULT 'inactive'
 );
 
 ALTER TABLE "users" ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");`


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5684

## Why is this change needed?

The PostgreSQL deparser was incorrectly handling default values for both jsonb and enum types, causing SQL syntax errors during DDL generation.

### Problems fixed:

1. **Enum default values** (#5684)
   - Cast expressions like `'invited'::user_status` were being triple-escaped → `'''invited''::user_status'`
   - Enum type names were not being properly quoted (e.g., `user_status` → `"user_status"`)

### Solution:

- Added `formatColumnDefault()` function to handle type-specific default value formatting
- Implemented `isLikelyEnumType()` to detect custom types (enums) vs built-in PostgreSQL types
- Special handling for cast expressions (containing `::`) to prevent double-escaping
- Proper quoting of enum type names in column definitions
- Comprehensive tests for all default value patterns

This ensures that all common default value formats are handled correctly without syntax errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - User-defined enum types in generated DDL are now consistently quoted.
  - Default-value formatting for enums, JSONB, and function-call defaults refined to avoid misquoting and preserve casts.

- Refactor
  - Centralized, type-aware default formatting with smarter detection of enum-like types and preserved array/cast handling.

- Tests
  - Added and updated tests covering enum defaults with casts and the new quoting/formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->