### PR TITLE
feat: Add user language response instructions to all agent LLM prompts

### DIFF
--- a/frontend/apps/app/eslint-suppressions.json
+++ b/frontend/apps/app/eslint-suppressions.json
@@ -139,11 +139,6 @@
       "count": 1
     }
   },
-  "components/SessionDetailPage/hooks/useRealtimeWorkflowRuns.ts": {
-    "no-throw-error/no-throw-error": {
-      "count": 1
-    }
-  },
   "components/SessionsNewPage/SessionsNewPage.module.css": {
     "css-modules-kit/no-unused-class-names": {
       "count": 19

--- a/frontend/internal-packages/agent/src/db-agent/prompt.ts
+++ b/frontend/internal-packages/agent/src/db-agent/prompt.ts
@@ -1,4 +1,5 @@
 import { PromptTemplate } from '@langchain/core/prompts'
+import { USER_LANGUAGE_RESPONSE_INSTRUCTION } from '../utils/sharedPrompts'
 
 export const SYSTEM_PROMPT = `
 # Role and Objective
@@ -13,6 +14,7 @@ Always begin your response with a concise checklist (3-7 bullets) of what you wi
 - Perform accurate schema modifications using the designated tools.
 - Clearly confirm completed changes to the database schema.
 - When facing ambiguity or insufficient information, proceed by making reasonable assumptions internally and continue schema design autonomously; do not request further clarification or interaction from the user.
+- ${USER_LANGUAGE_RESPONSE_INSTRUCTION}
 
 ## Operation Guidelines
 - All comments (tables and columns) should be descriptive and explain business purpose, not just technical details.

--- a/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
@@ -9,6 +9,7 @@ import { fromAsyncThrowable } from '@liam-hq/neverthrow'
 import type { ResultAsync } from 'neverthrow'
 import { SSE_EVENTS } from '../../streaming/constants'
 import type { WorkflowState } from '../../types'
+import { USER_LANGUAGE_RESPONSE_INSTRUCTION } from '../../utils/sharedPrompts'
 import { streamLLMResponse } from '../../utils/streamingLlmUtils'
 
 const AGENT_NAME = 'lead' as const
@@ -52,6 +53,7 @@ Please summarize:
 - Key database design decisions that were made
 - Any schemas, tables, or data structures that were created or modified
 - Important outcomes or results from this workflow
+- ${USER_LANGUAGE_RESPONSE_INSTRUCTION}
 
 Keep the summary informative but concise, focusing on the key achievements and decisions made during this database design session.`
 

--- a/frontend/internal-packages/agent/src/pm-agent/prompts/pmAnalysisPrompts.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/prompts/pmAnalysisPrompts.ts
@@ -3,6 +3,7 @@
  */
 
 import { ChatPromptTemplate } from '@langchain/core/prompts'
+import { USER_LANGUAGE_RESPONSE_INSTRUCTION } from '../../utils/sharedPrompts'
 
 const PM_ANALYSIS_SYSTEM_MESSAGE = `
 # Role and Objective
@@ -14,6 +15,7 @@ You are PM Agent, an experienced project manager specializing in analyzing user 
 - Convert ambiguous requests into clear, actionable requirements.
 - Extract and structure requirements into the specified BRD format.
 - Save the analyzed requirements using the appropriate tool, confirming successful completion.
+- ${USER_LANGUAGE_RESPONSE_INSTRUCTION}
 
 ## Expected Behaviors
 - No user dialogue; work autonomously to completion.

--- a/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/prompts.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/prompts.ts
@@ -1,9 +1,11 @@
 import { PromptTemplate } from '@langchain/core/prompts'
+import { USER_LANGUAGE_RESPONSE_INSTRUCTION } from '../../utils/sharedPrompts'
 
 const ROLE_CONTEXT = `
 You are a database testing expert specializing in Liam DB schema validation.
 Your SQL validates actual schema designs in production PostgreSQL environments.
 SUCCESS: Your executable SQL proves schema viability and dramatically increases design confidence.
+IMPORTANT: ${USER_LANGUAGE_RESPONSE_INSTRUCTION}
 `
 
 const CRITICAL_INSTRUCTIONS = `

--- a/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/validateSchemaRequirementsNode.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/validateSchemaRequirementsNode.ts
@@ -5,6 +5,7 @@ import { fromPromise } from '@liam-hq/neverthrow'
 import * as v from 'valibot'
 import { convertSchemaToText } from '../../utils/convertSchemaToText'
 import { toJsonSchema } from '../../utils/jsonSchema'
+import { USER_LANGUAGE_RESPONSE_INSTRUCTION } from '../../utils/sharedPrompts'
 import type { testcaseAnnotation } from './testcaseAnnotation'
 
 const validationResultSchema = v.object({
@@ -36,6 +37,7 @@ RESPOND with a structured result:
   * If INSUFFICIENT: Specific description of what elements are missing
 
 Be decisive and focus on what is missing, not how to design it. Do not suggest specific table structures or implementation details.
+${USER_LANGUAGE_RESPONSE_INSTRUCTION}
 `
 
 /**

--- a/frontend/internal-packages/agent/src/utils/sharedPrompts.ts
+++ b/frontend/internal-packages/agent/src/utils/sharedPrompts.ts
@@ -1,0 +1,1 @@
+export const USER_LANGUAGE_RESPONSE_INSTRUCTION = `Always respond in the same language as the user's input (Japanese input → Japanese response, English input → English response)`


### PR DESCRIPTION
## Summary

- Creates shared language instruction in `utils/sharedPrompts.ts` for token efficiency
- Adds user language response instruction to all agent LLM prompts:
  - PM Agent: Requirements analysis prompts
  - QA Agent: Test case generation and schema validation
  - DB Agent: Schema design prompts  
  - Lead Agent: Workflow summary prompts
- Ensures all agents respond in the same language as user input (Japanese ↔ English)

## Implementation Details

### Shared Variable Approach
- Created `USER_LANGUAGE_RESPONSE_INSTRUCTION` constant for consistency
- Token-efficient single-line instruction without redundant section headers
- Flexible integration as bullet points or inline instructions

### Integration Strategy
- **PM Agent**: Added as bullet point in Instructions section
- **QA Agent (testcase)**: Added with `IMPORTANT:` label in ROLE_CONTEXT
- **DB Agent**: Added as bullet point in Core Directives
- **QA Agent (validation)**: Added inline with instruction text
- **Lead Agent**: Added as bullet point in summary requirements

## Test Plan

- [ ] Test PM Agent with Japanese input → should respond in Japanese
- [ ] Test QA Agent with English input → should respond in English  
- [ ] Test DB Agent with mixed language scenarios
- [ ] Verify all agents maintain language consistency throughout responses

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Agents now automatically respond in the user’s input language across planning, summarization, PM analysis, and QA/testcase generation workflows for more consistent multilingual interactions.

- Chores
  - Enforced a linting rule by removing an ESLint suppression, improving code quality consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->