### PR TITLE
fix(app): Add SSR safety check to accessibleTransitions

### DIFF
--- a/frontend/apps/app/utils/accessibleTransitions.ts
+++ b/frontend/apps/app/utils/accessibleTransitions.ts
@@ -8,7 +8,9 @@ import type { CSSProperties } from 'react'
  * @returns CSS properties object with the appropriate transition
  */
 const checkReducedMotion = (): boolean => {
-  return window?.matchMedia('(prefers-reduced-motion: reduce)').matches ?? false
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function')
+    return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
 }
 
 export const createAccessibleTransition = (


### PR DESCRIPTION
## Issue

-

## Why is this change needed?

`accessibleTransitions.ts`で`window.matchMedia`を呼び出す際、SSR時にエラーが発生する可能性があったため、適切なチェックを追加しました。

### 変更内容

- `typeof window`のチェックに加えて、`typeof window.matchMedia`が関数であることを確認
- SSR環境では`false`を安全に返却
- オプショナルチェーン（`?.`）とnullish coalescing（`??`）の代わりに、明示的なチェックを実装

🤖 Generated with [Claude Code](https://claude.ai/code)