### PR TITLE
✨ Improve initial tab selection logic in SessionDetailPage

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   getCheckpointErrors,
   getMessages,
 } from '@liam-hq/agent'
+import { type Artifact, artifactSchema } from '@liam-hq/artifact'
 import type { Schema } from '@liam-hq/schema'
 import { schemaSchema } from '@liam-hq/schema'
 import { err, ok, type Result } from 'neverthrow'
@@ -35,6 +36,7 @@ async function loadSessionData(designSessionId: string): Promise<
       messages: StoredMessage[]
       buildingSchema: NonNullable<Awaited<ReturnType<typeof getBuildingSchema>>>
       initialSchema: Schema
+      initialArtifact: Artifact | null
       workflowError: string | null
     },
     Error
@@ -71,10 +73,28 @@ async function loadSessionData(designSessionId: string): Promise<
     return err(new Error('Invalid schema format'))
   }
 
+  const { data: artifactData, error } = await supabase
+    .from('artifacts')
+    // Explicitly specify columns as anon user has grants on individual columns, not all columns
+    .select('id, design_session_id, artifact, created_at, updated_at')
+    .eq('design_session_id', designSessionId)
+    .maybeSingle()
+
+  if (error) {
+    return err(new Error(`Error fetching artifact: ${error.message}`))
+  }
+
+  let initialArtifact: Artifact | null = null
+  const parsedArtifact = safeParse(artifactSchema, artifactData?.artifact)
+  if (parsedArtifact.success) {
+    initialArtifact = parsedArtifact.output
+  }
+
   return ok({
     messages,
     buildingSchema,
     initialSchema,
+    initialArtifact,
     workflowError,
   })
 }
@@ -89,8 +109,13 @@ export const SessionDetailPage: FC<Props> = async ({
     throw result.error
   }
 
-  const { messages, buildingSchema, initialSchema, workflowError } =
-    result.value
+  const {
+    messages,
+    buildingSchema,
+    initialSchema,
+    workflowError,
+    initialArtifact,
+  } = result.value
 
   const versions = await getVersions(buildingSchema.id)
   const latestVersion: Version | undefined = versions[0]
@@ -114,6 +139,7 @@ export const SessionDetailPage: FC<Props> = async ({
         initialDisplayedSchema={initialSchema}
         initialPrevSchema={initialPrevSchema}
         initialVersions={versions}
+        initialArtifact={initialArtifact}
         isDeepModelingEnabled={isDeepModelingEnabled}
         initialIsPublic={initialIsPublic}
         initialWorkflowError={workflowError}

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -82,11 +82,12 @@ export const SessionDetailPageClient: FC<Props> = ({
     }
   }, [])
 
-  const { artifact } = useRealtimeArtifact(
+  const { artifact, error: artifactError } = useRealtimeArtifact(
     designSessionId,
-    handleArtifactChange,
+    onChangeArtifact: handleArtifactChange,
   )
-  const shouldShowOutputSection = artifact !== null || selectedVersion !== null
+  const shouldShowOutputSection =
+    (artifact !== null || selectedVersion !== null) && activeTab
 
   const chatMessages = mapStoredMessagesToChatMessages(initialMessages)
   const { isStreaming, messages, start, error } = useStream({
@@ -162,6 +163,8 @@ export const SessionDetailPageClient: FC<Props> = ({
                 activeTab={activeTab}
                 onTabChange={setActiveTab}
                 initialIsPublic={initialIsPublic}
+                artifact={artifact}
+                artifactError={artifactError}
               />
             ) : (
               <Output
@@ -173,6 +176,8 @@ export const SessionDetailPageClient: FC<Props> = ({
                 selectedVersion={selectedVersion}
                 onSelectedVersionChange={handleVersionChange}
                 initialIsPublic={initialIsPublic}
+                artifact={artifact}
+                artifactError={artifactError}
               />
             )}
           </div>

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -17,6 +17,7 @@ import { useStream } from './hooks/useStream'
 import { SQL_REVIEW_COMMENTS } from './mock'
 import styles from './SessionDetailPage.module.css'
 import type { Version } from './types'
+import { Artifact } from '@liam-hq/artifact'
 
 type Props = {
   buildingSchemaId: string
@@ -28,6 +29,7 @@ type Props = {
   isDeepModelingEnabled: boolean
   initialIsPublic: boolean
   initialWorkflowError?: string | null
+  initialArtifact: Artifact | null
 }
 
 export const SessionDetailPageClient: FC<Props> = ({
@@ -40,6 +42,7 @@ export const SessionDetailPageClient: FC<Props> = ({
   isDeepModelingEnabled,
   initialIsPublic,
   initialWorkflowError,
+  initialArtifact
 }) => {
   const [activeTab, setActiveTab] = useState<string | undefined>(undefined)
 
@@ -82,9 +85,11 @@ export const SessionDetailPageClient: FC<Props> = ({
     }
   }, [])
 
-  const { artifact, error: artifactError } = useRealtimeArtifact(
+  const { artifact, error: artifactError } = useRealtimeArtifact({
     designSessionId,
+    initialArtifact,
     onChangeArtifact: handleArtifactChange,
+  }
   )
   const shouldShowOutputSection =
     (artifact !== null || selectedVersion !== null) && activeTab

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -5,19 +5,19 @@ import {
   mapStoredMessagesToChatMessages,
   type StoredMessage,
 } from '@langchain/core/messages'
+import type { Artifact } from '@liam-hq/artifact'
 import type { Schema } from '@liam-hq/schema'
 import clsx from 'clsx'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
 import { Chat } from './components/Chat'
 import { Output } from './components/Output'
 import { useRealtimeArtifact } from './components/Output/components/Artifact/hooks/useRealtimeArtifact'
-import { OUTPUT_TABS } from './components/Output/constants'
+import { OUTPUT_TABS, type OutputTabValue } from './components/Output/constants'
 import { useRealtimeVersionsWithSchema } from './hooks/useRealtimeVersionsWithSchema'
 import { useStream } from './hooks/useStream'
 import { SQL_REVIEW_COMMENTS } from './mock'
 import styles from './SessionDetailPage.module.css'
 import type { Version } from './types'
-import { Artifact } from '@liam-hq/artifact'
 
 type Props = {
   buildingSchemaId: string
@@ -42,9 +42,11 @@ export const SessionDetailPageClient: FC<Props> = ({
   isDeepModelingEnabled,
   initialIsPublic,
   initialWorkflowError,
-  initialArtifact
+  initialArtifact,
 }) => {
-  const [activeTab, setActiveTab] = useState<string | undefined>(undefined)
+  const [activeTab, setActiveTab] = useState<OutputTabValue | undefined>(
+    undefined,
+  )
 
   const {
     versions,
@@ -77,20 +79,11 @@ export const SessionDetailPageClient: FC<Props> = ({
     }
   }, [])
 
-  const handleNavigateToTab = useCallback((tab: 'erd' | 'artifact') => {
-    if (tab === 'erd') {
-      setActiveTab(OUTPUT_TABS.ERD)
-    } else if (tab === 'artifact') {
-      setActiveTab(OUTPUT_TABS.ARTIFACT)
-    }
-  }, [])
-
   const { artifact, error: artifactError } = useRealtimeArtifact({
     designSessionId,
     initialArtifact,
     onChangeArtifact: handleArtifactChange,
-  }
-  )
+  })
   const shouldShowOutputSection =
     (artifact !== null || selectedVersion !== null) && activeTab
 
@@ -150,41 +143,26 @@ export const SessionDetailPageClient: FC<Props> = ({
                 isDeepModelingEnabled,
               })
             }
-            onNavigate={handleNavigateToTab}
+            onNavigate={setActiveTab}
             error={combinedError}
           />
         </div>
         {shouldShowOutputSection && (
           <div className={styles.outputSection}>
-            {activeTab !== undefined ? (
-              <Output
-                designSessionId={designSessionId}
-                schema={displayedSchema}
-                prevSchema={prevSchema}
-                sqlReviewComments={SQL_REVIEW_COMMENTS}
-                versions={versions}
-                selectedVersion={selectedVersion}
-                onSelectedVersionChange={handleVersionChange}
-                activeTab={activeTab}
-                onTabChange={setActiveTab}
-                initialIsPublic={initialIsPublic}
-                artifact={artifact}
-                artifactError={artifactError}
-              />
-            ) : (
-              <Output
-                designSessionId={designSessionId}
-                schema={displayedSchema}
-                prevSchema={prevSchema}
-                sqlReviewComments={SQL_REVIEW_COMMENTS}
-                versions={versions}
-                selectedVersion={selectedVersion}
-                onSelectedVersionChange={handleVersionChange}
-                initialIsPublic={initialIsPublic}
-                artifact={artifact}
-                artifactError={artifactError}
-              />
-            )}
+            <Output
+              designSessionId={designSessionId}
+              schema={displayedSchema}
+              prevSchema={prevSchema}
+              sqlReviewComments={SQL_REVIEW_COMMENTS}
+              versions={versions}
+              selectedVersion={selectedVersion}
+              onSelectedVersionChange={handleVersionChange}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              initialIsPublic={initialIsPublic}
+              artifact={artifact}
+              artifactError={artifactError}
+            />
           </div>
         )}
       </div>

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -32,6 +32,31 @@ type Props = {
   initialArtifact: Artifact | null
 }
 
+// Determine the initial active tab based on available data
+const determineInitialTab = (
+  artifact: Artifact | null,
+  versions: Version[],
+): OutputTabValue | undefined => {
+  const hasArtifact = artifact !== null
+  const hasVersions = versions.length > 0
+
+  if (!hasArtifact && !hasVersions) {
+    return undefined
+  }
+
+  // Prioritize ERD tab when versions exist
+  if (hasVersions) {
+    return OUTPUT_TABS.ERD
+  }
+
+  // Show artifact tab when only artifact exists
+  if (hasArtifact) {
+    return OUTPUT_TABS.ARTIFACT
+  }
+
+  return undefined
+}
+
 export const SessionDetailPageClient: FC<Props> = ({
   buildingSchemaId,
   designSessionId,
@@ -45,7 +70,7 @@ export const SessionDetailPageClient: FC<Props> = ({
   initialArtifact,
 }) => {
   const [activeTab, setActiveTab] = useState<OutputTabValue | undefined>(
-    undefined,
+    determineInitialTab(initialArtifact, initialVersions),
   )
 
   const {
@@ -84,6 +109,7 @@ export const SessionDetailPageClient: FC<Props> = ({
     initialArtifact,
     onChangeArtifact: handleArtifactChange,
   })
+
   const shouldShowOutputSection =
     (artifact !== null || selectedVersion !== null) && activeTab
 

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/Chat.tsx
@@ -3,6 +3,7 @@
 import type { BaseMessage } from '@langchain/core/messages'
 import type { Schema } from '@liam-hq/schema'
 import type { FC } from 'react'
+import type { OutputTabValue } from '../Output/constants'
 import styles from './Chat.module.css'
 import { ChatInput } from './components/ChatInput'
 import { ErrorDisplay } from './components/ErrorDisplay'
@@ -16,7 +17,7 @@ type Props = {
   onSendMessage: (content: string) => void
   isWorkflowRunning?: boolean
   error?: string | null
-  onNavigate: (tab: 'erd' | 'artifact') => void
+  onNavigate: (tab: OutputTabValue) => void
 }
 
 export const Chat: FC<Props> = ({

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/AiMessage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/AiMessage.tsx
@@ -9,6 +9,7 @@ import { match } from 'ts-pattern'
 import * as v from 'valibot'
 import { MarkdownContent } from '../../../../../../MarkdownContent'
 import { CopyButton } from '../../../../CopyButton'
+import type { OutputTabValue } from '../../../../Output/constants'
 import { DBAgent, LeadAgent, PMAgent, QAAgent } from './AgentAvatar'
 import styles from './AiMessage.module.css'
 import { ReasoningMessage } from './ReasoningMessage'
@@ -36,7 +37,7 @@ const getAgentInfo = (name: string | undefined) => {
 type Props = {
   message: AIMessage
   toolMessages: ToolMessage[]
-  onNavigate: (tab: 'erd' | 'artifact') => void
+  onNavigate: (tab: OutputTabValue) => void
   isWorkflowRunning: boolean
 }
 

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ToolCallCard.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ToolCallCard.tsx
@@ -19,6 +19,7 @@ import {
 } from '@liam-hq/ui'
 import clsx from 'clsx'
 import type { FC } from 'react'
+import type { OutputTabValue } from '../../../../../../Output/constants'
 import { ArgumentsDisplay } from './ArgumentsDisplay'
 import { useAnimationState } from './hooks/useAnimationState'
 import { useEventHandlers } from './hooks/useEventHandlers'
@@ -34,7 +35,7 @@ type Props = {
   status?: 'pending' | 'running' | 'completed' | 'error'
   error?: string
   toolMessage?: ToolMessageType | undefined
-  onNavigate: (tab: 'erd' | 'artifact') => void
+  onNavigate: (tab: OutputTabValue) => void
 }
 
 // Component for expand/collapse button with tooltip

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/hooks/useEventHandlers.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/hooks/useEventHandlers.ts
@@ -1,3 +1,4 @@
+import type { OutputTabValue } from '../../../../../../../Output/constants'
 import type { useAnimationState } from './useAnimationState'
 import type { useExpandState } from './useExpandState'
 import type { useToolData } from './useToolData'
@@ -5,7 +6,7 @@ import type { useToolData } from './useToolData'
 export const useEventHandlers = (
   animationState: ReturnType<typeof useAnimationState>,
   expandState: ReturnType<typeof useExpandState>,
-  onNavigate: (tab: 'erd' | 'artifact') => void,
+  onNavigate: (tab: OutputTabValue) => void,
   toolInfo?: ReturnType<typeof useToolData>['toolInfo'],
 ) => {
   const handleArgumentsReady = () => {

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.tsx
@@ -3,6 +3,7 @@
 import type { ToolMessage as ToolMessageType } from '@langchain/core/messages'
 import type { ToolCalls as ToolCallsType } from '@liam-hq/agent/client'
 import { type FC, useEffect, useState } from 'react'
+import type { OutputTabValue } from '../../../../../Output/constants'
 import { ToolCallCard } from './ToolCallCard'
 import styles from './ToolCalls.module.css'
 
@@ -16,7 +17,7 @@ type ToolCallWithMessage = {
 type Props = {
   toolCallsWithMessages: ToolCallWithMessage[]
   isStreaming?: boolean
-  onNavigate: (tab: 'erd' | 'artifact') => void
+  onNavigate: (tab: OutputTabValue) => void
 }
 
 type ToolCallStatus = 'pending' | 'running' | 'completed' | 'error'

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/Messages.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/Messages.tsx
@@ -6,6 +6,7 @@ import {
   type ToolMessage,
 } from '@langchain/core/messages'
 import type { FC } from 'react'
+import type { OutputTabValue } from '../../../Output/constants'
 import { AiMessage } from './AiMessage'
 import { HumanMessage } from './HumanMessage'
 
@@ -80,7 +81,7 @@ const collectFollowingToolMessages = (
 
 type Props = {
   messages: BaseMessage[]
-  onNavigate: (tab: 'erd' | 'artifact') => void
+  onNavigate: (tab: OutputTabValue) => void
   isWorkflowRunning?: boolean
 }
 

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
@@ -95,10 +95,7 @@ export const Output: FC<Props> = ({
         />
       </TabsContent>
       <TabsContent value={OUTPUT_TABS.ARTIFACT} className={styles.tabsContent}>
-        <ArtifactContainer
-          artifact={artifact}
-          error={artifactError}
-        />
+        <ArtifactContainer artifact={artifact} error={artifactError} />
       </TabsContent>
     </TabsRoot>
   )

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/ArtifactContainer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/ArtifactContainer.tsx
@@ -7,15 +7,10 @@ import { formatArtifactToMarkdown } from './utils'
 
 type Props = {
   artifact: ArtifactType | null
-  loading: boolean
   error: Error | null
 }
 
-export const ArtifactContainer: FC<Props> = ({ artifact, loading, error }) => {
-  if (loading) {
-    return <div>Loading artifact...</div>
-  }
-
+export const ArtifactContainer: FC<Props> = ({ artifact, error }) => {
   if (error) {
     return <div>Error loading artifact: {error.message}</div>
   }

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/hooks/useRealtimeArtifact.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/hooks/useRealtimeArtifact.ts
@@ -14,13 +14,19 @@ const artifactDataSchema = v.object({
   updated_at: v.string(),
 })
 
-export function useRealtimeArtifact(
-  designSessionId: string,
-  onChangeArtifact?: (artifact: Artifact) => void,
-) {
+type Params = {
+  designSessionId: string
+  initialArtifact: Artifact | null
+  onChangeArtifact?: (artifact: Artifact) => void
+}
+
+export function useRealtimeArtifact({
+  designSessionId,
+  initialArtifact,
+  onChangeArtifact,
+}: Params) {
   const { isPublic } = useViewMode()
-  const [artifact, setArtifact] = useState<Artifact | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [artifact, setArtifact] = useState<Artifact | null>(initialArtifact)
   const [error, setError] = useState<Error | null>(null)
 
   const handleError = useCallback((err: unknown) => {
@@ -28,53 +34,6 @@ export function useRealtimeArtifact(
       err instanceof Error ? err : new Error('Artifact processing failed'),
     )
   }, [])
-
-  // Fetch artifact data
-  const fetchArtifact = useCallback(async () => {
-    setError(null) // Clear previous errors
-    const supabase = createClient()
-    const { data, error: fetchError } = await supabase
-      .from('artifacts')
-      // Explicitly specify columns as anon user has grants on individual columns, not all columns
-      .select('id, design_session_id, artifact, created_at, updated_at')
-      .eq('design_session_id', designSessionId)
-      .maybeSingle()
-
-    if (fetchError) {
-      if (fetchError.code) {
-        console.error(
-          'Error fetching artifact:',
-          fetchError.message || fetchError,
-        )
-        handleError(fetchError)
-      }
-
-      setLoading(false)
-      return
-    }
-
-    if (!data) {
-      setArtifact(null)
-      setLoading(false)
-      return
-    }
-
-    // Validate artifact data
-    const artifactData = v.safeParse(artifactDataSchema, data)
-    if (artifactData.success) {
-      setArtifact(artifactData.output.artifact)
-    } else {
-      console.error('Invalid artifact data schema:', artifactData.issues)
-      handleError(new Error('Invalid artifact data schema'))
-    }
-
-    setLoading(false)
-  }, [designSessionId, handleError])
-
-  // Initial fetch
-  useEffect(() => {
-    fetchArtifact()
-  }, [fetchArtifact])
 
   // Set up realtime subscription
   useEffect(() => {
@@ -121,7 +80,6 @@ export function useRealtimeArtifact(
 
   return {
     artifact,
-    loading,
     error,
   }
 }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5708

## Why is this change needed?

This PR improves the initial tab selection logic in SessionDetailPage to provide a better user experience by intelligently determining which tab to display first based on available data.

### Changes made:
1. **Added intelligent initial tab selection**: Created `determineInitialTab` function that decides which tab to show based on available artifacts and versions
2. **Server-side artifact fetching**: Added server-side fetching of artifacts to enable proper initial tab selection
3. **Unified navigation types**: Consolidated tab navigation types across Chat components for consistency
4. **Refactored useRealtimeArtifact hook**: Simplified the hook interface for better maintainability

### Tab selection priority:
- When versions exist → Show ERD tab (prioritized)
- When only artifact exists → Show Artifact tab
- When neither exists → Hide tabs (undefined)

This ensures users see the most relevant content immediately upon page load, reducing the need for manual tab switching.