### PR TITLE
Add maxCompletionTokens configuration to AI agents

### DIFF
--- a/frontend/internal-packages/agent/src/db-agent/invokeDesignAgent.ts
+++ b/frontend/internal-packages/agent/src/db-agent/invokeDesignAgent.ts
@@ -26,6 +26,7 @@ const AGENT_NAME = 'db' as const
 const model = new ChatOpenAI({
   model: 'gpt-5-mini',
   reasoning: { effort: 'low', summary: 'detailed' },
+  maxCompletionTokens: 6_000,
   useResponsesApi: true,
 }).bindTools([schemaDesignTool], {
   strict: true,

--- a/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
+++ b/frontend/internal-packages/agent/src/lead-agent/summarizeWorkflow/index.ts
@@ -43,6 +43,7 @@ function generateWorkflowSummary(
   const llm = new ChatOpenAI({
     model: 'gpt-5-nano',
     reasoning: { effort: 'minimal' },
+    maxCompletionTokens: 2_000,
   })
 
   const summaryPrompt = `Based on the following workflow conversation about database design, provide a concise summary of what was accomplished:

--- a/frontend/internal-packages/agent/src/pm-agent/invokePmAnalysisAgent.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/invokePmAnalysisAgent.ts
@@ -44,6 +44,7 @@ export const invokePmAnalysisAgent = (
   const model = new ChatOpenAI({
     model: 'gpt-5',
     reasoning: { effort: 'medium', summary: 'detailed' },
+    maxCompletionTokens: 8_000,
     useResponsesApi: true,
     streaming: true,
   }).bindTools(

--- a/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/generateTestcaseNode.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/generateTestcaseNode.ts
@@ -18,6 +18,7 @@ import type { testcaseAnnotation } from './testcaseAnnotation'
 const model = new ChatOpenAI({
   model: 'gpt-5-nano',
   reasoning: { effort: 'minimal', summary: 'auto' },
+  maxCompletionTokens: 4_000,
   verbosity: 'low',
   useResponsesApi: true,
 }).bindTools([saveTestcaseTool], {


### PR DESCRIPTION
## Issue

- resolve: Configures appropriate completion token limits for different agent types

## Why is this change needed?

Setting specific token limits helps optimize cost and performance for different AI agent roles. Each agent type has different complexity requirements:

- **DB agent**: 6,000 tokens for schema design work requiring detailed responses
- **Lead agent**: 2,000 tokens for concise workflow summaries
- **PM agent**: 8,000 tokens for comprehensive analysis requiring detailed explanations
- **QA agent**: 4,000 tokens for test case generation with moderate complexity

This prevents over-generation for simple tasks while ensuring sufficient capacity for complex operations.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Increased response length limits across agents to reduce truncation and provide richer outputs.
  * Design Agent: Expanded completion window for more detailed design suggestions.
  * PM Analysis Agent: Higher token allowance for deeper analysis responses.
  * QA Testcase Generation: Larger completions for more comprehensive test cases.
  * Workflow Summary: Extended token limit for fuller, clearer summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->