### PR TITLE
🐛(agent): Fix Supabase checkpoint task persistence and version handling

### DIFF
--- a/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.integration.test.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.integration.test.ts
@@ -1,7 +1,8 @@
+import type { StateSnapshot } from '@langchain/langgraph'
 import type { CheckpointSaverTestInitializer } from '@langchain/langgraph-checkpoint-validation'
 import { validate } from '@langchain/langgraph-checkpoint-validation'
 import { createClient } from '@liam-hq/db'
-import { describe } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { SupabaseCheckpointSaver } from './SupabaseCheckpointSaver'
 
 // Test database configuration - use local development environment variables
@@ -74,4 +75,128 @@ const supabaseCheckpointerInitializer: CheckpointSaverTestInitializer<SupabaseCh
 // LangGraph Official Validation Tests
 describe('LangGraph Official Validation', () => {
   validate(supabaseCheckpointerInitializer)
+})
+
+// Checkpoint next and tasks validation
+describe('Checkpoint next and tasks validation', () => {
+  it('should correctly save next nodes and pending tasks in checkpoints', async () => {
+    const { Annotation, END, START, StateGraph } = await import(
+      '@langchain/langgraph'
+    )
+
+    // Define state
+    const State = Annotation.Root({
+      foo: Annotation<string>,
+      bar: Annotation<string[]>({
+        reducer: (x, y) => x.concat(y),
+        default: () => [],
+      }),
+    })
+
+    // Build graph
+    const workflow = new StateGraph(State)
+      .addNode('nodeA', () => ({ foo: 'a', bar: ['a'] }))
+      .addNode('nodeB', () => ({ foo: 'b', bar: ['b'] }))
+      .addEdge(START, 'nodeA')
+      .addEdge('nodeA', 'nodeB')
+      .addEdge('nodeB', END)
+
+    // Create checkpointer
+    const organizationId = await getOrganizationId()
+    const client = createTestClient()
+    await clearOrganizationData(client, organizationId)
+    const checkpointer = new SupabaseCheckpointSaver({
+      client,
+      options: { organizationId },
+    })
+
+    const graph = workflow.compile({ checkpointer })
+
+    // Execute graph
+    const config = { configurable: { thread_id: 'test-next-tasks-thread' } }
+    await graph.invoke({ foo: '' }, config)
+
+    // Collect history
+    const history: StateSnapshot[] = []
+    for await (const snapshot of graph.getStateHistory(config)) {
+      history.push(snapshot)
+    }
+
+    const normalizeTasks = (tasks: StateSnapshot['tasks']) =>
+      tasks.map((task) => {
+        const { id: _id, ...rest } = task
+        return rest
+      })
+
+    const expectTasks = (
+      snapshot: StateSnapshot,
+      expected: Array<Record<string, unknown> | string>,
+    ) => {
+      expect(snapshot.tasks).toHaveLength(expected.length)
+      expect(normalizeTasks(snapshot.tasks)).toEqual(expected)
+    }
+
+    expect(history).toHaveLength(4)
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const [finalState, afterNodeAState, initialState, startState] = history as [
+      StateSnapshot,
+      StateSnapshot,
+      StateSnapshot,
+      StateSnapshot,
+    ]
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const finalValues = finalState.values as typeof State.State
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const afterNodeAValues = afterNodeAState.values as typeof State.State
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const initialValues = initialState.values as typeof State.State
+
+    // Step 2: Final state (nodeB completed)
+    expect(finalState.metadata?.step).toBe(2)
+    expect(finalValues.foo).toBe('b')
+    expect(finalValues.bar).toEqual(['a', 'b'])
+    expect(finalState.next).toEqual([])
+    expect(finalState.tasks).toHaveLength(0)
+
+    // Step 1: nodeA completed; Supabase snapshots expose the queued task via tasks
+    expect(afterNodeAState.metadata?.step).toBe(1)
+    expect(afterNodeAValues.foo).toBe('a')
+    expect(afterNodeAValues.bar).toEqual(['a'])
+    expect(afterNodeAState.next).toEqual(['nodeB'])
+    expectTasks(afterNodeAState, [
+      {
+        name: 'nodeB',
+        path: ['__pregel_pull', 'nodeB'],
+        interrupts: [],
+        result: { foo: 'b', bar: ['b'] },
+      },
+    ])
+
+    // Step 0: Initial input
+    expect(initialState.metadata?.step).toBe(0)
+    expect(initialValues.foo).toBe('')
+    expect(initialValues.bar).toEqual([])
+    expect(initialState.next).toEqual(['nodeA'])
+    expectTasks(initialState, [
+      {
+        name: 'nodeA',
+        path: ['__pregel_pull', 'nodeA'],
+        interrupts: [],
+        result: { foo: 'a', bar: ['a'] },
+      },
+    ])
+
+    // Step -1: Graph start
+    expect(startState.metadata?.step).toBe(-1)
+    expect(startState.next).toEqual(['__start__'])
+    expectTasks(startState, [
+      {
+        name: '__start__',
+        path: ['__pregel_pull', '__start__'],
+        interrupts: [],
+        result: { foo: '' },
+      },
+    ])
+  })
 })

--- a/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.ts
+++ b/frontend/internal-packages/agent/src/checkpoint/SupabaseCheckpointSaver.ts
@@ -815,10 +815,6 @@ export class SupabaseCheckpointSaver extends BaseCheckpointSaver<number> {
       versionEntries.set(TASKS, resolvedVersion)
     }
 
-    if (versionEntries.size === 0) {
-      return []
-    }
-
     const blobs: Database['public']['Tables']['checkpoint_blobs']['Insert'][] =
       []
 


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?

This PR fixes critical issues in the Supabase checkpoint saver related to task persistence and version handling:

1. **Tasks channel version handling**: The checkpoint saver was not properly managing versions for the `tasks` channel, causing issues when retrieving checkpoint history
2. **Task persistence**: Tasks were not being correctly persisted in checkpoint blobs, leading to incomplete state snapshots

These fixes ensure that:
- Task information is correctly saved and retrieved in checkpoints
- Version handling for the tasks channel is consistent with other channels
- Checkpoint history accurately reflects pending tasks and next nodes

The changes include comprehensive integration tests that validate the correct behavior of checkpoint next nodes and pending tasks across multiple execution steps.