### PR TITLE
🐛 Fix artifact display when realtime connection fails

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css
@@ -11,6 +11,29 @@
   overflow: hidden;
 }
 
+.warningBanner {
+  padding: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+  background-color: var(--callout-warning-background);
+  border: 1px solid var(--callout-warning-border);
+  border-radius: var(--border-radius-medium);
+  color: var(--callout-warning-text);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-4);
+  line-height: 1.5;
+}
+
+.warningIcon {
+  flex-shrink: 0;
+  color: var(--callout-warning-text);
+}
+
+.warningMessage {
+  flex: 1;
+}
+
 .head {
   display: flex;
   flex-direction: row;

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.module.css
@@ -11,29 +11,6 @@
   overflow: hidden;
 }
 
-.warningBanner {
-  padding: var(--spacing-3);
-  margin-bottom: var(--spacing-4);
-  background-color: var(--callout-warning-background);
-  border: 1px solid var(--callout-warning-border);
-  border-radius: var(--border-radius-medium);
-  color: var(--callout-warning-text);
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  font-size: var(--font-size-4);
-  line-height: 1.5;
-}
-
-.warningIcon {
-  flex-shrink: 0;
-  color: var(--callout-warning-text);
-}
-
-.warningMessage {
-  flex: 1;
-}
-
 .head {
   display: flex;
   flex-direction: row;

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.stories.tsx
@@ -68,8 +68,8 @@ VALUES ('john_doe', 'john@example.com', NOW());
 Users should be able to update their profile information including email, password, and display name.
 
 \`\`\`sql
-UPDATE users 
-SET email = 'newemail@example.com', 
+UPDATE users
+SET email = 'newemail@example.com',
     updated_at = NOW()
 WHERE user_id = 123;
 \`\`\`
@@ -95,6 +95,7 @@ export const Default: Story = {
   name: 'Default',
   args: {
     doc: sampleMarkdown,
+    error: null,
   },
 }
 
@@ -159,5 +160,14 @@ This is regular markdown text that should wrap normally without horizontal scrol
 SELECT * FROM users WHERE active = true;
 \`\`\`
 `,
+    error: null,
+  },
+}
+
+export const WithRealtimeError: Story = {
+  name: 'With Realtime Connection Error',
+  args: {
+    doc: sampleMarkdown,
+    error: new Error('Artifact realtime subscription failed'),
   },
 }

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
@@ -2,6 +2,7 @@
 
 import {
   AlertTriangle,
+  Callout,
   syntaxCodeTagProps,
   syntaxCustomStyle,
   syntaxTheme,
@@ -37,10 +38,9 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
   return (
     <div className={styles.container}>
       {error && (
-        <div className={styles.warningBanner}>
-          <AlertTriangle className={styles.warningIcon} size={20} />
-          <span className={styles.warningMessage}>{error.message}</span>
-        </div>
+        <Callout variant="warning" icon={<AlertTriangle size={20} />}>
+          {error.message}
+        </Callout>
       )}
       <div className={styles.head}>
         <CopyButton textToCopy={doc} tooltipLabel="Copy Markdown" />

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import { syntaxCodeTagProps, syntaxCustomStyle, syntaxTheme } from '@liam-hq/ui'
+import {
+  AlertTriangle,
+  syntaxCodeTagProps,
+  syntaxCustomStyle,
+  syntaxTheme,
+} from '@liam-hq/ui'
 import type { FC, HTMLAttributes, ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -25,11 +30,18 @@ type CodeProps = {
 
 type Props = {
   doc: string
+  error: Error | null
 }
 
-export const Artifact: FC<Props> = ({ doc }) => {
+export const Artifact: FC<Props> = ({ doc, error }) => {
   return (
     <div className={styles.container}>
+      {error && (
+        <div className={styles.warningBanner}>
+          <AlertTriangle className={styles.warningIcon} size={20} />
+          <span className={styles.warningMessage}>{error.message}</span>
+        </div>
+      )}
       <div className={styles.head}>
         <CopyButton textToCopy={doc} tooltipLabel="Copy Markdown" />
       </div>

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/ArtifactContainer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/ArtifactContainer.tsx
@@ -11,14 +11,10 @@ type Props = {
 }
 
 export const ArtifactContainer: FC<Props> = ({ artifact, error }) => {
-  if (error) {
-    return <div>Error loading artifact: {error.message}</div>
-  }
-
   if (!artifact) {
     return <div>No artifact available yet</div>
   }
 
   const markdownContent = formatArtifactToMarkdown(artifact)
-  return <Artifact doc={markdownContent} />
+  return <Artifact doc={markdownContent} error={error} />
 }


### PR DESCRIPTION
## Issue

Previously, artifacts would disappear when realtime subscription failed. 

<img width="800" height="2056" alt="image" src="https://github.com/user-attachments/assets/10e64655-b9aa-4ca6-946f-0dddc226418a" />

Now the last known artifact data continues to be displayed with a warning banner indicating that realtime updates are unavailable.

<img width="800" height="673" alt="image" src="https://github.com/user-attachments/assets/5dcefa0c-8492-4225-a5b7-76cca92e2bac" />

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a clear error banner to artifact output, showing connection errors above the content for better visibility.
  - Error display works consistently whether or not artifact content is available.

- Refactor
  - Unified error handling so the artifact view consistently manages and displays errors, while preserving the “No artifact available yet” state when applicable.

- Documentation
  - Added a Storybook scenario for realtime error states.
  - Updated existing stories to include an explicit error field for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->