### PR TITLE
🔧(ci): Use GitHub Secrets for LANGSMITH_PROJECT instead of hardcoded value

### DIFF
--- a/.github/workflows/agent-deep-modeling.yml
+++ b/.github/workflows/agent-deep-modeling.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGSMITH_PROJECT: "liam-app"
+          LANGSMITH_PROJECT: ${{ secrets.LANGSMITH_PROJECT }}
           LANGSMITH_ORGANIZATION_ID: ${{ secrets.LANGSMITH_ORGANIZATION_ID }}
           LANGSMITH_PROJECT_ID: ${{ secrets.LANGSMITH_PROJECT_ID }}
           NO_COLOR: 1


### PR DESCRIPTION
## Issue

- resolve: route06/liam-internal#5791

## Why is this change needed?

Currently, the `LANGSMITH_PROJECT` value is hardcoded as "liam-app" in the GitHub Actions workflow, which prevents us from using different LangSmith projects for different environments (production vs development/CI). 

This change enables environment-specific LangSmith project configuration by using GitHub Secrets, allowing us to:
- Separate production metrics from development/CI data
- Accurately track success rates and performance metrics for production environment
- Maintain flexibility in LangSmith project management

## What changed?

Changed `.github/workflows/agent-deep-modeling.yml` to use `${{ secrets.LANGSMITH_PROJECT }}` instead of the hardcoded `"liam-app"` value.

This allows us to configure different LangSmith projects per environment by updating GitHub Secrets without code changes.