### PR TITLE
📝(docs): clarify merge queue usage in review-renovate command

### DIFF
--- a/.claude/commands/review-renovate.md
+++ b/.claude/commands/review-renovate.md
@@ -54,7 +54,7 @@ flowchart TD
     CreatePR --> AddApprovalComment
     
     AddApprovalComment --> ApprovePR[Approve PR with gh pr review --approve]
-    ApprovePR --> AddToMergeQueue[Add to merge queue with gh pr merge --auto]
+    ApprovePR --> AddToMergeQueue[Add to merge queue: gh pr merge --auto]
     
     AddToMergeQueue --> NextPR{Other PRs exist?}
     
@@ -70,6 +70,9 @@ flowchart TD
 - **Patch updates**: LOW risk - quick review
 - **Minor updates**: MEDIUM risk - check for new features
 - **Major updates**: HIGH risk - detailed review required
+
+### Merge Strategy Note
+This repository uses GitHub merge queue. Use `gh pr merge --auto` to add approved PRs to the queue. Direct merge commands (`--squash`, `--merge`) will be rejected.
 
 ### Arguments
 $ARGUMENTS


### PR DESCRIPTION
## Issue

- resolve: N/A - Documentation improvement

## Why is this change needed?

This change improves the `/review-renovate` command documentation by clarifying the merge queue usage pattern. The original documentation was ambiguous about the merge strategy, which could lead to confusion when using the command.

### Changes made:
- Updated flowchart to use clearer syntax: `gh pr merge --auto` instead of `Add to merge queue with gh pr merge --auto`
- Added dedicated "Merge Strategy Note" section explaining that this repository uses GitHub merge queue
- Clarified that direct merge commands (`--squash`, `--merge`) will be rejected in favor of the queue system

This documentation improvement helps ensure consistent usage of the merge queue workflow and reduces potential errors when processing Renovate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions for adding pull requests to the merge queue, standardizing wording around automatic merges.
  * Added a section explaining the merge queue strategy, noting that direct merges are rejected and reiterating merge policy.
  * Improves reviewer and contributor guidance, reducing ambiguity in the review/merge workflow.
  * No functional changes to the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->