### PR TITLE
✨(agent): Implement atomic checkpoint insertion with Supabase RPC

### DIFF
--- a/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.test.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.test.ts
@@ -87,23 +87,29 @@ describe('SupabaseCheckpointSaver', () => {
       return HttpResponse.json(data)
     })
 
-  const mockSaveCheckpointResponse = () =>
-    http.post(`${SUPABASE_URL}/rest/v1/checkpoints`, () => {
-      return HttpResponse.json({ success: true })
-    })
-
-  const mockSaveBlobsResponse = () =>
-    http.post(`${SUPABASE_URL}/rest/v1/checkpoint_blobs`, () => {
-      return HttpResponse.json({ success: true })
-    })
-
   const mockSaveWritesResponse = () =>
     http.post(`${SUPABASE_URL}/rest/v1/checkpoint_writes`, () => {
       return HttpResponse.json({ success: true })
     })
 
+  const mockPutCheckpointRpc = () =>
+    http.post(`${SUPABASE_URL}/rest/v1/rpc/put_checkpoint`, () => {
+      return new HttpResponse(null, { status: 204 })
+    })
+
+  const mockPutCheckpointRpcError = (errorMessage: string) =>
+    http.post(`${SUPABASE_URL}/rest/v1/rpc/put_checkpoint`, () => {
+      return HttpResponse.json(
+        {
+          error: errorMessage,
+          message: errorMessage,
+        },
+        { status: 500 },
+      )
+    })
+
   describe('Checkpoint persistence', () => {
-    it('should save and retrieve a checkpoint with state', async () => {
+    it('should save and retrieve a checkpoint with state using RPC transaction', async () => {
       // Arrange
       const checkpoint = createMinimalCheckpoint()
       const metadata: CheckpointMetadata = {
@@ -113,8 +119,8 @@ describe('SupabaseCheckpointSaver', () => {
       }
       const config = createMinimalConfig()
 
-      // Mock save operations
-      server.use(mockSaveCheckpointResponse(), mockSaveBlobsResponse())
+      // Mock RPC save operation
+      server.use(mockPutCheckpointRpc())
 
       // Mock retrieval
       const savedCheckpointData = {
@@ -608,13 +614,12 @@ describe('SupabaseCheckpointSaver', () => {
 
       server.use(
         http.post(
-          `${SUPABASE_URL}/rest/v1/checkpoints`,
+          `${SUPABASE_URL}/rest/v1/rpc/put_checkpoint`,
           async ({ request }) => {
             capturedSaveData = await request.json()
-            return HttpResponse.json({ success: true })
+            return new HttpResponse(null, { status: 204 })
           },
         ),
-        mockSaveBlobsResponse(),
         http.get(`${SUPABASE_URL}/rest/v1/checkpoints`, ({ request }) => {
           const url = new URL(request.url)
           capturedQueryParams = url.searchParams
@@ -636,12 +641,12 @@ describe('SupabaseCheckpointSaver', () => {
       await saver.put(config, checkpoint, metadata, checkpoint.channel_versions)
 
       // Assert
-      if (
-        capturedSaveData &&
-        typeof capturedSaveData === 'object' &&
-        'organization_id' in capturedSaveData
-      ) {
-        expect(capturedSaveData.organization_id).toBe(TEST_ORG_ID)
+      if (capturedSaveData && typeof capturedSaveData === 'object') {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const data = capturedSaveData as {
+          p_checkpoint: { organization_id: string }
+        }
+        expect(data.p_checkpoint.organization_id).toBe(TEST_ORG_ID)
       }
 
       // Act
@@ -651,6 +656,108 @@ describe('SupabaseCheckpointSaver', () => {
       // Assert
       expect(result).toBeUndefined() // No checkpoint found
       expect(capturedQueryParams).toBeDefined()
+    })
+  })
+
+  describe('Transactional behavior', () => {
+    it('should save checkpoint and blobs atomically using RPC', async () => {
+      // Arrange
+      const checkpoint = createMinimalCheckpoint()
+      const metadata: CheckpointMetadata = {
+        source: 'input' as const,
+        step: -1,
+        parents: {},
+      }
+      const config = createMinimalConfig()
+
+      let capturedRpcData: unknown = null
+
+      server.use(
+        http.post(
+          `${SUPABASE_URL}/rest/v1/rpc/put_checkpoint`,
+          async ({ request }) => {
+            capturedRpcData = await request.json()
+            return new HttpResponse(null, { status: 204 })
+          },
+        ),
+      )
+
+      const saver = createTestSaver()
+
+      // Act
+      const result = await saver.put(
+        config,
+        checkpoint,
+        metadata,
+        checkpoint.channel_versions,
+      )
+
+      // Assert
+      expect(result).toEqual({
+        configurable: {
+          thread_id: TEST_THREAD_ID,
+          checkpoint_ns: TEST_CHECKPOINT_NS,
+          checkpoint_id: TEST_CHECKPOINT_ID,
+        },
+      })
+
+      // Verify RPC was called with correct parameters
+      expect(capturedRpcData).toBeDefined()
+      if (capturedRpcData && typeof capturedRpcData === 'object') {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const data = capturedRpcData as {
+          p_checkpoint: {
+            thread_id: string
+            checkpoint_id: string
+            organization_id: string
+          }
+          p_blobs: unknown
+        }
+        expect(data.p_checkpoint.thread_id).toBe(TEST_THREAD_ID)
+        expect(data.p_checkpoint.checkpoint_id).toBe(TEST_CHECKPOINT_ID)
+        expect(data.p_checkpoint.organization_id).toBe(TEST_ORG_ID)
+        expect(data.p_blobs).toBeDefined()
+      }
+    })
+
+    it('should throw error when RPC returns error', async () => {
+      // Arrange
+      const checkpoint = createMinimalCheckpoint()
+      const metadata: CheckpointMetadata = {
+        source: 'input' as const,
+        step: -1,
+        parents: {},
+      }
+      const config = createMinimalConfig()
+
+      server.use(mockPutCheckpointRpcError('Database transaction failed'))
+
+      const saver = createTestSaver()
+
+      // Act & Assert
+      await expect(
+        saver.put(config, checkpoint, metadata, checkpoint.channel_versions),
+      ).rejects.toThrow('Failed to save checkpoint')
+    })
+
+    it('should handle database errors gracefully', async () => {
+      // Arrange
+      const checkpoint = createMinimalCheckpoint()
+      const metadata: CheckpointMetadata = {
+        source: 'input' as const,
+        step: -1,
+        parents: {},
+      }
+      const config = createMinimalConfig()
+
+      server.use(mockPutCheckpointRpcError('Connection timeout'))
+
+      const saver = createTestSaver()
+
+      // Act & Assert
+      await expect(
+        saver.put(config, checkpoint, metadata, checkpoint.channel_versions),
+      ).rejects.toThrow('Failed to save checkpoint')
     })
   })
 })

--- a/frontend/internal-packages/db/schema/schema.sql
+++ b/frontend/internal-packages/db/schema/schema.sql
@@ -512,6 +512,74 @@ $$;
 ALTER FUNCTION "public"."prevent_delete_last_organization_member"() OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."put_checkpoint"("p_checkpoint" "jsonb", "p_blobs" "jsonb") RETURNS "void"
+    LANGUAGE "plpgsql"
+    AS $$
+begin
+  -- Insert checkpoint
+  insert into checkpoints (
+    thread_id,
+    checkpoint_ns,
+    checkpoint_id,
+    parent_checkpoint_id,
+    checkpoint,
+    metadata,
+    organization_id,
+    created_at,
+    updated_at
+  ) values (
+    (p_checkpoint->>'thread_id')::text,
+    (p_checkpoint->>'checkpoint_ns')::text,
+    (p_checkpoint->>'checkpoint_id')::text,
+    (p_checkpoint->>'parent_checkpoint_id')::text,
+    p_checkpoint->'checkpoint',
+    p_checkpoint->'metadata',
+    (p_checkpoint->>'organization_id')::uuid,
+    (p_checkpoint->>'created_at')::timestamptz,
+    (p_checkpoint->>'updated_at')::timestamptz
+  )
+  on conflict (thread_id, checkpoint_ns, checkpoint_id, organization_id)
+  do update set
+    parent_checkpoint_id = excluded.parent_checkpoint_id,
+    checkpoint = excluded.checkpoint,
+    metadata = excluded.metadata,
+    updated_at = excluded.updated_at;
+
+  -- Insert blobs if provided
+  if p_blobs is not null and jsonb_array_length(p_blobs) > 0 then
+    insert into checkpoint_blobs (
+      thread_id,
+      checkpoint_ns,
+      channel,
+      version,
+      type,
+      blob,
+      organization_id
+    )
+    select
+      (blob->>'thread_id')::text,
+      (blob->>'checkpoint_ns')::text,
+      (blob->>'channel')::text,
+      (blob->>'version')::text,
+      (blob->>'type')::text,
+      case
+        when blob->>'blob' is null then null
+        else decode(blob->>'blob', 'base64')
+      end,
+      (blob->>'organization_id')::uuid
+    from jsonb_array_elements(p_blobs) as blob
+    on conflict (thread_id, checkpoint_ns, channel, version, organization_id)
+    do update set
+      type = excluded.type,
+      blob = excluded.blob;
+  end if;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."put_checkpoint"("p_checkpoint" "jsonb", "p_blobs" "jsonb") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "public"."set_artifacts_organization_id"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
     AS $$
@@ -4102,6 +4170,11 @@ GRANT ALL ON FUNCTION "public"."l2_normalize"("public"."vector") TO "service_rol
 
 GRANT ALL ON FUNCTION "public"."prevent_delete_last_organization_member"() TO "authenticated";
 GRANT ALL ON FUNCTION "public"."prevent_delete_last_organization_member"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."put_checkpoint"("p_checkpoint" "jsonb", "p_blobs" "jsonb") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."put_checkpoint"("p_checkpoint" "jsonb", "p_blobs" "jsonb") TO "service_role";
 
 
 

--- a/frontend/internal-packages/db/supabase/database.types.ts
+++ b/frontend/internal-packages/db/supabase/database.types.ts
@@ -1429,7 +1429,11 @@ export type Database = {
       }
       l2_normalize: {
         Args: { '': string } | { '': unknown } | { '': unknown }
-        Returns: string
+        Returns: unknown
+      }
+      put_checkpoint: {
+        Args: { p_blobs: Json; p_checkpoint: Json }
+        Returns: undefined
       }
       sparsevec_out: {
         Args: { '': unknown }

--- a/frontend/internal-packages/db/supabase/migrations/20251001190247_put_checkpoint.sql
+++ b/frontend/internal-packages/db/supabase/migrations/20251001190247_put_checkpoint.sql
@@ -1,0 +1,67 @@
+-- Function to handle checkpoint and blobs insertion atomically
+create or replace function put_checkpoint(
+  p_checkpoint jsonb,
+  p_blobs jsonb
+) returns void as $$
+begin
+  -- Insert checkpoint
+  insert into checkpoints (
+    thread_id,
+    checkpoint_ns,
+    checkpoint_id,
+    parent_checkpoint_id,
+    checkpoint,
+    metadata,
+    organization_id,
+    created_at,
+    updated_at
+  ) values (
+    (p_checkpoint->>'thread_id')::text,
+    (p_checkpoint->>'checkpoint_ns')::text,
+    (p_checkpoint->>'checkpoint_id')::text,
+    (p_checkpoint->>'parent_checkpoint_id')::text,
+    p_checkpoint->'checkpoint',
+    p_checkpoint->'metadata',
+    (p_checkpoint->>'organization_id')::uuid,
+    (p_checkpoint->>'created_at')::timestamptz,
+    (p_checkpoint->>'updated_at')::timestamptz
+  )
+  on conflict (thread_id, checkpoint_ns, checkpoint_id, organization_id)
+  do update set
+    parent_checkpoint_id = excluded.parent_checkpoint_id,
+    checkpoint = excluded.checkpoint,
+    metadata = excluded.metadata,
+    updated_at = excluded.updated_at;
+
+  -- Insert blobs if provided
+  if p_blobs is not null and jsonb_array_length(p_blobs) > 0 then
+    insert into checkpoint_blobs (
+      thread_id,
+      checkpoint_ns,
+      channel,
+      version,
+      type,
+      blob,
+      organization_id
+    )
+    select
+      (blob->>'thread_id')::text,
+      (blob->>'checkpoint_ns')::text,
+      (blob->>'channel')::text,
+      (blob->>'version')::text,
+      (blob->>'type')::text,
+      case
+        when blob->>'blob' is null then null
+        else decode(blob->>'blob', 'base64')
+      end,
+      (blob->>'organization_id')::uuid
+    from jsonb_array_elements(p_blobs) as blob
+    on conflict (thread_id, checkpoint_ns, channel, version, organization_id)
+    do update set
+      type = excluded.type,
+      blob = excluded.blob;
+  end if;
+end;
+$$ language plpgsql;
+
+revoke all on function put_checkpoint(jsonb, jsonb) from anon;


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?

This change improves the reliability of checkpoint persistence by ensuring atomic insertion of checkpoints and their associated blobs. Previously, checkpoint and blob insertions were separate operations, which could lead to inconsistent state if one succeeded while the other failed.

The implementation introduces a PostgreSQL RPC function `put_checkpoint` that handles both insertions within a single database transaction, guaranteeing consistency.

**Key changes:**
- Created `put_checkpoint` RPC function in PostgreSQL to handle atomic insertions
- Updated `SupabaseCheckpointSaver` to use the RPC instead of separate insert operations
- Added comprehensive tests for transactional behavior and error handling
- Simplified blob deserialization by removing unnecessary double-encoding