### PR TITLE
🐛 Fix ARGUMENTS display during tool running state

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ArgumentsDisplay/ArgumentsDisplay.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ArgumentsDisplay/ArgumentsDisplay.tsx
@@ -302,7 +302,9 @@ export const ArgumentsDisplay: FC<Props> = ({
 
   // Don't show anything during preparation phase (only for animated content)
   // For non-animated content, always show
-  if (isAnimated && !isReady && displayLines.length > 0) {
+  // Show immediately for running tools to avoid hiding arguments
+  // Keep empty check to avoid rendering empty content
+  if (isAnimated && !isReady && displayLines.length === 0) {
     return null
   }
 


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5697

## Why is this change needed?

This PR fixes a bug where ARGUMENTS parameters were not displayed in the timeline when AI agent tools were in a "running" state. The arguments would only appear after the tool execution completed, making it difficult for users to understand what the tool was doing in real-time.

### Problem
- When a tool was in "running" or "pending" state, the ARGUMENTS section was completely hidden
- Users couldn't see what parameters were being passed to the tool during execution
- This affected debugging and transparency of tool operations

### Solution
Modified the `ArgumentsDisplay` component to show arguments immediately when tools are running, instead of hiding them during the animation preparation phase. The fix changes the condition from checking if `displayLines.length > 0` to `displayLines.length === 0`, ensuring arguments are visible as soon as they're available.

### Technical Details
- File modified: `frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ArgumentsDisplay/ArgumentsDisplay.tsx`
- The component was returning `null` when `isAnimated && !isReady && displayLines.length > 0`
- Now it only returns `null` when there are actually no lines to display (`displayLines.length === 0`)