### PR TITLE
🔧(agent): Ensure Sentry is initialized before capturing exceptions

### DIFF
--- a/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
+++ b/frontend/internal-packages/agent/src/utils/withSentryCaptureException.ts
@@ -1,5 +1,17 @@
 import * as Sentry from '@sentry/node'
 
+const ensureSentryInitialized = () => {
+  const client = Sentry.getClient()
+  if (!client || !client.getDsn()) {
+    Sentry.init({
+      dsn: process.env['SENTRY_DSN'] || '',
+      tracesSampleRate: 1.0,
+      environment: process.env['NEXT_PUBLIC_ENV_NAME'] || '',
+      debug: false,
+    })
+  }
+}
+
 export const withSentryCaptureException = async <T>(
   operation: () => Promise<T>,
 ): Promise<T> => {
@@ -7,6 +19,7 @@ export const withSentryCaptureException = async <T>(
   try {
     return await operation()
   } catch (error) {
+    ensureSentryInitialized()
     Sentry.captureException(error)
     throw error
   }


### PR DESCRIPTION
## Issue

- Errors occurring within the Agent package were not being sent to Sentry.

## Problem

- The Agent package (@liam-hq/agent) uses @sentry/node.
- However, the Sentry client was never initialized.
- In API Routes, @sentry/nextjs is initialized, but since it is a separate instance, it is not shared.

## Solution

- Add automatic Sentry initialization within the Agent package.
- In local environment, error event was successfully sent to Sentry

## Notes

- When going through API Routes, traces will be separated (different trace IDs).
- However, errors are now reliably sent to Sentry.

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improved reliability of error reporting by ensuring the monitoring service initializes before capturing exceptions, reducing missed error logs.
- Chores
  - Hardened internal monitoring behavior with no changes to public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->