### PR TITLE
fix(app): プロジェクト作成時のGitHub連携401を解消し、Projects空・検索空状態に「Add New Project」ボタンを追加

### DIFF
--- a/frontend/apps/app/app/projects/new/page.tsx
+++ b/frontend/apps/app/app/projects/new/page.tsx
@@ -1,4 +1,3 @@
-import { getInstallations } from '@liam-hq/github'
 import { redirect } from 'next/navigation'
 import { ProjectNewPage } from '../../../components/ProjectNewPage'
 import { getOrganizationId } from '../../../features/organizations/services/getOrganizationId'
@@ -26,17 +25,9 @@ export default async function NewProjectPage() {
   }
 
   const { data } = await supabase.auth.getSession()
-
   if (data.session === null) {
     redirect(urlgen('login'))
   }
 
-  const { installations } = await getInstallations(data.session)
-
-  return (
-    <ProjectNewPage
-      installations={installations}
-      organizationId={organizationId}
-    />
-  )
+  return <ProjectNewPage organizationId={organizationId} />
 }

--- a/frontend/apps/app/components/ProjectNewPage/ProjectNewPage.tsx
+++ b/frontend/apps/app/components/ProjectNewPage/ProjectNewPage.tsx
@@ -1,24 +1,16 @@
-import type { Installation } from '@liam-hq/github'
 import type { FC } from 'react'
-import { InstallationSelector } from './components/InstallationSelector'
+import { InstallationLoader } from './components/InstallationLoader/InstallationLoader'
 import styles from './ProjectNewPage.module.css'
 
 type Props = {
-  installations: Installation[]
   organizationId: string
 }
 
-export const ProjectNewPage: FC<Props> = ({
-  installations,
-  organizationId,
-}) => {
+export const ProjectNewPage: FC<Props> = ({ organizationId }) => {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Add a Project</h1>
-      <InstallationSelector
-        installations={installations}
-        organizationId={organizationId}
-      />
+      <InstallationLoader organizationId={organizationId} />
     </div>
   )
 }

--- a/frontend/apps/app/components/ProjectNewPage/components/InstallationLoader/InstallationLoader.tsx
+++ b/frontend/apps/app/components/ProjectNewPage/components/InstallationLoader/InstallationLoader.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { getInstallations, type Installation } from '@liam-hq/github'
+import { useEffect, useState } from 'react'
+import { createClient } from '../../../../libs/db/client'
+import { SignInGithubButton } from '../../../LoginPage/SignInGithubButton'
+import { InstallationSelector } from '../InstallationSelector'
+
+type Props = {
+  organizationId: string
+}
+
+export function InstallationLoader({ organizationId }: Props) {
+  const [installations, setInstallations] = useState<Installation[] | null>(
+    null,
+  )
+  const [needsGithubAuth, setNeedsGithubAuth] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient()
+      const { data } = await supabase.auth.getSession()
+      const session = data.session
+
+      // If we don't have a provider token, prompt to sign in with GitHub
+      if (!session?.provider_token) {
+        setNeedsGithubAuth(true)
+        setInstallations([])
+        return
+      }
+
+      try {
+        const { installations } = await getInstallations(session)
+        setInstallations(installations)
+      } catch (e) {
+        console.error('Failed to load GitHub installations:', e)
+        setInstallations([])
+      }
+    }
+    void load()
+  }, [])
+
+  if (needsGithubAuth) {
+    return (
+      <div>
+        <p>Connect your GitHub account to list installations.</p>
+        <SignInGithubButton returnTo="/projects/new" />
+      </div>
+    )
+  }
+
+  if (installations === null) {
+    return <div>Loading installations...</div>
+  }
+
+  return (
+    <InstallationSelector
+      installations={installations}
+      organizationId={organizationId}
+    />
+  )
+}

--- a/frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.module.css
+++ b/frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.module.css
@@ -52,6 +52,7 @@
   align-items: center;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-4);
+  margin-top: var(--spacing-3);
   background-color: var(--button-primary-background);
   color: var(--button-foreground);
   border: var(--border-width-base) solid var(--button-primary-background);

--- a/frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.tsx
+++ b/frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.tsx
@@ -40,6 +40,10 @@ export const EmptyProjectsState: FC<EmptyProjectsStateProps> = ({
             <br />
             Try using different keywords.
           </p>
+
+          <Link href={createProjectHref} className={styles.createButton}>
+            Add New Project
+          </Link>
         </div>
       )}
     </div>

--- a/frontend/apps/app/components/ProjectsPage/components/ProjectsListView/ProjectsListView.tsx
+++ b/frontend/apps/app/components/ProjectsPage/components/ProjectsListView/ProjectsListView.tsx
@@ -94,7 +94,14 @@ export function ProjectsListView({
       </div>
 
       {projects === null || projects.length === 0 ? (
-        <EmptyProjectsState projects={projects} />
+        <EmptyProjectsState
+          projects={projects}
+          createProjectHref={
+            organizationId
+              ? urlgen('projects/new')
+              : urlgen('organizations/new')
+          }
+        />
       ) : (
         <div className={styles.projectsGrid}>
           {projects.map((project) => (


### PR DESCRIPTION
## Issue

- resolve: liam-hq/liam#5764

## Why is this change needed?

サーバーレンダリング中にブラウザ用GitHub APIを呼び出しており、`session.provider_token` が取得できず 401 が発生していた問題を解消。また、/projects ページが空、または検索結果が0件の時にも「Add New Project」ボタンを表示して、プロジェクト追加導線を明確化。

## 原因

- サーバー側（RSC）で `GET /user/installations` を実行していたため、Supabaseの `provider_token` が手に入らず、Octokitが 401 を返していた。

## 変更内容

### GitHubインストレーション取得をクライアント側へ移行

- `frontend/apps/app/app/projects/new/page.tsx`: SSRでは認証・組織ID取得のみ。インストレーション取得は削除。
- `frontend/apps/app/components/ProjectNewPage/ProjectNewPage.tsx`: `installations` プロップを廃止し、新ローダーを使用。
- `frontend/apps/app/components/ProjectNewPage/components/InstallationLoader/InstallationLoader.tsx`: 追加。ブラウザでSupabaseセッションを確認し、`provider_token` があれば `getInstallations(session)` 実行。なければGitHubサインインボタン（returnTo=/projects/new）を表示。

### 空・検索空状態に追加ボタンを表示

- `frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.tsx`: 検索空状態でも「Add New Project」ボタンを表示。
- `frontend/apps/app/components/ProjectsPage/components/ProjectsListView/ProjectsListView.tsx`: `EmptyProjectsState` に `createProjectHref` を渡すよう修正（組織あり: `urlgen('projects/new')`、未選択: `urlgen('organizations/new')`）。
- `frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.module.css`: `.createButton` に `margin-top` を追加して説明文との余白を拡大。

## 変更ファイル

- frontend/apps/app/app/projects/new/page.tsx
- frontend/apps/app/components/ProjectNewPage/ProjectNewPage.tsx
- frontend/apps/app/components/ProjectNewPage/components/InstallationLoader/InstallationLoader.tsx（新規）
- frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.tsx
- frontend/apps/app/components/ProjectsPage/components/ProjectsListView/ProjectsListView.tsx
- frontend/apps/app/components/ProjectsPage/components/EmptyProjectsState/EmptyProjectsState.module.css

## 動作確認

### /projects/new
- ✅ ログイン済み + GitHub OAuth済み（provider_tokenあり）: インストール選択→リポジトリ表示→プロジェクト作成まで正常に進む
- ✅ GitHub OAuth未実施: 「Sign in with GitHub」ボタン表示→認証後 /projects/new へ戻り、インストール一覧が取得される

### /projects
- ✅ プロジェクト空: 「Add New Project」ボタン表示（組織あり→/projects/new、未選択→/organizations/new）
- ✅ 検索結果0件: 「Oops! No results found」に加えて「Add New Project」ボタン表示
- ✅ UI: 空・検索空いずれも説明文とボタンの間に余白があること

## 影響範囲

- アプリ（@liam-hq/app）のプロジェクト作成フロー、Projects一覧の空状態UI
- サーバーAPIやDBマイグレーションの変更はなし

## 環境変数

- NEXT_PUBLIC_GITHUB_APP_URL: 「Install GitHub App」ボタンで使用。未設定だとリンク無効のため要確認。

## 既知のフォローアップ

- @liam-hq/ui の Button でリンクを扱えるように asChild もしくは LinkButton を検討（現在はリンクをボタン風にスタイリング）