### PR TITLE
🎨 Format CSS calc expression on single line

### DIFF
--- a/frontend/apps/app/features/sessions/components/GitHubSessionForm/SchemaInfoSection/SchemaInfoSection.module.css
+++ b/frontend/apps/app/features/sessions/components/GitHubSessionForm/SchemaInfoSection/SchemaInfoSection.module.css
@@ -96,11 +96,10 @@
   border: 1px solid var(--overlay-5);
   border-radius: var(--border-radius-base);
   padding: var(--spacing-1half);
-  padding-right: calc(
-    var(--spacing-1half) +
-    14px +
-    var(--spacing-1half)
-  ); /* RemoveButton width + gap */
+
+  /* RemoveButton width + gap */
+  padding-right: calc(var(--spacing-1half) + 14px + var(--spacing-1half));
+
   position: relative;
 }
 


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
Formatted CSS calc expression to be on a single line for better readability and consistency with project styling standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Cleaned up comments and whitespace in the Schema Info section stylesheet to improve maintainability.
  - Repositioned an inline comment around padding calculations for consistency with style standards; no changes to layout, spacing, behavior, or accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->