### PR TITLE
📝 Add multiple schema files documentation for Drizzle

### DIFF
--- a/frontend/apps/docs/content/docs/parser/supported-formats/drizzle.mdx
+++ b/frontend/apps/docs/content/docs/parser/supported-formats/drizzle.mdx
@@ -18,6 +18,18 @@ npx @liam-hq/cli erd build --format drizzle --input src/db/schema.ts
 
 If the above command runs without issue, you should see an ER diagram generated.
 
+### Handling Multiple Drizzle Schema Files
+
+If your Drizzle schema is split across multiple TypeScript files, you can generate the ER diagram by specifying a glob pattern to include all schema files in the directory.
+
+For example, if you have multiple schema files in the `src/db/schema/` directory, use the following command:
+
+```npm
+npx @liam-hq/cli erd build --format drizzle --input "src/db/schema/*.ts"
+```
+
+This allows you to generate the ER diagram from all schema files in the specified directory.
+
 ## Database Type Support
 
 Drizzle support in Liam ERD automatically detects whether you're using PostgreSQL or MySQL based on your imports:


### PR DESCRIPTION
## Issue

- resolve: N/A (Documentation improvement)

## Why is this change needed?

Added documentation for handling multiple Drizzle schema files using glob patterns, following the same structure as the existing Prisma documentation.

## Summary

- Added "Handling Multiple Drizzle Schema Files" section to [drizzle.mdx](frontend/apps/docs/content/docs/parser/supported-formats/drizzle.mdx)
- Explains how to use glob patterns (`src/db/schema/*.ts`) to include multiple schema files
- Maintains consistency with Prisma documentation structure

## Test


https://liam-docs-git-docs-drizzle-multiple-files-liambx.vercel.app/docs/parser/supported-formats/drizzle

<img width="907" height="410" alt="ss 3944" src="https://github.com/user-attachments/assets/8ef4ee71-3d53-4b06-ba32-b1657f099ea8" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section, “Handling Multiple Drizzle Schema Files,” explaining how to generate ER diagrams from multiple schema files using glob patterns (e.g., src/db/schema/*.ts).
  * Clarifies steps for multi-file setups, improving discoverability and reducing confusion when organizing schemas across folders.
  * No changes to product behavior or features; this is guidance-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->