### PR TITLE
🐛 Fix infinite re-render loop in MigrationsViewer

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SQL/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SQL/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
@@ -129,12 +129,6 @@ export const useMigrationsViewer = ({
   useEffect(() => {
     if (!container) return
 
-    // Clean up existing view
-    if (view) {
-      view.destroy()
-      setView(undefined)
-    }
-
     const extensions = buildExtensions(
       showComments,
       onQuickFix,
@@ -145,6 +139,11 @@ export const useMigrationsViewer = ({
     setView(viewCurrent)
 
     applyComments(viewCurrent, showComments, comments)
+
+    // Cleanup function
+    return () => {
+      viewCurrent.destroy()
+    }
   }, [
     doc,
     prevDoc,
@@ -156,7 +155,6 @@ export const useMigrationsViewer = ({
     buildExtensions,
     createEditorView,
     onQuickFix,
-    view,
   ])
 
   useEffect(() => {
@@ -165,14 +163,6 @@ export const useMigrationsViewer = ({
     const effect = setCommentsEffect.of(comments)
     view.dispatch({ effects: [effect] })
   }, [comments, view, showComments])
-
-  useEffect(() => {
-    return () => {
-      if (view) {
-        view.destroy()
-      }
-    }
-  }, [view])
 
   return {
     ref,


### PR DESCRIPTION
## Issue

- resolve: Maximum update depth exceeded error in useMigrationsViewer hook






## Why is this change needed?

The MigrationsViewer component was experiencing an infinite re-render loop causing a "Maximum update depth exceeded" React error. This was caused by including the `view` state variable in the useEffect dependency array while also updating it within the same effect, creating a circular dependency.

The fix removes `view` from the dependency array and properly handles cleanup using a closure over the `viewCurrent` variable, preventing the infinite loop while maintaining proper component lifecycle management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e7e336f6-af65-43ae-841b-fdc8344353e8" /> | <video src="https://github.com/user-attachments/assets/ca211b95-f2d7-49ba-b7df-12257e8d59b7" /> | 


## Summary by CodeRabbit

- **Refactor**
  - Streamlined the editor lifecycle in the Migrations Viewer to centralize cleanup, reducing unnecessary work and improving stability.
  - Improved resource management when switching docs, toggling diff/comments, and navigating the page.
  - No changes to user-facing controls or behavior; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->