### PR TITLE
fix(schema): support complex Drizzle method chaining patterns

### DIFF
--- a/.changeset/whole-mirrors-throw.md
+++ b/.changeset/whole-mirrors-throw.md
@@ -2,4 +2,4 @@
 "@liam-hq/schema": patch
 ---
 
-🐛 fix(schema): support chained methods like pgTable().enableRLS().$comment()
+🐛 fix(Drizzle parser): support chained methods like pgTable().enableRLS().$comment()

--- a/.changeset/whole-mirrors-throw.md
+++ b/.changeset/whole-mirrors-throw.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/schema": patch
+---
+
+🐛 fix(schema): support chained methods like pgTable().enableRLS().$comment()

--- a/frontend/packages/schema/src/parser/drizzle/postgres/__tests__/index.test.ts
+++ b/frontend/packages/schema/src/parser/drizzle/postgres/__tests__/index.test.ts
@@ -57,5 +57,86 @@ describe(processor, () => {
         'numeric(10,2)',
       )
     })
+
+    it('should parse tables with .enableRLS() method chaining', async () => {
+      const { value } = await processor(`
+        import { pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
+
+        export const users = pgTable('users', {
+          id: serial('id').primaryKey(),
+          name: varchar('name', { length: 255 }).notNull(),
+          email: text('email').notNull(),
+        }).enableRLS();
+
+        export const posts = pgTable('posts', {
+          id: serial('id').primaryKey(),
+          title: text('title').notNull(),
+          content: text('content'),
+          userId: serial('user_id').references(() => users.id),
+        }).enableRLS();
+
+        export const categories = pgTable('categories', {
+          id: serial('id').primaryKey(),
+          name: varchar('name', { length: 100 }).notNull(),
+        }).enableRLS();
+      `)
+
+      // Verify that all tables with .enableRLS() are correctly parsed
+      expect(Object.keys(value.tables)).toHaveLength(3)
+      expect(value.tables['users']).toBeDefined()
+      expect(value.tables['posts']).toBeDefined()
+      expect(value.tables['categories']).toBeDefined()
+
+      // Verify table structures
+      expect(value.tables['users']?.columns['id']?.type).toBe('serial')
+      expect(value.tables['users']?.columns['name']?.type).toBe('varchar(255)')
+      expect(value.tables['users']?.columns['email']?.type).toBe('text')
+
+      expect(value.tables['posts']?.columns['userId']?.type).toBe('serial')
+      expect(value.tables['posts']?.columns['title']?.type).toBe('text')
+
+      expect(value.tables['categories']?.columns['name']?.type).toBe(
+        'varchar(100)',
+      )
+    })
+
+    it('should parse tables with .$comment() method chaining', async () => {
+      const { value } = await processor(`
+        import { pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
+
+        export const users = pgTable('users', {
+          id: serial('id').primaryKey(),
+          name: varchar('name', { length: 255 }).notNull(),
+          email: text('email').notNull(),
+        }).$comment('User accounts table');
+
+        export const posts = pgTable('posts', {
+          id: serial('id').primaryKey(),
+          title: text('title').notNull(),
+          content: text('content'),
+        }).$comment('Blog posts storage');
+
+        export const mixed = pgTable('mixed', {
+          id: serial('id').primaryKey(),
+          data: text('data'),
+        }).enableRLS().$comment('Mixed methods example');
+      `)
+
+      // Verify that all tables with .$comment() are correctly parsed
+      expect(Object.keys(value.tables)).toHaveLength(3)
+      expect(value.tables['users']).toBeDefined()
+      expect(value.tables['posts']).toBeDefined()
+      expect(value.tables['mixed']).toBeDefined()
+
+      // Verify table structures and comments
+      expect(value.tables['users']?.comment).toBe('User accounts table')
+      expect(value.tables['posts']?.comment).toBe('Blog posts storage')
+      expect(value.tables['mixed']?.comment).toBe('Mixed methods example')
+
+      // Verify column structures are still correct
+      expect(value.tables['users']?.columns['name']?.type).toBe('varchar(255)')
+      expect(value.tables['posts']?.columns['title']?.type).toBe('text')
+      expect(value.tables['mixed']?.columns['data']?.type).toBe('text')
+    })
   })
 })

--- a/frontend/packages/schema/src/parser/drizzle/postgres/astUtils.ts
+++ b/frontend/packages/schema/src/parser/drizzle/postgres/astUtils.ts
@@ -111,8 +111,31 @@ export const isMemberExpression = (
 /**
  * Check if a call expression is a pgTable call
  */
-export const isPgTableCall = (callExpr: CallExpression): boolean => {
+const isPgTableCall = (callExpr: CallExpression): boolean => {
   return isIdentifierWithName(callExpr.callee, 'pgTable')
+}
+/**
+ * Extract the base pgTable call from method chaining patterns
+ * Handles patterns like: pgTable(...).enableRLS(), pgTable(...).comment(...), etc.
+ */
+export const extractPgTableFromChain = (
+  callExpr: CallExpression,
+): CallExpression | null => {
+  // If it's already a direct pgTable call, return it
+  if (isPgTableCall(callExpr)) {
+    return callExpr
+  }
+
+  // If it's a method call on another expression, check the object
+  if (callExpr.callee.type === 'MemberExpression') {
+    const baseCall = callExpr.callee.object
+    if (baseCall.type === 'CallExpression') {
+      // Recursively check if the base call is or contains a pgTable call
+      return extractPgTableFromChain(baseCall)
+    }
+  }
+
+  return null
 }
 
 /**

--- a/frontend/packages/schema/src/parser/drizzle/postgres/mainParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/postgres/mainParser.ts
@@ -2,10 +2,10 @@
  * Main orchestrator for Drizzle ORM schema parsing
  */
 
-import type { Module, VariableDeclarator } from '@swc/core'
+import type { CallExpression, Module, VariableDeclarator } from '@swc/core'
 import { parseSync } from '@swc/core'
 import type { Processor, ProcessResult } from '../../types.js'
-import { isPgTableCall, isSchemaTableCall } from './astUtils.js'
+import { extractPgTableFromChain, isSchemaTableCall } from './astUtils.js'
 import {
   convertDrizzleEnumsToInternal,
   convertDrizzleTablesToInternal,
@@ -80,6 +80,96 @@ const visitModule = (
 }
 
 /**
+ * Check if the call expression is a comment call
+ */
+const isCommentCall = (callExpr: CallExpression): boolean => {
+  return (
+    callExpr.type === 'CallExpression' &&
+    callExpr.callee.type === 'MemberExpression' &&
+    callExpr.callee.property.type === 'Identifier' &&
+    callExpr.callee.property.value === '$comment'
+  )
+}
+
+/**
+ * Check if the call expression is a pgEnum call
+ */
+const isPgEnumCall = (callExpr: CallExpression): boolean => {
+  return (
+    callExpr.callee.type === 'Identifier' && callExpr.callee.value === 'pgEnum'
+  )
+}
+
+/**
+ * Handle comment calls
+ */
+const handleCommentCall = (
+  declarator: VariableDeclarator,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  if (declarator.init?.type !== 'CallExpression') return
+
+  const table = parsePgTableWithComment(declarator.init)
+  if (table && declarator.id.type === 'Identifier') {
+    tables[table.name] = table
+    variableToTableMapping[declarator.id.value] = table.name
+  }
+}
+
+/**
+ * Handle schema table calls
+ */
+const handleSchemaTableCall = (
+  declarator: VariableDeclarator,
+  callExpr: CallExpression,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  const table = parseSchemaTableCall(callExpr)
+  if (table && declarator.id.type === 'Identifier') {
+    tables[table.name] = table
+    variableToTableMapping[declarator.id.value] = table.name
+  }
+}
+
+/**
+ * Handle pgEnum calls
+ */
+const handlePgEnumCall = (
+  declarator: VariableDeclarator,
+  callExpr: CallExpression,
+  enums: Record<string, DrizzleEnumDefinition>,
+) => {
+  const enumDef = parsePgEnumCall(callExpr)
+  if (enumDef && declarator.id.type === 'Identifier') {
+    // Store enum by its actual name (e.g., 'user_role')
+    enums[enumDef.name] = enumDef
+    // Also store by variable name (e.g., 'userRoleEnum') for lookup
+    enums[declarator.id.value] = enumDef
+  }
+}
+
+/**
+ * Handle pgTable calls (direct or method chained)
+ */
+const handlePgTableCall = (
+  declarator: VariableDeclarator,
+  callExpr: CallExpression,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  const basePgTableCall = extractPgTableFromChain(callExpr)
+  if (basePgTableCall) {
+    const table = parsePgTableCall(basePgTableCall)
+    if (table && declarator.id.type === 'Identifier') {
+      tables[table.name] = table
+      variableToTableMapping[declarator.id.value] = table.name
+    }
+  }
+}
+
+/**
  * Visit variable declarator to find pgTable, pgEnum, or relations calls
  */
 const visitVariableDeclarator = (
@@ -88,45 +178,21 @@ const visitVariableDeclarator = (
   enums: Record<string, DrizzleEnumDefinition>,
   variableToTableMapping: Record<string, string>,
 ) => {
-  if (!declarator.init || declarator.init.type !== 'CallExpression') return
+  if (!declarator.init || declarator.init.type !== 'CallExpression') {
+    return
+  }
 
   const callExpr = declarator.init
 
-  if (isPgTableCall(callExpr)) {
-    const table = parsePgTableCall(callExpr)
-    if (table && declarator.id.type === 'Identifier') {
-      tables[table.name] = table
-      // Map variable name to table name
-      variableToTableMapping[declarator.id.value] = table.name
-    }
+  // Handle different types of call expressions
+  if (isCommentCall(declarator.init)) {
+    handleCommentCall(declarator, tables, variableToTableMapping)
   } else if (isSchemaTableCall(callExpr)) {
-    const table = parseSchemaTableCall(callExpr)
-    if (table && declarator.id.type === 'Identifier') {
-      tables[table.name] = table
-      // Map variable name to table name
-      variableToTableMapping[declarator.id.value] = table.name
-    }
-  } else if (
-    declarator.init.type === 'CallExpression' &&
-    declarator.init.callee.type === 'MemberExpression' &&
-    declarator.init.callee.property.type === 'Identifier' &&
-    declarator.init.callee.property.value === '$comment'
-  ) {
-    // Handle table comments: pgTable(...).comment(...)
-    const table = parsePgTableWithComment(declarator.init)
-    if (table && declarator.id.type === 'Identifier') {
-      tables[table.name] = table
-      // Map variable name to table name
-      variableToTableMapping[declarator.id.value] = table.name
-    }
-  } else if (
-    callExpr.callee.type === 'Identifier' &&
-    callExpr.callee.value === 'pgEnum'
-  ) {
-    const enumDef = parsePgEnumCall(callExpr)
-    if (enumDef && declarator.id.type === 'Identifier') {
-      enums[declarator.id.value] = enumDef
-    }
+    handleSchemaTableCall(declarator, callExpr, tables, variableToTableMapping)
+  } else if (isPgEnumCall(callExpr)) {
+    handlePgEnumCall(declarator, callExpr, enums)
+  } else {
+    handlePgTableCall(declarator, callExpr, tables, variableToTableMapping)
   }
 }
 

--- a/frontend/packages/schema/src/parser/drizzle/postgres/mainParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/postgres/mainParser.ts
@@ -143,10 +143,9 @@ const handlePgEnumCall = (
 ) => {
   const enumDef = parsePgEnumCall(callExpr)
   if (enumDef && declarator.id.type === 'Identifier') {
-    // Store enum by its actual name (e.g., 'user_role')
-    enums[enumDef.name] = enumDef
-    // Also store by variable name (e.g., 'userRoleEnum') for lookup
-    enums[declarator.id.value] = enumDef
+    const variableName = declarator.id.value
+    // Only store by variable name to avoid conflicts between actual name and variable name
+    enums[variableName] = enumDef
   }
 }
 


### PR DESCRIPTION
## ⚠️ Please do not merge

**Please do not merge this PR yet, as the base PR has not been merged.**
- https://github.com/liam-hq/liam/pull/3607


## Issue
- fix: https://github.com/route06/liam-internal/issues/5739

## Summary

Enhance the Drizzle PostgreSQL parser to correctly handle complex method chaining patterns like `.enableRLS().$comment()`. This fixes GitHub folder URL parsing for Drizzle schemas that use multiple method chaining patterns.

## Issues Fixed

- Complex method chaining patterns like `.enableRLS().$comment()` were not being parsed correctly
- GitHub folder URL feature was only showing some tables instead of all tables from Drizzle schemas
- Tables using complex method chaining were being ignored during parsing

## Technical Details

### AST Structure Analysis

The complex chaining pattern `.enableRLS().$comment()` creates this AST structure:
1. Root call: `$comment(...)` 
2. Its callee object: `enableRLS()` call
3. enableRLS's callee object: `pgTable(...)` call (the base)

### Solution Implementation

The fix involves recursively traversing the method chain to find the underlying `pgTable` call, regardless of how many intermediate method calls are chained.

## Testing



### before

in cli

<img width="701" height="555" alt="ss 3912" src="https://github.com/user-attachments/assets/dd01dc30-2e72-4e18-bfdb-00aa4f2f558c" />



### after

https://liam-app-git-feature-github-drizzle-method-chaini-3328d9-liambx.vercel.app/erd/p/github.com/kanbn/kan/tree/main/packages/db/src/schema

<img width="1606" height="701" alt="ss 3898" src="https://github.com/user-attachments/assets/c87e414b-3a3b-4ffc-9ea7-047b652b54c2" />


## Impact

This change ensures that ERD visualizations from GitHub folder URLs correctly display all tables from Drizzle schemas, regardless of the method chaining patterns used. Users can now use complex patterns like `.enableRLS().$comment()` without losing tables in their ERD diagrams.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser now supports chained pgTable definitions (e.g., with RLS and table comments).
  * Recognizes comment-based table declarations and schema-qualified tables.
  * Adds parsing support for PostgreSQL enums.
* **Refactor**
  * Reworked parser flow for improved modularity and extensibility, enhancing handling of Drizzle Postgres constructs.
* **Tests**
  * Added tests covering chained pgTable usage with RLS and comments, including mixed scenarios, to ensure correct table detection, comments, and column types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->