### PR TITLE
feat: deny npm run commands in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,8 @@
     "allow": [],
     "deny": [
       "Bash(git commit --no-verify:*)",
-      "Edit(frontend/internal-packages/db/schema/schema.sql)"
+      "Edit(frontend/internal-packages/db/schema/schema.sql)",
+      "Bash(npm run:*)"
     ]
   }
 }


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This change prevents npm commands from being used in Claude Code sessions for this project, which exclusively uses pnpm. By adding `npm run:*` to the deny list in `.claude/settings.json`, we ensure consistency with the project's package manager choice and prevent potential confusion or conflicts.

## Summary

- Added `Bash(npm run:*)` to the deny permissions in `.claude/settings.json`
- Ensures Claude Code will use pnpm commands instead of npm commands
- Maintains consistency with project's package manager choice

## Test plan

- [x] Verify `.claude/settings.json` validates correctly
- [ ] Test that npm run commands are blocked in Claude Code sessions
- [ ] Confirm pnpm commands continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal AI tool configuration to expand denied actions, enhancing guardrails for scripted commands and schema edits. This strengthens development safety and reduces risk during automated operations.
  * No changes to features, performance, or user interface. No API or data behavior changes; existing functionality remains unaffected.
  * No action required from users or admins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->