### PR TITLE
📝(docs): Move database operations guidance to package-specific CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,6 @@ pnpm --filter @liam-hq/agent fmt
 pnpm --filter @liam-hq/agent test
 ```
 
-### Database Operations
-
-For database migration and type generation workflows, see @docs/migrationOpsContext.md.
-
 ## Architecture
 
 ### Monorepo Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### App-specific Commands
 
-````bash
+```bash
 # Run only the main web app (port 3001)
 pnpm --filter @liam-hq/app dev
 
@@ -22,6 +22,7 @@ pnpm --filter @liam-hq/agent fmt
 
 # Test
 pnpm --filter @liam-hq/agent test
+```
 
 ### Database Operations
 
@@ -53,11 +54,13 @@ For database migration and type generation workflows, see @docs/migrationOpsCont
 
 Keep every implementation as small and obvious as possible.
 
+- **Let the code speak** – If you need a multi-paragraph comment, refactor until intent is obvious
+- **Delete fearlessly, Git remembers** – Cut dead code, stale logic, and verbose history
+
 ### TypeScript Standards
 
 - Use runtime type validation with `valibot` for external data validation
 - Use early returns for readability
-- **Let the code speak** – If you need a multi-paragraph comment, refactor until intent is obvious
 
 ### Code Editing
 
@@ -75,7 +78,7 @@ function saveUser(data: UserData, userId?: string) {
 function saveUser(data: UserData, userId: string) {
   return db.save(userId, data); // Simple and clear
 }
-````
+```
 
 ### Component Patterns
 

--- a/frontend/internal-packages/db/CLAUDE.md
+++ b/frontend/internal-packages/db/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md - Database Package
+
+This file provides guidance to Claude Code (claude.ai/code) when working with database operations.
+
+## Database Operations
+
+For database migration and type generation workflows, see @../../../docs/migrationOpsContext.md


### PR DESCRIPTION
## Issue

- resolve: Documentation organization improvement

## Why is this change needed?

Improved organization of documentation by:
1. Moving database operations guidance from main CLAUDE.md to package-specific location
2. Adding "Delete fearlessly, Git remembers" principle to core principles  
3. Fixing code block formatting inconsistencies in CLAUDE.md

This follows the "less is more" principle by keeping the main CLAUDE.md focused on essential project-wide guidance while placing specialized documentation in appropriate package locations.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Markdown formatting for command examples and code blocks.
  * Expanded development guidelines with clearer principles to streamline code clarity and cleanup.
  * Updated a code example to clarify required parameters in the Code Editing section.
  * Added a new guidance doc for working with database operations, including references to the migration and type-generation workflow.

* **Chores**
  * Editorial cleanup and consistency adjustments across internal docs.

* **Note**
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->