### PR TITLE
🐛 Fix duplicate enum name display in ToolCall arguments

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ArgumentsDisplay/SyntaxHighlightedLine.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ArgumentsDisplay/SyntaxHighlightedLine.tsx
@@ -55,10 +55,10 @@ export const SyntaxHighlightedLine: FC<Props> = ({
 
   const renderRestOfLine = (text: string) => {
     // Handle quoted strings
-    const parts = text.split(/('([^']+)')/g)
+    const parts = text.split(/('[^']+')/g)
 
     return parts.map((part, i) => {
-      if (i % 3 === 1) {
+      if (i % 2 === 1) {
         // This is a quoted string
         return (
           <span key={`quote-${i}-${part}`} className={styles.syntaxIdentifier}>


### PR DESCRIPTION
## Issue
- fix: https://github.com/route06/liam-internal/issues/5754

Enum names were appearing twice in the ToolCall arguments display, for example:
```
Creating enum 'visibility_enum'visibility_enum
```

<img width="360" height="459" alt="ss 3922" src="https://github.com/user-attachments/assets/336e614b-abdd-45a7-8f80-970d3a1c5321" />


## Why is this change needed?

The `SyntaxHighlightedLine` component's `renderRestOfLine` function was using a regex pattern with nested capture groups `/('([^']+)')/g`. When JavaScript's `split()` method encounters capture groups, it includes them in the resulting array. With two nested groups, this caused the array to contain both the quoted string AND the unquoted content, leading to duplicate display.

## Changes

- Changed regex from `/('([^']+)')/g` to `/('[^']+')/g` (single capture group)
- Updated the modulo check from `i % 3 === 1` to `i % 2 === 1` to match the new array structure

## Technical Details

**Before (with nested capture groups):**
```javascript
" 'animal_status_enum'".split(/('([^']+)')/g)
// Result: [" ", "'animal_status_enum'", "animal_status_enum", ""]
//          [0]   [1] highlighted       [2] duplicate!        [3]
```

**After (single capture group):**
```javascript
" 'animal_status_enum'".split(/('[^']+')/g)
// Result: [" ", "'animal_status_enum'", ""]
//          [0]   [1] highlighted       [2]
```

## Testing

https://liam-app-git-fix-syntax-highlighter-quoted-string-ef9a71-liambx.vercel.app/design_sessions/ede1e64e-0046-4440-a6d6-c3ecbcd1e831?deepModeling=true

<img width="345" height="220" alt="ss 3934" src="https://github.com/user-attachments/assets/0d40168f-9dbb-4780-97be-a1a3f4d93843" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected detection and rendering of quoted strings in the Arguments display of Tool Call cards within AI Messages. This improves syntax highlighting accuracy, preventing miscolored or merged segments and making complex argument values easier to read on the Session Detail page. Visual clarity and consistency are improved without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->