### PR TITLE
🔧 Reduce minimum release age for dependencies from 14 days to 2 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-minimum-release-age=20160

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
   - "frontend/packages/*"
   - "frontend/packages/__mocks__/*"
   - "frontend/internal-packages/*"
-minimumReleaseAge: 20160 # 14 days
+minimumReleaseAge: 2880 # 2 days


### PR DESCRIPTION
## Issue

- ref. https://github.com/route06/liam-internal/issues/5743#issuecomment-3344757102

## Why is this change needed?

This change reduces the minimum release age requirement for npm dependencies from 14 days to 2 days. This allows us to adopt new package releases more quickly while still maintaining a short buffer period for stability.

The changes affect:
- `.npmrc`: Removed the `minimum-release-age` setting (no longer needed at file level)
- `pnpm-workspace.yaml`: Updated `minimumReleaseAge` from 20160 minutes (14 days) to 2880 minutes (2 days)

This will help us stay more current with dependency updates while maintaining reasonable safety measures.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release configuration by lowering the minimum release age for certain packages, enabling quicker availability of updates.
  * Cleaned up package manager settings by removing an outdated release-age option to simplify configuration.
  * Build and installation behavior remains unchanged; this only affects internal release cadence.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->