### PR TITLE
✨(commands): add deparse-dataset-to-schema command

### DIFF
--- a/.claude/commands/deparse-dataset-to-schema.md
+++ b/.claude/commands/deparse-dataset-to-schema.md
@@ -1,0 +1,31 @@
+---
+description: Convert JSON benchmark datasets back to schema files
+---
+
+# Deparse Dataset to Schema
+
+## Task
+
+Convert a JSON schema dataset to a schema file in the specified format using @liam-hq/schema deparser functionality.
+
+### Process
+
+1. Read the JSON dataset from the specified input path
+2. Use @liam-hq/schema's `postgresqlSchemaDeparser` function to convert JSON to SQL DDL
+3. Save the generated schema file to the specified output path
+4. Verify the generated schema is valid and properly formatted
+
+### Arguments
+
+$ARGUMENTS
+
+Expected arguments:
+
+- Input JSON file path - path to the JSON schema dataset to convert
+- Output file path - where to save the generated schema file
+- Format (optional - currently supports postgres, defaults to postgres)
+
+Example usage:
+`/deparse-dataset-to-schema frontend/internal-packages/schema-bench/benchmark-workspace-default/execution/reference/case-001.json schema.sql`
+`/deparse-dataset-to-schema data/case-002.json output/schema.sql --format postgres`
+`/deparse-dataset-to-schema ./my-schema.json generated-schema.sql`


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This change adds a new Claude Code command that enables users to convert JSON schema datasets back to SQL DDL format using the existing `@liam-hq/schema` deparser functionality.

### Key Features

- **JSON to SQL conversion**: Leverages `@liam-hq/schema`'s `postgresqlSchemaDeparser` for accurate DDL generation
- **Flexible file paths**: Accepts any input JSON file path and output SQL file path
- **Format support**: Currently supports PostgreSQL with extensible design for future formats
- **Comprehensive examples**: Includes realistic usage examples with actual file paths

### Use Cases

- Converting benchmark datasets to SQL for testing and validation
- Generating SQL schemas from JSON representations
- Supporting reverse engineering workflows
- Facilitating schema format conversions

### Command Usage

```bash
/deparse-dataset-to-schema input.json output.sql
/deparse-dataset-to-schema data/case-001.json schema.sql --format postgres
```

This complements the existing schema parsing capabilities by providing the reverse operation, enabling bidirectional conversion between JSON schema representations and SQL DDL.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a guide for a CLI command to convert JSON benchmark datasets into SQL schema files.
  - Includes step-by-step process, required arguments (input JSON path, output path), and an optional format flag.
  - Provides example invocations and notes on validating the generated schema.
  - Currently supports PostgreSQL format (default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->