### PR TITLE
Enable strict mode for QA agent test case generation

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/utils/__tests__/formatArtifactToMarkdown.test.ts
@@ -536,37 +536,6 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
       expect(result).toContain('```sql\nUPDATE users SET status = $1\n```')
     })
 
-    it('should format operation without description', () => {
-      const artifact: Artifact = {
-        requirement_analysis: {
-          business_requirement: 'Test',
-          requirements: [
-            {
-              name: 'Test Feature',
-              description: ['Test description'],
-              type: 'functional',
-              test_cases: [
-                {
-                  title: 'Test Use Case',
-                  description: 'Use case description',
-                  dmlOperation: {
-                    operation_type: 'DELETE',
-                    sql: 'DELETE FROM users WHERE id = $1',
-                    dml_execution_logs: [],
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      }
-
-      const result = formatArtifactToMarkdown(artifact)
-
-      expect(result).toContain('**DELETE**')
-      expect(result).not.toContain('**DELETE** -')
-    })
-
     it('should format successful execution logs', () => {
       const artifact: Artifact = {
         requirement_analysis: {
@@ -583,6 +552,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT * FROM users',
+                    description: 'Test operation',
                     dml_execution_logs: [
                       {
                         executed_at: '2024-03-20T14:45:30Z',
@@ -621,6 +591,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'INSERT',
                     sql: 'INSERT INTO users (email) VALUES ($1)',
+                    description: 'Test operation',
                     dml_execution_logs: [
                       {
                         executed_at: '2024-03-20T14:45:30Z',
@@ -658,6 +629,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'INSERT',
                     sql: 'INSERT INTO orders (user_id, total) VALUES ($1, $2)',
+                    description: 'Test operation',
                     dml_execution_logs: [
                       {
                         executed_at: '2024-03-20T10:00:00Z',
@@ -702,6 +674,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT * FROM products',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -732,6 +705,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: '  \n  SELECT * FROM users  \n  ',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -765,6 +739,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'INSERT',
                     sql: 'INSERT INTO logs (message) VALUES ($1)',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -798,6 +773,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -830,6 +806,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -839,6 +816,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -848,6 +826,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -880,6 +859,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -889,6 +869,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -905,6 +886,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT 1',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -941,6 +923,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'INSERT',
                     sql: 'INSERT INTO test',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -950,6 +933,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'UPDATE',
                     sql: 'UPDATE test',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -959,6 +943,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'DELETE',
                     sql: 'DELETE FROM test',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },
@@ -968,6 +953,7 @@ WHERE id = 'fc70279f-04d3-41ea-97e9-3a1bb7ee358f';`,
                   dmlOperation: {
                     operation_type: 'SELECT',
                     sql: 'SELECT * FROM test',
+                    description: 'Test operation',
                     dml_execution_logs: [],
                   },
                 },

--- a/frontend/internal-packages/agent/src/qa-agent/distributeRequirements/getUnprocessedRequirements.test.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/distributeRequirements/getUnprocessedRequirements.test.ts
@@ -37,6 +37,7 @@ const createMockTestcase = (requirementId: string): Testcase => ({
   dmlOperation: {
     operation_type: 'SELECT',
     sql: 'SELECT * FROM users',
+    description: 'Test DML operation',
     dml_execution_logs: [],
   },
 })

--- a/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/generateTestcaseNode.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/generateTestcaseNode.ts
@@ -21,6 +21,7 @@ const model = new ChatOpenAI({
   verbosity: 'low',
   useResponsesApi: true,
 }).bindTools([saveTestcaseTool], {
+  strict: true,
   parallel_tool_calls: false,
   tool_choice: 'auto',
 })

--- a/frontend/internal-packages/artifact/src/schemas/artifact.ts
+++ b/frontend/internal-packages/artifact/src/schemas/artifact.ts
@@ -11,7 +11,7 @@ export const dmlExecutionLogSchema = v.object({
 export const dmlOperationSchema = v.object({
   operation_type: v.picklist(['INSERT', 'UPDATE', 'DELETE', 'SELECT']),
   sql: v.string(),
-  description: v.optional(v.string()),
+  description: v.string(),
   dml_execution_logs: v.array(dmlExecutionLogSchema),
 })
 


### PR DESCRIPTION
## Issue

- resolve: Enable strict mode for OpenAI structured outputs in QA agent

## Why is this change needed?

OpenAI's structured outputs with `strict: true` provides more reliable tool calling and schema validation. This change enables strict mode for the QA agent's test case generation to ensure consistent and valid test case outputs.

## Summary

- ✅ **Add strict mode**: Enable `strict: true` in ChatOpenAI tool binding for generateTestcaseNode 
- ✅ **Make description required**: Change `dmlOperation.description` from optional to required field to meet OpenAI strict mode requirements
- ✅ **Update tests**: Add required description field to all test cases and remove obsolete "without description" test
- ✅ **Verify integration**: Confirm integration tests pass with strict mode enabled

## Test plan

- [x] Integration tests pass with strict mode enabled
- [x] All TypeScript compilation errors resolved  
- [x] Lint checks pass
- [x] QA agent generates valid test cases with structured outputs

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Artifact outputs now always include a description for each DML operation, improving clarity and consistency in rendered Markdown on session details.

- Refactor
  - Strengthened validation to require descriptions for all DML operations.

- Tests
  - Updated test data to include mandatory descriptions and removed an obsolete case for missing descriptions.

- Chores
  - Enabled strict mode in agent tooling configuration for more robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->