### PR TITLE
📝 Update benchmark timeout guidance for LiamDB execution

### DIFF
--- a/.claude/commands/benchmark-execute.md
+++ b/.claude/commands/benchmark-execute.md
@@ -22,6 +22,8 @@ Execute schema benchmark comparison between LiamDB and OpenAI models.
 - Automatic input format standardization
 - Improved error handling and progress reporting
 
+**Critical**: When executing LiamDB benchmarks, use a 30-minute (1800-second) timeout to prevent premature termination. The deep modeling workflow can take 10+ minutes per test case.
+
 First, I'll clean up any existing workspace and set up a fresh benchmark environment with multiple datasets:
 
 ```bash


### PR DESCRIPTION
## Issue

- resolve: Add critical timeout guidance for LiamDB benchmark execution

## Why is this change needed?

This change improves the benchmark execution documentation with critical timeout guidance to prevent premature termination during LiamDB deep modeling workflows.

### Changes Made

**Benchmark timeout guidance**: Updated `.claude/commands/benchmark-execute.md` with critical timeout information for LiamDB benchmarks to prevent premature termination during deep modeling workflows that can take 10+ minutes per test case.

### Technical Details

- Added 30-minute (1800-second) timeout recommendation for LiamDB benchmarks
- Prevents premature termination during deep modeling workflows
- Improves benchmark execution reliability

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Clarified that LiamDB benchmark executions have a 30-minute (1800-second) timeout, helping users plan and monitor longer runs and set expectations for completion or termination. This documentation-only update improves transparency around execution limits and prevents confusion around stalled runs or timeouts. No changes to command behavior, usage, or workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->