### PR TITLE
🐛 Fix tab reset issue when versions update via realtime

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/hooks/useRealtimeVersionsWithSchema/useRealtimeVersionsWithSchema.ts
+++ b/frontend/apps/app/components/SessionDetailPage/hooks/useRealtimeVersionsWithSchema/useRealtimeVersionsWithSchema.ts
@@ -2,7 +2,7 @@
 
 import { buildingSchemaVersionsSchema } from '@liam-hq/db'
 import { type Schema, schemaSchema } from '@liam-hq/schema'
-import { useCallback, useEffect, useState, useTransition } from 'react'
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react'
 import * as v from 'valibot'
 import { createClient } from '../../../../libs/db/client'
 import { useViewMode } from '../../hooks/viewMode'
@@ -31,6 +31,7 @@ export function useRealtimeVersionsWithSchema({
   const [selectedVersion, setSelectedVersion] = useState<Version | null>(
     initialVersions[0] ?? null,
   )
+  const prevVersionsLengthRef = useRef(initialVersions.length)
 
   const [displayedSchema, setDisplayedSchema] = useState<Schema>(
     initialDisplayedSchema,
@@ -91,9 +92,13 @@ export function useRealtimeVersionsWithSchema({
   useEffect(() => {
     const targetVersion = versions[0] ?? null
     setSelectedVersion(targetVersion)
-    if (targetVersion !== null) {
+
+    // Call onChangeSelectedVersion only when a new version is added
+    if (versions.length > prevVersionsLengthRef.current && targetVersion) {
       onChangeSelectedVersion(targetVersion)
     }
+
+    prevVersionsLengthRef.current = versions.length
   }, [versions, onChangeSelectedVersion])
 
   useEffect(() => {


### PR DESCRIPTION
## Issue

- resolve: #

## Why is this change needed?

When versions are updated through realtime subscriptions in the SessionDetailPage, the active tab unexpectedly resets to the ERD tab, disrupting the user's workflow. This caused two specific issues:

1. **SQL tab becomes unclickable**: When users tried to switch to the SQL tab, it would immediately revert back to the ERD tab
2. **Tab selection not preserved**: Any manual tab selection by the user would be lost when versions were updated via realtime

This occurred because the `onChangeSelectedVersion` callback was being triggered for any version update, not just when new versions are added.

The fix ensures that the ERD tab is only automatically activated when:
1. A new version is added via realtime updates
2. The user manually selects a different version

This preserves the user's tab selection during routine version updates while maintaining the expected behavior for new version additions, and ensures all tabs (including SQL) remain clickable and functional.


| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/3ae37559-e55c-4803-9575-10e1887612d4" /> | <video src="https://github.com/user-attachments/assets/d502aca5-bc1c-4f42-99b6-ef7bf70b1e94" /> | 


