### PR TITLE
fix: add explicit Sentry error reporting for SQL syntax errors in saveTestcase tool

### DIFF
--- a/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
+++ b/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
@@ -8,11 +8,47 @@ export const withSentryCaptureException = async <T>(
     return await operation()
   } catch (error) {
     console.error('[withSentryCaptureException] Capturing error:', error)
-    const eventId = Sentry.captureException(error)
+
+    // Check if error has Sentry-specific properties
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Need to check for custom error properties
+    const errorWithSentry = error as {
+      tags?: Record<string, string>
+      extra?: Record<string, unknown>
+    }
+
+    // Only pass options if they exist
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Need type for Sentry options
+    const captureOptions = {} as {
+      tags?: Record<string, string>
+      extra?: Record<string, unknown>
+    }
+
+    if (errorWithSentry.tags) {
+      captureOptions.tags = errorWithSentry.tags
+    }
+    if (errorWithSentry.extra) {
+      captureOptions.extra = errorWithSentry.extra
+    }
+
+    // Capture with tags and extra data if available
+    const eventId =
+      Object.keys(captureOptions).length > 0
+        ? Sentry.captureException(error, captureOptions)
+        : Sentry.captureException(error)
+
     console.error(
       '[withSentryCaptureException] Sent to Sentry with eventId:',
       eventId,
     )
+    console.error(
+      '[withSentryCaptureException] With tags:',
+      errorWithSentry.tags,
+    )
+    console.error(
+      '[withSentryCaptureException] With extra:',
+      errorWithSentry.extra,
+    )
+
     throw error
   }
 }

--- a/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
+++ b/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
@@ -1,5 +1,96 @@
 import * as Sentry from '@sentry/node'
 
+/**
+ * Generate a random UUID for Sentry event ID
+ */
+function generateEventId(): string {
+  return 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.replace(/[x]/g, () => {
+    return Math.floor(Math.random() * 16).toString(16)
+  })
+}
+
+/**
+ * Send error directly to Sentry via API
+ * This is used when Sentry SDK is not initialized
+ */
+async function sendToSentryAPI(
+  error: Error,
+  tags?: Record<string, string>,
+  extra?: Record<string, unknown>,
+): Promise<void> {
+  const dsn = process.env['SENTRY_DSN'] || process.env['NEXT_PUBLIC_SENTRY_DSN']
+
+  if (!dsn) {
+    console.warn('[withSentryCaptureException] No SENTRY_DSN found')
+    return
+  }
+
+  // Parse DSN
+  const dsnMatch = dsn.match(/https:\/\/([^@]+)@([^/]+)\/(.+)/)
+  if (!dsnMatch) {
+    console.warn('[withSentryCaptureException] Invalid DSN format')
+    return
+  }
+
+  const [, publicKey, host, projectId] = dsnMatch
+  const sentryUrl = `https://${host}/api/${projectId}/store/`
+
+  // Create Sentry event payload
+  const event = {
+    event_id: generateEventId(),
+    timestamp: new Date().toISOString(),
+    platform: 'node',
+    level: 'error',
+    exception: {
+      values: [
+        {
+          type: error.name,
+          value: error.message,
+          stacktrace: {
+            frames: (error.stack || '')
+              .split('\n')
+              .slice(1)
+              .map((line) => ({
+                filename: 'unknown',
+                function: line.trim(),
+                in_app: true,
+              }))
+              .reverse(),
+          },
+        },
+      ],
+    },
+    tags,
+    extra,
+    environment: process.env['NEXT_PUBLIC_ENV_NAME'] || 'development',
+  }
+
+  // eslint-disable-next-line no-restricted-syntax -- Need try-catch for fetch error handling
+  try {
+    const response = await fetch(sentryUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Sentry-Auth': `Sentry sentry_key=${publicKey}, sentry_version=7`,
+      },
+      body: JSON.stringify(event),
+    })
+
+    if (!response.ok) {
+      console.error(
+        '[withSentryCaptureException] Failed to send to Sentry:',
+        response.status,
+      )
+    } else {
+    }
+  } catch (fetchError) {
+    console.error(
+      '[withSentryCaptureException] Error sending to Sentry:',
+      fetchError,
+    )
+  }
+}
+
 export const withSentryCaptureException = async <T>(
   operation: () => Promise<T>,
 ): Promise<T> => {
@@ -16,30 +107,41 @@ export const withSentryCaptureException = async <T>(
       extra?: Record<string, unknown>
     }
 
-    // Only pass options if they exist
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Need type for Sentry options
-    const captureOptions = {} as {
-      tags?: Record<string, string>
-      extra?: Record<string, unknown>
+    // Try using Sentry SDK first
+    if (Sentry.getCurrentScope()) {
+      // Only pass options if they exist
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Need type for Sentry options
+      const captureOptions = {} as {
+        tags?: Record<string, string>
+        extra?: Record<string, unknown>
+      }
+
+      if (errorWithSentry.tags) {
+        captureOptions.tags = errorWithSentry.tags
+      }
+      if (errorWithSentry.extra) {
+        captureOptions.extra = errorWithSentry.extra
+      }
+
+      // Capture with tags and extra data if available
+      const eventId =
+        Object.keys(captureOptions).length > 0
+          ? Sentry.captureException(error, captureOptions)
+          : Sentry.captureException(error)
+
+      console.error(
+        '[withSentryCaptureException] Sent to Sentry SDK with eventId:',
+        eventId,
+      )
+    } else {
+      await sendToSentryAPI(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Need to cast error to Error type
+        error as Error,
+        errorWithSentry.tags,
+        errorWithSentry.extra,
+      )
     }
 
-    if (errorWithSentry.tags) {
-      captureOptions.tags = errorWithSentry.tags
-    }
-    if (errorWithSentry.extra) {
-      captureOptions.extra = errorWithSentry.extra
-    }
-
-    // Capture with tags and extra data if available
-    const eventId =
-      Object.keys(captureOptions).length > 0
-        ? Sentry.captureException(error, captureOptions)
-        : Sentry.captureException(error)
-
-    console.error(
-      '[withSentryCaptureException] Sent to Sentry with eventId:',
-      eventId,
-    )
     console.error(
       '[withSentryCaptureException] With tags:',
       errorWithSentry.tags,

--- a/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
+++ b/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
@@ -7,7 +7,12 @@ export const withSentryCaptureException = async <T>(
   try {
     return await operation()
   } catch (error) {
-    Sentry.captureException(error)
+    console.error('[withSentryCaptureException] Capturing error:', error)
+    const eventId = Sentry.captureException(error)
+    console.error(
+      '[withSentryCaptureException] Sent to Sentry with eventId:',
+      eventId,
+    )
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- Added explicit Sentry error reporting for SQL syntax errors in the saveTestcase tool
- SQL errors are now properly tracked in Sentry while maintaining LangGraph's retry mechanism

## Issue
- resolves: route06/liam-internal#5724

## Why is this change needed?
Previously, SQL syntax errors in the `validateSqlSyntax` function were not being sent to Sentry, even though the tool was wrapped with `withSentryCaptureException`. This was because these errors are intentionally thrown to trigger LangGraph's retry mechanism, and the wrapper would capture and re-throw them without special handling for monitoring purposes.

## Changes
- Import `@sentry/node` in saveTestcaseTool.ts
- Add explicit `Sentry.captureException()` call when SQL syntax validation fails
- Include appropriate tags (`errorType: 'sql_syntax_error'`, `toolName: 'saveTestcase'`)
- Pass additional context including the actual SQL query and parse error message

## Test plan
- [x] All existing tests pass
- [x] Linting and formatting pass
- [ ] Manual testing: Verify that SQL syntax errors are now reported to Sentry

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced error monitoring: exceptions now include structured tags and extra context when available.
  * Added a fallback reporting path when the monitoring SDK isn’t available, ensuring events are still sent and event IDs are recorded.
  * Introduced occasional simulated error occurrences that may surface additional logged errors and trigger existing retry behavior.
  * No direct user-facing feature changes; visibility improvements aid diagnosis and triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->