### PR TITLE
🐛 Fix schema benchmark environment loading and improve stability

### DIFF
--- a/frontend/internal-packages/schema-bench/README.md
+++ b/frontend/internal-packages/schema-bench/README.md
@@ -18,7 +18,7 @@ This creates a benchmark workspace with multiple datasets:
 
 System features:
 - Parallel dataset processing for faster execution
-- Smart concurrency per dataset (MAX_CONCURRENT=5)
+- Smart concurrency per dataset (MAX_CONCURRENT=3)
 - Automatic input standardization (strings get wrapped to `{ "input": "..." }`)
 
 ### 2) Execute a model

--- a/frontend/internal-packages/schema-bench/src/cli/executeLiamDbShared.ts
+++ b/frontend/internal-packages/schema-bench/src/cli/executeLiamDbShared.ts
@@ -14,7 +14,7 @@ import {
 import * as v from 'valibot'
 import { execute, type LiamDbExecutorInput } from '../executors/liamDb/index.ts'
 
-config({ path: resolve(__dirname, '../../../../../.env') })
+config({ path: resolve(__dirname, '../../../.env') })
 
 const InputSchema = v.union([
   v.object({
@@ -134,6 +134,8 @@ async function executeCase(
 ): Promise<Result<void, Error>> {
   const result = await execute(input)
   if (result.isErr()) {
+    console.error(`❌ Failed to execute ${caseId}:`, result.error.message)
+    console.error('Full error:', result.error)
     return err(
       new Error(`Failed to execute ${caseId}: ${result.error.message}`),
     )
@@ -164,8 +166,8 @@ export async function processDataset(
     return { datasetName, success: 0, failure: 0 }
   }
 
-  // Process each case with max 5 concurrent requests for stability
-  const MAX_CONCURRENT = 5
+  // Process each case with max 3 concurrent requests for stability
+  const MAX_CONCURRENT = 3
   let successCount = 0
   let failureCount = 0
 

--- a/frontend/internal-packages/schema-bench/src/cli/executeOpenai.ts
+++ b/frontend/internal-packages/schema-bench/src/cli/executeOpenai.ts
@@ -156,8 +156,8 @@ async function main() {
   // Create executor
   const executor = new OpenAIExecutor({ apiKey })
 
-  // Process each case with max 5 concurrent requests
-  const MAX_CONCURRENT = 5
+  // Process each case with max 3 concurrent requests
+  const MAX_CONCURRENT = 3
   let failureCount = 0
 
   const getErrorMessage = (


### PR DESCRIPTION
## Issue

- resolve: Fix LiamDB schema benchmark execution failures due to environment variable loading issues

## Why is this change needed?

The LiamDB schema benchmark was failing because:
1. The `.env` file path was incorrect, causing `OPENAI_API_KEY` to not be loaded
2. High concurrency (5) was causing instability and potential rate limit issues

This change fixes the environment variable loading issue and improves benchmark execution stability by reducing concurrency.

### Changes Made

1. **Environment Variable Fix**: Corrected the `.env` file path from `../../../../../.env` to `../../../.env` in `executeLiamDbShared.ts`
2. **Enhanced Error Logging**: Added detailed error logging for better debugging when benchmark execution fails
3. **Concurrency Optimization**: Reduced `MAX_CONCURRENT` from 5 to 3 in both LiamDB and OpenAI executors for better stability
4. **Documentation Update**: Updated README to reflect the new concurrency setting

### Testing

- Verified that environment variables are now properly loaded
- Confirmed that LiamDB benchmark execution starts successfully (previously failed immediately)
- Expected execution time should now be 20-30 minutes as intended

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated System features to reflect reduced per-dataset concurrency limit from 5 to 3.
- Chores
  - Lowered concurrency in CLI executors to 3 for datasets and input cases to improve stability.
  - Improved failure logging with case identifiers for easier troubleshooting.
  - Updated environment variable loading path for more reliable configuration.
  - No changes to public interfaces or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->