### PR TITLE
fix: improve table comment text wrapping to break at word boundaries

### DIFF
--- a/.changeset/quick-ends-work.md
+++ b/.changeset/quick-ends-work.md
@@ -1,0 +1,5 @@
+---
+"@liam-hq/erd-core": patch
+---
+
+💄 Improve table comment text wrapping to break at word boundaries

--- a/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Comment/Comment.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDContent/components/TableNode/TableDetail/Comment/Comment.module.css
@@ -12,4 +12,6 @@
   font-style: normal;
   font-weight: 400;
   line-height: 150%;
+  word-break: normal;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5752

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
