### PR TITLE
⬆️ chore(deps): update pnpm to 10.17.1 and set `minimumReleaseAge`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vercel:env-pull": "vercel env pull .env",
     "vercel:link": "vercel link -p liam-app -S \"liambx\" -y"
   },
-  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
+  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
   "pnpm": {
     "onlyBuiltDependencies": [
       "supabase"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "frontend/packages/*"
   - "frontend/packages/__mocks__/*"
   - "frontend/internal-packages/*"
+minimumReleaseAge: 20160 # 14 days


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?
1. Update pnpm package manager from version 10.15.1 to 10.17.1 to get the latest bug fixes and improvements.

Updated using corepack:
```bash
corepack use pnpm@10.17.1
```

2.  set `minimumReleaseAge`

- see [this blog entry](https://pnpm.io/blog/releases/10.16)
- https://pnpm.io/settings#minimumreleaseage

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated project package manager to the latest patch release to improve install consistency, security, and tooling compatibility.
  * Added a new workspace configuration to manage minimum release age (internal release cadence). No functional or user-facing changes; no action required from end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->