### PR TITLE
✨ feat(command palette): support "table" SearchInput mode

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.test.tsx
@@ -157,6 +157,23 @@ describe('input mode and filters', () => {
       expect(screen.queryByRole('option')).not.toBeInTheDocument()
       expect(screen.getByText('No results found.')).toBeInTheDocument()
     })
+
+    // TODO: implement table input mode and remove this test
+    it('does not switch to "table" mode when pressing Tab key', async () => {
+      const user = userEvent.setup()
+      render(<CommandPaletteContent />, { wrapper })
+
+      // switch to "command" input mode
+      await user.keyboard('{Tab}')
+
+      // command options still be displayed because table mode is not activated
+      expect(
+        screen.getByRole('option', { name: 'Copy Link ⌘ C' }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('option', { name: 'Zoom to Fit ⇧ 1' }),
+      ).toBeInTheDocument()
+    })
   })
 })
 

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteContent/CommandPaletteContent.tsx
@@ -42,6 +42,7 @@ export const CommandPaletteContent: FC = () => {
       <div className={styles.searchContainer}>
         <CommandPaletteSearchInput
           mode={inputMode}
+          suggestion={suggestion}
           setMode={setInputMode}
           onBlur={(event) => event.target.focus()}
         />

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -60,43 +60,36 @@ describe('in case input mode is "default"', () => {
   })
 
   describe('when the user pressed Tab key', () => {
-    it('should switch to "table" mode and make the input empty when a table is suggested', async () => {
-      const user = userEvent.setup()
-      render(
-        <CommandPaletteSearchInput
-          mode={{ type: 'default' }}
-          suggestion={{ type: 'table', name: 'users' }}
-          setMode={mockSetMode}
-        />,
-        { wrapper },
-      )
-      const input = screen.getByRole('combobox')
-      input.focus()
-
-      // make the input not empty
-      await user.keyboard('user')
-
-      await user.keyboard('{Tab}')
-
-      expect(mockSetMode).toHaveBeenCalledWith({
-        type: 'table',
-        tableName: 'users',
-      })
-      expect(input).toHaveValue('')
-    })
-
-    it.each<CommandPaletteSuggestion | null>([
-      { type: 'command', name: 'Copy Link' },
-      null,
-    ])(
-      'should not switch input mode and do not modify input value when suggestion is %o',
-      async (suggestion) => {
+    // TODO: remove this describe block and always activate table mode when releasing the feature
+    describe('when table mode is not activatable (default)', () => {
+      it('should not switch to "table" mode when a table is suggested', async () => {
         const user = userEvent.setup()
         render(
           <CommandPaletteSearchInput
             mode={{ type: 'default' }}
-            suggestion={suggestion}
+            suggestion={{ type: 'table', name: 'users' }}
             setMode={mockSetMode}
+          />,
+          { wrapper },
+        )
+        const input = screen.getByRole('combobox')
+        input.focus()
+
+        await user.keyboard('{Tab}')
+
+        expect(mockSetMode).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when table mode is activatable', () => {
+      it('should switch to "table" mode and make the input empty when a table is suggested', async () => {
+        const user = userEvent.setup()
+        render(
+          <CommandPaletteSearchInput
+            mode={{ type: 'default' }}
+            suggestion={{ type: 'table', name: 'users' }}
+            setMode={mockSetMode}
+            isTableModeActivatable
           />,
           { wrapper },
         )
@@ -108,10 +101,41 @@ describe('in case input mode is "default"', () => {
 
         await user.keyboard('{Tab}')
 
-        expect(mockSetMode).not.toHaveBeenCalled()
-        expect(input).toHaveValue('user')
-      },
-    )
+        expect(mockSetMode).toHaveBeenCalledWith({
+          type: 'table',
+          tableName: 'users',
+        })
+        expect(input).toHaveValue('')
+      })
+
+      it.each<CommandPaletteSuggestion | null>([
+        { type: 'command', name: 'Copy Link' },
+        null,
+      ])(
+        'should not switch input mode and do not modify input value when suggestion is %o',
+        async (suggestion) => {
+          const user = userEvent.setup()
+          render(
+            <CommandPaletteSearchInput
+              mode={{ type: 'default' }}
+              suggestion={suggestion}
+              setMode={mockSetMode}
+            />,
+            { wrapper },
+          )
+          const input = screen.getByRole('combobox')
+          input.focus()
+
+          // make the input not empty
+          await user.keyboard('user')
+
+          await user.keyboard('{Tab}')
+
+          expect(mockSetMode).not.toHaveBeenCalled()
+          expect(input).toHaveValue('user')
+        },
+      )
+    })
   })
 })
 

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -22,6 +22,7 @@ describe('in case input mode is "default"', () => {
       render(
         <CommandPaletteSearchInput
           mode={{ type: 'default' }}
+          suggestion={null}
           setMode={mockSetMode}
         />,
         { wrapper },
@@ -39,6 +40,7 @@ describe('in case input mode is "default"', () => {
     render(
       <CommandPaletteSearchInput
         mode={{ type: 'default' }}
+        suggestion={null}
         setMode={mockSetMode}
       />,
       { wrapper },
@@ -61,6 +63,7 @@ describe('in case input mode is "command"', () => {
       render(
         <CommandPaletteSearchInput
           mode={{ type: 'command' }}
+          suggestion={null}
           setMode={mockSetMode}
         />,
         { wrapper },
@@ -78,6 +81,7 @@ describe('in case input mode is "command"', () => {
     render(
       <CommandPaletteSearchInput
         mode={{ type: 'command' }}
+        suggestion={null}
         setMode={mockSetMode}
       />,
       { wrapper },

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -31,7 +31,6 @@ describe('in case input mode is "default"', () => {
         />,
         { wrapper },
       )
-      screen.getByRole('combobox').focus()
 
       await user.keyboard('>')
 
@@ -48,7 +47,6 @@ describe('in case input mode is "default"', () => {
         />,
         { wrapper },
       )
-      screen.getByRole('combobox').focus()
 
       // make the input not empty
       await user.keyboard('hello')
@@ -72,8 +70,6 @@ describe('in case input mode is "default"', () => {
           />,
           { wrapper },
         )
-        const input = screen.getByRole('combobox')
-        input.focus()
 
         await user.keyboard('{Tab}')
 
@@ -94,7 +90,6 @@ describe('in case input mode is "default"', () => {
           { wrapper },
         )
         const input = screen.getByRole('combobox')
-        input.focus()
 
         // make the input not empty
         await user.keyboard('user')
@@ -124,7 +119,6 @@ describe('in case input mode is "default"', () => {
             { wrapper },
           )
           const input = screen.getByRole('combobox')
-          input.focus()
 
           // make the input not empty
           await user.keyboard('user')
@@ -154,7 +148,6 @@ describe.each<CommandPaletteInputMode>([
         />,
         { wrapper },
       )
-      screen.getByRole('combobox').focus()
 
       await user.keyboard('{backspace}')
 
@@ -172,7 +165,6 @@ describe.each<CommandPaletteInputMode>([
       />,
       { wrapper },
     )
-    screen.getByRole('combobox').focus()
 
     // make the input not empty
     await user.keyboard('hello')

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -60,7 +60,7 @@ describe('in case input mode is "default"', () => {
   })
 
   describe('when the user pressed Tab key', () => {
-    it('should switch to "column" mode and make the input empty when a table is suggested', async () => {
+    it('should switch to "table" mode and make the input empty when a table is suggested', async () => {
       const user = userEvent.setup()
       render(
         <CommandPaletteSearchInput
@@ -79,7 +79,7 @@ describe('in case input mode is "default"', () => {
       await user.keyboard('{Tab}')
 
       expect(mockSetMode).toHaveBeenCalledWith({
-        type: 'column',
+        type: 'table',
         tableName: 'users',
       })
       expect(input).toHaveValue('')
@@ -117,7 +117,7 @@ describe('in case input mode is "default"', () => {
 
 describe.each<CommandPaletteInputMode>([
   { type: 'command' },
-  { type: 'column', tableName: 'users' },
+  { type: 'table', tableName: 'users' },
 ])('in case input mode is $type', (inputMode) => {
   describe('when the user pressed Backspace key', () => {
     it('should switch to "default" mode when value is empty', async () => {

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -3,7 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { Command } from 'cmdk'
 import type { PropsWithChildren } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { CommandPaletteSuggestion } from '../types'
+import type {
+  CommandPaletteInputMode,
+  CommandPaletteSuggestion,
+} from '../types'
 import { CommandPaletteSearchInput } from './CommandPaletteSearchInput'
 
 const mockSetMode = vi.fn()
@@ -86,7 +89,7 @@ describe('in case input mode is "default"', () => {
       { type: 'command', name: 'Copy Link' },
       null,
     ])(
-      'should not switch input mode and do not modify input value whe suggestion is %o',
+      'should not switch input mode and do not modify input value when suggestion is %o',
       async (suggestion) => {
         const user = userEvent.setup()
         render(
@@ -112,13 +115,16 @@ describe('in case input mode is "default"', () => {
   })
 })
 
-describe('in case input mode is "command"', () => {
+describe.each<CommandPaletteInputMode>([
+  { type: 'command' },
+  { type: 'column', tableName: 'users' },
+])('in case input mode is $type', (inputMode) => {
   describe('when the user pressed Backspace key', () => {
     it('should switch to "default" mode when value is empty', async () => {
       const user = userEvent.setup()
       render(
         <CommandPaletteSearchInput
-          mode={{ type: 'command' }}
+          mode={inputMode}
           suggestion={null}
           setMode={mockSetMode}
         />,
@@ -136,7 +142,7 @@ describe('in case input mode is "command"', () => {
     const user = userEvent.setup()
     render(
       <CommandPaletteSearchInput
-        mode={{ type: 'command' }}
+        mode={inputMode}
         suggestion={null}
         setMode={mockSetMode}
       />,

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.test.tsx
@@ -33,26 +33,26 @@ describe('in case input mode is "default"', () => {
 
       expect(mockSetMode).toHaveBeenCalledWith({ type: 'command' })
     })
-  })
 
-  it('should not switch input mode when value is not empty', async () => {
-    const user = userEvent.setup()
-    render(
-      <CommandPaletteSearchInput
-        mode={{ type: 'default' }}
-        suggestion={null}
-        setMode={mockSetMode}
-      />,
-      { wrapper },
-    )
-    screen.getByRole('combobox').focus()
+    it('should not switch input mode when value is not empty', async () => {
+      const user = userEvent.setup()
+      render(
+        <CommandPaletteSearchInput
+          mode={{ type: 'default' }}
+          suggestion={null}
+          setMode={mockSetMode}
+        />,
+        { wrapper },
+      )
+      screen.getByRole('combobox').focus()
 
-    // make the input not empty
-    await user.keyboard('hello')
+      // make the input not empty
+      await user.keyboard('hello')
 
-    await user.keyboard('>')
+      await user.keyboard('>')
 
-    expect(mockSetMode).not.toHaveBeenCalled()
+      expect(mockSetMode).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -18,12 +18,16 @@ type Props = ComponentProps<typeof Command.Input> & {
   mode: CommandPaletteInputMode
   suggestion: CommandPaletteSuggestion | null
   setMode: (mode: CommandPaletteInputMode) => void
+
+  // TODO: remove this prop and always activate table mode when releasing the feature
+  isTableModeActivatable?: boolean
 }
 
 export const CommandPaletteSearchInput: FC<Props> = ({
   mode,
   suggestion,
   setMode,
+  isTableModeActivatable = false,
   ...inputProps
 }) => {
   const [value, setValue] = useState('')
@@ -40,6 +44,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
   }, [mode])
 
   const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO: refactor this function to reduce cognitive complexity
     (event) => {
       switch (mode.type) {
         case 'default': {
@@ -50,12 +55,15 @@ export const CommandPaletteSearchInput: FC<Props> = ({
             return
           }
 
-          // switch to "table" mode if a table is suggested and Tab key is pressed
-          if (event.key === 'Tab' && suggestion?.type === 'table') {
-            event.preventDefault()
-            setMode({ type: 'table', tableName: suggestion.name })
-            setValue('')
-            return
+          // TODO: remove this condition and always activate table mode when releasing the feature
+          if (isTableModeActivatable) {
+            if (event.key === 'Tab' && suggestion?.type === 'table') {
+              // switch to "table" mode if a table is suggested and Tab key is pressed
+              event.preventDefault()
+              setMode({ type: 'table', tableName: suggestion.name })
+              setValue('')
+              return
+            }
           }
 
           break
@@ -74,7 +82,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
         }
       }
     },
-    [mode.type, value, setMode, suggestion],
+    [mode.type, value, setMode, suggestion, isTableModeActivatable],
   )
 
   return (

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -96,6 +96,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
           onValueChange={setValue}
           className={styles.input}
           placeholder="Search"
+          autoFocus
           onKeyDown={handleKeydown}
         />
       </div>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -50,6 +50,14 @@ export const CommandPaletteSearchInput: FC<Props> = ({
             return
           }
 
+          // switch to "column" mode if a table is suggested and Tab key is pressed
+          if (event.key === 'Tab' && suggestion?.type === 'table') {
+            event.preventDefault()
+            setMode({ type: 'column', tableName: suggestion.name })
+            setValue('')
+            return
+          }
+
           break
         }
 
@@ -65,7 +73,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
         }
       }
     },
-    [mode.type, value, setMode],
+    [mode.type, value, setMode, suggestion],
   )
 
   return (

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -7,16 +7,21 @@ import {
   useMemo,
   useState,
 } from 'react'
-import type { CommandPaletteInputMode } from '../types'
+import type {
+  CommandPaletteInputMode,
+  CommandPaletteSuggestion,
+} from '../types'
 import styles from './CommandPaletteSearchInput.module.css'
 
 type Props = ComponentProps<typeof Command.Input> & {
   mode: CommandPaletteInputMode
+  suggestion: CommandPaletteSuggestion | null
   setMode: (mode: CommandPaletteInputMode) => void
 }
 
 export const CommandPaletteSearchInput: FC<Props> = ({
   mode,
+  suggestion,
   setMode,
   ...inputProps
 }) => {
@@ -28,6 +33,8 @@ export const CommandPaletteSearchInput: FC<Props> = ({
         return null
       case 'command':
         return '>'
+      case 'column':
+        return `${mode.tableName} /`
     }
   }, [mode])
 

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -3,7 +3,8 @@ import { Command } from 'cmdk'
 import {
   type ComponentProps,
   type FC,
-  useEffect,
+  type KeyboardEventHandler,
+  useCallback,
   useMemo,
   useState,
 } from 'react'
@@ -38,35 +39,34 @@ export const CommandPaletteSearchInput: FC<Props> = ({
     }
   }, [mode])
 
-  useEffect(() => {
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex logic for handling CommandPalette input mode with user keyboard interactions
-    const down = (event: KeyboardEvent) => {
-      if (mode.type === 'default') {
-        // switch to "command" mode if value is empty and `>` is pressed
-        if (event.key === '>' && value === '') {
-          event.preventDefault()
-          setMode({ type: 'command' })
-          return
+  const handleKeydown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      switch (mode.type) {
+        case 'default': {
+          // switch to "command" mode if value is empty and `>` is pressed
+          if (event.key === '>' && value === '') {
+            event.preventDefault()
+            setMode({ type: 'command' })
+            return
+          }
+
+          break
         }
 
-        return
-      }
+        case 'command': {
+          // switch to "default" mode if value is empty and delete key is pressed
+          if (event.key === 'Backspace' && value === '') {
+            event.preventDefault()
+            setMode({ type: 'default' })
+            return
+          }
 
-      if (mode.type === 'command') {
-        // switch to "default" mode if value is empty and delete key is pressed
-        if (event.key === 'Backspace' && value === '') {
-          event.preventDefault()
-          setMode({ type: 'default' })
-          return
+          break
         }
-
-        return
       }
-    }
-
-    document.addEventListener('keydown', down)
-    return () => document.removeEventListener('keydown', down)
-  }, [value, mode, setMode])
+    },
+    [mode.type, value, setMode],
+  )
 
   return (
     <div className={styles.container}>
@@ -79,6 +79,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
           onValueChange={setValue}
           className={styles.input}
           placeholder="Search"
+          onKeyDown={handleKeydown}
         />
       </div>
     </div>

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -61,7 +61,8 @@ export const CommandPaletteSearchInput: FC<Props> = ({
           break
         }
 
-        case 'command': {
+        case 'command':
+        case 'column': {
           // switch to "default" mode if value is empty and delete key is pressed
           if (event.key === 'Backspace' && value === '') {
             event.preventDefault()

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteSearchInput/CommandPaletteSearchInput.tsx
@@ -34,7 +34,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
         return null
       case 'command':
         return '>'
-      case 'column':
+      case 'table':
         return `${mode.tableName} /`
     }
   }, [mode])
@@ -50,10 +50,10 @@ export const CommandPaletteSearchInput: FC<Props> = ({
             return
           }
 
-          // switch to "column" mode if a table is suggested and Tab key is pressed
+          // switch to "table" mode if a table is suggested and Tab key is pressed
           if (event.key === 'Tab' && suggestion?.type === 'table') {
             event.preventDefault()
-            setMode({ type: 'column', tableName: suggestion.name })
+            setMode({ type: 'table', tableName: suggestion.name })
             setValue('')
             return
           }
@@ -62,7 +62,7 @@ export const CommandPaletteSearchInput: FC<Props> = ({
         }
 
         case 'command':
-        case 'column': {
+        case 'table': {
           // switch to "default" mode if value is empty and delete key is pressed
           if (event.key === 'Backspace' && value === '') {
             event.preventDefault()

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
@@ -1,6 +1,7 @@
-export type CommandPaletteInputMode = { type: 'default' } | { type: 'command' }
-// upcoming input mode
-// | { type: 'column'; tableName: string }
+export type CommandPaletteInputMode =
+  | { type: 'default' }
+  | { type: 'command' }
+  | { type: 'column'; tableName: string }
 
 export type CommandPaletteSuggestion =
   | { type: 'table'; name: string }

--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/types.ts
@@ -1,7 +1,7 @@
 export type CommandPaletteInputMode =
   | { type: 'default' }
   | { type: 'command' }
-  | { type: 'column'; tableName: string }
+  | { type: 'table'; tableName: string }
 
 export type CommandPaletteSuggestion =
   | { type: 'table'; name: string }


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

To support column search in the CommandPalette, we would like to introduce a new input mode which filters options with specific tables.
This PR will introduce "table" input mode with a table name. It is not activatable by default, so that users will not see for a while.

### demo

I created a preview with table mode activatable -> https://liam-erd-sample-7mknrlgc9-liambx.vercel.app
You can press "Tab" key when selecting a table option to go into the table mode with it. We haven't implemented the table mode behaviours, so it will be empty, but you can see the input element changing.

https://github.com/user-attachments/assets/ca89d009-6d23-48fa-b32d-035f1d8eaf12



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette shows contextual suggestions (table or command) and can enter a table/column mode that displays "tableName /" when accepted.
  * Tab (when enabled) can accept a table suggestion and switch to table mode, clearing the input; '>' still triggers command mode.

* **Tests**
  * Added tests for suggestion-driven behavior, Tab acceptance, Backspace transitions, and related mode edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->