### PR TITLE
♻️ Move empty schema validation from node to conditional edge

### DIFF
--- a/frontend/internal-packages/agent/src/createGraph.ts
+++ b/frontend/internal-packages/agent/src/createGraph.ts
@@ -2,6 +2,7 @@ import { AIMessage } from '@langchain/core/messages'
 import type { RunnableConfig } from '@langchain/core/runnables'
 import { END, START, StateGraph } from '@langchain/langgraph'
 import type { BaseCheckpointSaver } from '@langchain/langgraph-checkpoint'
+import { isEmptySchema } from '@liam-hq/schema'
 import { createDbAgentGraph } from './db-agent/createDbAgentGraph'
 import { convertRequirementsToPrompt } from './db-agent/utils/convertAnalyzedRequirementsToPrompt'
 import { createLeadAgentGraph } from './lead-agent/createLeadAgentGraph'
@@ -70,7 +71,12 @@ export const createGraph = (checkpointer?: BaseCheckpointSaver) => {
         const isFirstExecution = !state.messages.some(
           (msg) => msg instanceof AIMessage,
         )
-        return isFirstExecution ? 'validateInitialSchema' : 'leadAgent'
+
+        if (isFirstExecution && !isEmptySchema(state.schemaData)) {
+          return 'validateInitialSchema'
+        }
+
+        return 'leadAgent'
       },
       {
         validateInitialSchema: 'validateInitialSchema',

--- a/frontend/internal-packages/agent/src/workflow/nodes/validateInitialSchemaNode.test.ts
+++ b/frontend/internal-packages/agent/src/workflow/nodes/validateInitialSchemaNode.test.ts
@@ -1,4 +1,4 @@
-import { AIMessage, HumanMessage } from '@langchain/core/messages'
+import { HumanMessage } from '@langchain/core/messages'
 import { END, START, StateGraph } from '@langchain/langgraph'
 import { aColumn, aSchema, aTable } from '@liam-hq/schema'
 import { describe, expect, it } from 'vitest'
@@ -9,45 +9,6 @@ import { validateInitialSchemaNode } from './validateInitialSchemaNode'
 
 describe('validateInitialSchemaNode Integration', () => {
   describe('First execution scenarios', () => {
-    it('should display fresh database message when schema is empty', async () => {
-      const { config, context, checkpointer } = await getTestConfig({
-        useOpenAI: false,
-      })
-      const graph = new StateGraph(workflowAnnotation)
-        .addNode('validateInitialSchema', validateInitialSchemaNode)
-        .addEdge(START, 'validateInitialSchema')
-        .addEdge('validateInitialSchema', END)
-        .compile({ checkpointer })
-
-      const state: WorkflowState = {
-        messages: [new HumanMessage('Create a new database schema')],
-        designSessionId: context.designSessionId,
-        organizationId: context.organizationId,
-        userId: context.userId,
-        schemaData: aSchema({
-          tables: {},
-          enums: {},
-          extensions: {},
-        }),
-        analyzedRequirements: {
-          businessRequirement: '',
-          functionalRequirements: {},
-          nonFunctionalRequirements: {},
-        },
-        testcases: [],
-        schemaIssues: [],
-        buildingSchemaId: 'test-building-schema-id',
-        latestVersionNumber: 1,
-        next: 'leadAgent',
-      }
-
-      const result = await graph.invoke(state, config)
-
-      // Assert
-      // Empty schema should return unchanged state
-      expect(result).toEqual(state)
-    })
-
     it('should validate existing schema successfully', async () => {
       const { config, context, checkpointer } = await getTestConfig({
         useOpenAI: false,
@@ -102,59 +63,8 @@ describe('validateInitialSchemaNode Integration', () => {
     }, 30000) // 30 second timeout for CI/preview environments
   })
 
-  describe('Non-first execution scenarios', () => {
-    it('should skip validation when AI messages already exist', async () => {
-      const { config, context, checkpointer } = await getTestConfig({
-        useOpenAI: false,
-      })
-      const graph = new StateGraph(workflowAnnotation)
-        .addNode('validateInitialSchema', validateInitialSchemaNode)
-        .addEdge(START, 'validateInitialSchema')
-        .addEdge('validateInitialSchema', END)
-        .compile({ checkpointer })
-
-      const state: WorkflowState = {
-        messages: [
-          new HumanMessage('First message'),
-          new AIMessage('AI response'), // This indicates non-first execution
-          new HumanMessage('Follow-up message'),
-        ],
-        designSessionId: context.designSessionId,
-        organizationId: context.organizationId,
-        userId: context.userId,
-        schemaData: aSchema({
-          tables: {
-            users: aTable({
-              name: 'users',
-              columns: {
-                id: aColumn({
-                  name: 'id',
-                  type: 'uuid',
-                  notNull: true,
-                }),
-              },
-            }),
-          },
-          enums: {},
-          extensions: {},
-        }),
-        analyzedRequirements: {
-          businessRequirement: '',
-          functionalRequirements: {},
-          nonFunctionalRequirements: {},
-        },
-        testcases: [],
-        schemaIssues: [],
-        buildingSchemaId: 'test-building-schema-id',
-        latestVersionNumber: 1,
-        next: 'leadAgent',
-      }
-
-      const result = await graph.invoke(state, config)
-
-      expect(result).toEqual(state)
-    }, 30000) // 30 second timeout for CI/preview environments
-  })
+  // NOTE: Non-first execution scenarios are now handled at the graph level (createGraph.ts)
+  // and the validateInitialSchemaNode is skipped entirely, so these tests are no longer applicable.
 
   describe('Error handling scenarios', () => {
     it('should fail when schema contains invalid column type', async () => {

--- a/frontend/internal-packages/agent/src/workflow/nodes/validateInitialSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/workflow/nodes/validateInitialSchemaNode.ts
@@ -1,5 +1,5 @@
 import { executeQuery } from '@liam-hq/pglite-server'
-import { isEmptySchema, postgresqlSchemaDeparser } from '@liam-hq/schema'
+import { postgresqlSchemaDeparser } from '@liam-hq/schema'
 import type { WorkflowState } from '../../types'
 import { WorkflowTerminationError } from '../../utils/errorHandling'
 
@@ -20,11 +20,6 @@ const createValidationError = (
 export async function validateInitialSchemaNode(
   state: WorkflowState,
 ): Promise<WorkflowState> {
-  if (isEmptySchema(state.schemaData)) {
-    // TODO: Add message creation in next PR
-    return state
-  }
-
   const ddlResult = postgresqlSchemaDeparser(state.schemaData)
 
   if (ddlResult.errors.length > 0) {


### PR DESCRIPTION
## Issue

resolve: 

## Why is this change needed?

The current implementation handles `isEmptySchema` branching logic inside `validateInitialSchemaNode`. This refactoring moves that branching logic to `conditionalEdge` in `createGraph.ts` for better flow control at the graph level.

## Changes

### 🔧 Core Changes
- **validateInitialSchemaNode.ts**: Removed `isEmptySchema` early return, simplified to focus purely on schema validation logic
- **createGraph.ts**: Added `isEmptySchema` import and conditional edge logic to skip validation node for empty schemas

### 🧪 Test Updates
- **validateInitialSchemaNode.test.ts**: Removed test cases for empty schema and non-first execution scenarios (now handled at graph level)

### 📊 Impact
- Empty schema: Skips `validateInitialSchemaNode` entirely and goes directly to `leadAgent`
- Non-empty schema: Follows existing flow `validateInitialSchema` → `leadAgent`
- Flow control unified at graph level, improving maintainability

## Test plan

- [x] Existing tests pass successfully
- [x] TypeScript type checking passes
- [x] ESLint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)