### PR TITLE
🐛 Fix infinite loop in useSessionStorageOnce hook

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/hooks/useStream/useSessionStorageOnce.ts
+++ b/frontend/apps/app/components/SessionDetailPage/hooks/useStream/useSessionStorageOnce.ts
@@ -5,7 +5,7 @@ import {
   coerceMessageLikeToMessage,
   isHumanMessage,
 } from '@langchain/core/messages'
-import { useEffect, useRef, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
 import { LG_INITIAL_MESSAGE_PREFIX } from '../../../../constants/storageKeys'
 
 /**
@@ -17,12 +17,12 @@ export function useSessionStorageOnce(
 ): BaseMessage | null {
   const key = `${LG_INITIAL_MESSAGE_PREFIX}:${designSessionId}`
 
-  const subscribe = (_callback: () => void) => {
+  const subscribe = useCallback((_callback: () => void) => {
     // sessionStorage does not fire events within the same tab
     return () => {}
-  }
+  }, [])
 
-  const getSnapshot = () => {
+  const getSnapshot = useCallback(() => {
     if (typeof window === 'undefined') return null
     const stored = sessionStorage.getItem(key)
     if (!stored) return null
@@ -34,9 +34,9 @@ export function useSessionStorageOnce(
     } catch {
       return null
     }
-  }
+  }, [key])
 
-  const getServerSnapshot = () => null
+  const getServerSnapshot = useCallback(() => null, [])
 
   const message = useSyncExternalStore(
     subscribe,


### PR DESCRIPTION
## Summary
- Fixed React infinite loop in `useSessionStorageOnce` hook by memoizing callback functions
- Used `useCallback` for `subscribe`, `getSnapshot`, and `getServerSnapshot` to provide stable references to `useSyncExternalStore`
- Resolved compatibility issue with React 19 + Next.js 15

## Test plan
- [x] Verify no infinite loop errors in browser console
- [x] Confirm sessionStorage functionality still works correctly
- [x] Test that initial messages are properly loaded and deleted

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal handling of a one-time session message read to reduce unnecessary re-renders and improve responsiveness on the session detail page.
  * Memoized related callbacks to stabilize behavior across renders without altering existing functionality.
  * Preserves current user experience and public API; no UI or workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->