### PR TITLE
🔧 Remove LangChain packages from Renovate automerge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,9 +35,7 @@
       "description": "Automerge dependencies only used by internal packages",
       "matchPackageNames": [
         "@modelcontextprotocol/sdk",
-        "style-dictionary",
-        "/^@langchain/",
-        "langsmith"
+        "style-dictionary"
       ],
       "matchFileNames": ["frontend/internal-packages/**"],
       "automerge": true


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This change removes `@langchain/*` and `langsmith` packages from Renovate's automerge configuration following a recent compatibility issue that required downgrading these packages (commit 142787935). By excluding them from automerge, future updates to these packages will require manual review, preventing automatic updates that may introduce breaking changes or compatibility issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted dependency update automation to auto-merge a narrower set of internal packages, improving control over updates.
  - Excluded certain libraries from automatic merges to reduce risk and increase stability.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->