### PR TITLE
⚡ Add 120s timeout to prevent hanging API calls in generateTestcaseNode

### DIFF
--- a/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/generateTestcaseNode.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/testcaseGeneration/generateTestcaseNode.ts
@@ -49,12 +49,19 @@ export async function generateTestcaseNode(
   const cleanedMessages = removeReasoningFromMessages(messages)
 
   const streamModel = fromAsyncThrowable(() => {
-    return model.stream([
-      new SystemMessage(SYSTEM_PROMPT_FOR_TESTCASE_GENERATION),
-      new HumanMessage(contextMessage),
-      // Include all previous messages in this subgraph's scope
-      ...cleanedMessages,
-    ])
+    return model.stream(
+      [
+        new SystemMessage(SYSTEM_PROMPT_FOR_TESTCASE_GENERATION),
+        new HumanMessage(contextMessage),
+        // Include all previous messages in this subgraph's scope
+        ...cleanedMessages,
+      ],
+      {
+        options: {
+          timeout: 120000, // 120s
+        },
+      },
+    )
   })
 
   const streamResult = await streamModel()


### PR DESCRIPTION
## Issue

- ref: route06/liam-internal#5703 

## Why is this change needed?

The generateTestcaseNode function could hang for 1600+ seconds in some cases, despite the expected 10-minute default timeout. This was because the timeout wasn't being explicitly set for the streaming API call. Without the explicit timeout in the options parameter, streaming could continue indefinitely as the default timeout only applies to initial connection establishment, not to ongoing streaming data.

This change adds an explicit 120-second timeout to the `model.stream()` call to ensure requests complete within a reasonable time and trigger LangGraph's retry mechanism when they exceed the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Introduced a 2-minute timeout for AI streaming during test case generation to prevent indefinite hangs.
  * Improves responsiveness and recovery in unstable network conditions.
  * Preserves existing message flow and outputs when requests finish within the timeout.
  * Downstream error handling remains unchanged, ensuring consistent behavior on timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->