### PR TITLE
feat: add ERD demo page for pre-parsed schema JSON

### DIFF
--- a/frontend/apps/app/app/erd/demo/[...slug]/page.tsx
+++ b/frontend/apps/app/app/erd/demo/[...slug]/page.tsx
@@ -1,0 +1,178 @@
+import { schemaSchema } from '@liam-hq/schema'
+import type { Metadata } from 'next'
+import { cookies } from 'next/headers'
+import { notFound } from 'next/navigation'
+import * as v from 'valibot'
+import type { PageProps } from '../../../types'
+import ERDViewer from '../../p/[...slug]/erdViewer'
+
+const paramsSchema = v.object({
+  slug: v.array(v.string()),
+})
+
+const resolveContentUrl = (url: string): string | undefined => {
+  try {
+    const parsedUrl = new URL(url)
+
+    if (parsedUrl.hostname === 'github.com' && url.includes('/blob/')) {
+      return url
+        .replace('github.com', 'raw.githubusercontent.com')
+        .replace('/blob', '')
+    }
+
+    return url
+  } catch {
+    return undefined
+  }
+}
+
+const renderErrorView = (
+  errors: Array<{ name: string; message: string; instruction?: string }>,
+  fallbackMessage: string,
+  fallbackInstruction: string,
+) => {
+  const blankSchema = { tables: {}, enums: {}, extensions: {} }
+
+  return (
+    <ERDViewer
+      schema={blankSchema}
+      defaultSidebarOpen={false}
+      errorObjects={
+        errors.length > 0
+          ? errors
+          : [
+              {
+                name: 'NetworkError',
+                message: fallbackMessage,
+                instruction: fallbackInstruction,
+              },
+            ]
+      }
+    />
+  )
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const parsedParams = v.safeParse(paramsSchema, await params)
+  if (!parsedParams.success) notFound()
+
+  const joinedPath = parsedParams.output.slug.join('/')
+  const metaTitle = `${joinedPath} - Liam ERD Demo`
+  const metaDescription =
+    'View pre-parsed ER diagrams from JSON schema files. Ideal for sharing and reviewing schemas.'
+
+  const imageUrl = '/assets/liam_erd.png'
+
+  return {
+    title: metaTitle,
+    description: metaDescription,
+    openGraph: {
+      url: `https://liambx.com/erd/demo/${joinedPath}`,
+      images: imageUrl,
+    },
+  }
+}
+
+export default async function Page({ params }: PageProps) {
+  const parsedParams = v.safeParse(paramsSchema, await params)
+  if (!parsedParams.success) notFound()
+
+  const joinedPath = parsedParams.output.slug.join('/')
+  const url = `https://${joinedPath}`
+  const weCannotAccess = `Our signal's lost in the void! No access at this time..`
+  const pleaseCheck = `Double-check the transmission link ${url} and initiate contact again.`
+
+  const contentUrl = resolveContentUrl(url)
+  if (!contentUrl) {
+    return renderErrorView([], weCannotAccess, pleaseCheck)
+  }
+
+  const networkErrorObjects: Array<{
+    name: 'NetworkError'
+    message: string
+    instruction?: string
+  }> = []
+
+  const res = await fetch(contentUrl, { cache: 'no-store' }).catch((e) => {
+    if (e instanceof Error) {
+      networkErrorObjects.push({
+        name: 'NetworkError',
+        message: `${e.name}: ${e.message}. ${weCannotAccess}`,
+        instruction: pleaseCheck,
+      })
+    } else {
+      networkErrorObjects.push({
+        name: 'NetworkError',
+        message: `Unknown NetworkError. ${weCannotAccess}`,
+        instruction: pleaseCheck,
+      })
+    }
+    return null
+  })
+
+  if (!res) {
+    return renderErrorView(networkErrorObjects, weCannotAccess, pleaseCheck)
+  }
+
+  let jsonData: unknown
+  try {
+    jsonData = await res.json()
+  } catch (_e) {
+    return renderErrorView(
+      [
+        {
+          name: 'ParseError',
+          message: 'Failed to parse JSON from the provided URL',
+          instruction: 'Please ensure the URL points to a valid JSON file',
+        },
+      ],
+      weCannotAccess,
+      pleaseCheck,
+    )
+  }
+
+  const parseResult = v.safeParse(schemaSchema, jsonData)
+  if (!parseResult.success) {
+    return renderErrorView(
+      [
+        {
+          name: 'ValidationError',
+          message: 'Invalid schema format',
+          instruction:
+            'Please ensure the JSON matches the expected schema format',
+        },
+      ],
+      weCannotAccess,
+      pleaseCheck,
+    )
+  }
+
+  const schema = parseResult.output
+
+  const cookieStore = await cookies()
+  const defaultSidebarOpen = cookieStore.get('sidebar:state')?.value === 'true'
+  const layoutCookie = cookieStore.get('panels:layout')
+  const defaultPanelSizes = (() => {
+    if (!layoutCookie) return [20, 80]
+    try {
+      const sizes = JSON.parse(layoutCookie.value)
+      if (Array.isArray(sizes) && sizes.length >= 2) {
+        return sizes
+      }
+    } catch {
+      // Use default values if JSON.parse fails
+    }
+    return [20, 80]
+  })()
+
+  return (
+    <ERDViewer
+      schema={schema}
+      defaultSidebarOpen={defaultSidebarOpen}
+      defaultPanelSizes={defaultPanelSizes}
+      errorObjects={[]}
+    />
+  )
+}

--- a/pm-testcases-after.json
+++ b/pm-testcases-after.json
@@ -1,0 +1,2199 @@
+{
+    "tables": {
+      "organizations": {
+        "name": "organizations",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique identifier for each organization unit (company, division, department)"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Official organization name, unique across the system"
+          },
+          "parent_id": {
+            "name": "parent_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional parent organization id for hierarchical structure"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active flag to soft-delete or archive organizations"
+          }
+        },
+        "comment": "Organizational units with parent-child hierarchy for company structure and access control",
+        "indexes": {
+          "ix_organizations_name": {
+            "name": "ix_organizations_name",
+            "unique": true,
+            "columns": [
+              "name"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_organizations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_organizations",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_organizations_parent": {
+            "type": "FOREIGN KEY",
+            "name": "fk_organizations_parent",
+            "columnNames": [
+              "parent_id"
+            ],
+            "targetTableName": "organizations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "positions": {
+        "name": "positions",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique identifier for position/title (job role)"
+          },
+          "code": {
+            "name": "code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional short code for the position"
+          },
+          "title": {
+            "name": "title",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Human-readable position title"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Detailed description of responsibilities"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active flag for the position"
+          }
+        },
+        "comment": "Catalog of positions/roles that employees can hold within organizations",
+        "indexes": {},
+        "constraints": {
+          "pk_positions": {
+            "type": "PRIMARY KEY",
+            "name": "pk_positions",
+            "columnNames": [
+              "id"
+            ]
+          }
+        }
+      },
+      "employees": {
+        "name": "employees",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique identifier for each employee"
+          },
+          "employee_number": {
+            "name": "employee_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional company employee number"
+          },
+          "first_name": {
+            "name": "first_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee given name"
+          },
+          "last_name": {
+            "name": "last_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee family name"
+          },
+          "email": {
+            "name": "email",
+            "type": "text",
+            "default": null,
+            "check": "email ~* '^[^@\\s]+@[^@\\s]+\\.[^@\\s]+'",
+            "notNull": false,
+            "comment": "Work email address"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active employment flag"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp"
+          }
+        },
+        "comment": "Employees who may belong to multiple organizations and hold positions",
+        "indexes": {
+          "ix_employees_email": {
+            "name": "ix_employees_email",
+            "unique": true,
+            "columns": [
+              "email"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_employees": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employees",
+            "columnNames": [
+              "id"
+            ]
+          }
+        }
+      },
+      "employee_affiliations": {
+        "name": "employee_affiliations",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique id for an employee affiliation to an organization"
+          },
+          "employee_id": {
+            "name": "employee_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Reference to the employee"
+          },
+          "organization_id": {
+            "name": "organization_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Reference to the organization the employee is affiliated with"
+          },
+          "position_id": {
+            "name": "position_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Position the employee holds in this organization"
+          },
+          "reports_to_affiliation_id": {
+            "name": "reports_to_affiliation_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Affiliation id of the manager/reporting person within the same organization"
+          },
+          "is_primary": {
+            "name": "is_primary",
+            "type": "boolean",
+            "default": "false",
+            "check": null,
+            "notNull": true,
+            "comment": "Marks the primary affiliation for cross-organization contexts"
+          },
+          "start_date": {
+            "name": "start_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Affiliation start date"
+          },
+          "end_date": {
+            "name": "end_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Affiliation end date, if any"
+          }
+        },
+        "comment": "Mapping of employees to organizations with a single position per employee-organization pair and reporting within same org",
+        "indexes": {
+          "ux_employee_org_position": {
+            "name": "ux_employee_org_position",
+            "unique": true,
+            "columns": [
+              "employee_id",
+              "organization_id",
+              "position_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_employee_affiliations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employee_affiliations",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_affil_employee": {
+            "type": "FOREIGN KEY",
+            "name": "fk_affil_employee",
+            "columnNames": [
+              "employee_id"
+            ],
+            "targetTableName": "employees",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_affil_organization": {
+            "type": "FOREIGN KEY",
+            "name": "fk_affil_organization",
+            "columnNames": [
+              "organization_id"
+            ],
+            "targetTableName": "organizations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_affil_position": {
+            "type": "FOREIGN KEY",
+            "name": "fk_affil_position",
+            "columnNames": [
+              "position_id"
+            ],
+            "targetTableName": "positions",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_affil_reports_to": {
+            "type": "FOREIGN KEY",
+            "name": "fk_affil_reports_to",
+            "columnNames": [
+              "reports_to_affiliation_id"
+            ],
+            "targetTableName": "employee_affiliations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "business_partners": {
+        "name": "business_partners",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique identifier for a business partner entity"
+          },
+          "legal_name": {
+            "name": "legal_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Legal name of the business partner"
+          },
+          "category": {
+            "name": "category",
+            "type": "text",
+            "default": "vendor",
+            "check": "category IN ('vendor','client')",
+            "notNull": true,
+            "comment": "High-level category: vendor (supplier) or client"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation time"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active flag indicating partner can be used in transactions"
+          }
+        },
+        "comment": "Master record for any external business partner, either a client or a supplier",
+        "indexes": {
+          "ux_business_partners_name": {
+            "name": "ux_business_partners_name",
+            "unique": true,
+            "columns": [
+              "legal_name"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_business_partners": {
+            "type": "PRIMARY KEY",
+            "name": "pk_business_partners",
+            "columnNames": [
+              "id"
+            ]
+          }
+        }
+      },
+      "suppliers": {
+        "name": "suppliers",
+        "columns": {
+          "business_partner_id": {
+            "name": "business_partner_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to business_partners, represents supplier subtype"
+          },
+          "supplier_code": {
+            "name": "supplier_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional supplier code"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active supplier flag"
+          }
+        },
+        "comment": "Supplier-specific extension row for business partners that act as suppliers. One row per business_partner when partner is supplier",
+        "indexes": {},
+        "constraints": {
+          "pk_suppliers": {
+            "type": "PRIMARY KEY",
+            "name": "pk_suppliers",
+            "columnNames": [
+              "business_partner_id"
+            ]
+          },
+          "fk_suppliers_bp": {
+            "type": "FOREIGN KEY",
+            "name": "fk_suppliers_bp",
+            "columnNames": [
+              "business_partner_id"
+            ],
+            "targetTableName": "business_partners",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "clients": {
+        "name": "clients",
+        "columns": {
+          "business_partner_id": {
+            "name": "business_partner_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to business_partners, represents client subtype"
+          },
+          "client_code": {
+            "name": "client_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional client code"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active client flag"
+          }
+        },
+        "comment": "Client-specific extension row for business partners that act as clients. One row per business_partner when partner is client",
+        "indexes": {},
+        "constraints": {
+          "pk_clients": {
+            "type": "PRIMARY KEY",
+            "name": "pk_clients",
+            "columnNames": [
+              "business_partner_id"
+            ]
+          },
+          "fk_clients_bp": {
+            "type": "FOREIGN KEY",
+            "name": "fk_clients_bp",
+            "columnNames": [
+              "business_partner_id"
+            ],
+            "targetTableName": "business_partners",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "brands": {
+        "name": "brands",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique brand identifier"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Brand name"
+          },
+          "manufacturer": {
+            "name": "manufacturer",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Manufacturer name associated with the brand"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active flag for brand"
+          }
+        },
+        "comment": "Brands of items; suppliers may handle brands",
+        "indexes": {
+          "ux_brands_name": {
+            "name": "ux_brands_name",
+            "unique": true,
+            "columns": [
+              "name"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_brands": {
+            "type": "PRIMARY KEY",
+            "name": "pk_brands",
+            "columnNames": [
+              "id"
+            ]
+          }
+        }
+      },
+      "handled_brands": {
+        "name": "handled_brands",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique id for supplier handled brand mapping"
+          },
+          "supplier_id": {
+            "name": "supplier_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to suppliers.business_partner_id"
+          },
+          "brand_id": {
+            "name": "brand_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to brands.id"
+          },
+          "since_date": {
+            "name": "since_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date supplier started handling this brand"
+          },
+          "is_preferred": {
+            "name": "is_preferred",
+            "type": "boolean",
+            "default": "false",
+            "check": null,
+            "notNull": true,
+            "comment": "Indicates preferred supplier for this brand"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional notes about handling terms"
+          }
+        },
+        "comment": "Which suppliers handle which brands; only valid for suppliers (not clients)",
+        "indexes": {
+          "ux_handled_supplier_brand": {
+            "name": "ux_handled_supplier_brand",
+            "unique": true,
+            "columns": [
+              "supplier_id",
+              "brand_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_handled_brands": {
+            "type": "PRIMARY KEY",
+            "name": "pk_handled_brands",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_handled_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_handled_supplier",
+            "columnNames": [
+              "supplier_id"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_handled_brand": {
+            "type": "FOREIGN KEY",
+            "name": "fk_handled_brand",
+            "columnNames": [
+              "brand_id"
+            ],
+            "targetTableName": "brands",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "item_categories": {
+        "name": "item_categories",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Category id for grouping items"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Category name"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Category description"
+          }
+        },
+        "comment": "Hierarchy of item categories for classification and procurement grouping",
+        "indexes": {
+          "ux_item_categories_name": {
+            "name": "ux_item_categories_name",
+            "unique": true,
+            "columns": [
+              "name"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_item_categories": {
+            "type": "PRIMARY KEY",
+            "name": "pk_item_categories",
+            "columnNames": [
+              "id"
+            ]
+          }
+        }
+      },
+      "items": {
+        "name": "items",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique item identifier used in procurement and projects"
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Manufacturer part number, unique across items"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Item description and specifications"
+          },
+          "brand_id": {
+            "name": "brand_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Brand for the item"
+          },
+          "category_id": {
+            "name": "category_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Item category"
+          },
+          "is_active": {
+            "name": "is_active",
+            "type": "boolean",
+            "default": "true",
+            "check": null,
+            "notNull": true,
+            "comment": "Active item flag"
+          }
+        },
+        "comment": "Procurement catalog of items with unique manufacturer part numbers and category/brand references",
+        "indexes": {
+          "ux_items_mpn": {
+            "name": "ux_items_mpn",
+            "unique": true,
+            "columns": [
+              "manufacturer_part_number"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_items",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_items_brand": {
+            "type": "FOREIGN KEY",
+            "name": "fk_items_brand",
+            "columnNames": [
+              "brand_id"
+            ],
+            "targetTableName": "brands",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_items_category": {
+            "type": "FOREIGN KEY",
+            "name": "fk_items_category",
+            "columnNames": [
+              "category_id"
+            ],
+            "targetTableName": "item_categories",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "prototype_projects": {
+        "name": "prototype_projects",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique identifier for a prototype project"
+          },
+          "client_id": {
+            "name": "client_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to business_partners acting as client"
+          },
+          "project_code": {
+            "name": "project_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique project code for identification"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Project name"
+          },
+          "registration_date": {
+            "name": "registration_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date the project was registered"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Project-level notes"
+          }
+        },
+        "comment": "Prototype projects commissioned by clients for which models and procurement are tracked",
+        "indexes": {
+          "ux_project_code": {
+            "name": "ux_project_code",
+            "unique": true,
+            "columns": [
+              "project_code"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_prototype_projects": {
+            "type": "PRIMARY KEY",
+            "name": "pk_prototype_projects",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_project_client": {
+            "type": "FOREIGN KEY",
+            "name": "fk_project_client",
+            "columnNames": [
+              "client_id"
+            ],
+            "targetTableName": "clients",
+            "targetColumnNames": [
+              "business_partner_id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "models": {
+        "name": "models",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique model identifier within a project"
+          },
+          "project_id": {
+            "name": "project_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to prototype_projects"
+          },
+          "model_name": {
+            "name": "model_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Model name unique within project"
+          },
+          "production_quantity": {
+            "name": "production_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": "production_quantity >= 0",
+            "notNull": true,
+            "comment": "Number of units to be produced for this model"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Model-level notes"
+          }
+        },
+        "comment": "Models belonging to a prototype project; model_name scoped unique per project",
+        "indexes": {
+          "ux_model_project_name": {
+            "name": "ux_model_project_name",
+            "unique": true,
+            "columns": [
+              "project_id",
+              "model_name"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_models": {
+            "type": "PRIMARY KEY",
+            "name": "pk_models",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_models_project": {
+            "type": "FOREIGN KEY",
+            "name": "fk_models_project",
+            "columnNames": [
+              "project_id"
+            ],
+            "targetTableName": "prototype_projects",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "model_items": {
+        "name": "model_items",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique id for a BOM line (item within a model)"
+          },
+          "model_id": {
+            "name": "model_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to models"
+          },
+          "item_id": {
+            "name": "item_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to items used in the model"
+          },
+          "quantity_per_unit": {
+            "name": "quantity_per_unit",
+            "type": "integer",
+            "default": "1",
+            "check": "quantity_per_unit > 0",
+            "notNull": true,
+            "comment": "Quantity of the item required per produced model unit"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Notes about this BOM line"
+          }
+        },
+        "comment": "Bill of Materials lines for models; quantities per model must be positive integers",
+        "indexes": {
+          "ux_model_item_unique": {
+            "name": "ux_model_item_unique",
+            "unique": true,
+            "columns": [
+              "model_id",
+              "item_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_model_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_model_items",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_model_items_model": {
+            "type": "FOREIGN KEY",
+            "name": "fk_model_items_model",
+            "columnNames": [
+              "model_id"
+            ],
+            "targetTableName": "models",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_model_items_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_model_items_item",
+            "columnNames": [
+              "item_id"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "project_items": {
+        "name": "project_items",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique id representing an aggregated project procurement line"
+          },
+          "project_id": {
+            "name": "project_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to prototype_projects"
+          },
+          "item_id": {
+            "name": "item_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to items aggregated across models in project"
+          },
+          "client_provided_quantity": {
+            "name": "client_provided_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": "client_provided_quantity >= 0",
+            "notNull": true,
+            "comment": "Quantity provided by client and thus not requiring procurement"
+          },
+          "required_procurement_quantity": {
+            "name": "required_procurement_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": "required_procurement_quantity >= 0",
+            "notNull": true,
+            "comment": "Calculated required procurement quantity across models minus client provided quantity"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Notes about aggregated project item needs"
+          }
+        },
+        "comment": "Aggregated project-level items and required procurement quantities computed from models and client-provided quantities",
+        "indexes": {
+          "ux_project_item_unique": {
+            "name": "ux_project_item_unique",
+            "unique": true,
+            "columns": [
+              "project_id",
+              "item_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_project_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_project_items",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_project_items_project": {
+            "type": "FOREIGN KEY",
+            "name": "fk_project_items_project",
+            "columnNames": [
+              "project_id"
+            ],
+            "targetTableName": "prototype_projects",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_project_items_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_project_items_item",
+            "columnNames": [
+              "item_id"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "rfqs": {
+        "name": "rfqs",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique RFQ header identifier"
+          },
+          "project_id": {
+            "name": "project_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional linked prototype project"
+          },
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Business RFQ number"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "RFQ creation timestamp"
+          },
+          "created_by_affiliation_id": {
+            "name": "created_by_affiliation_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee affiliation who created the RFQ"
+          },
+          "status": {
+            "name": "status",
+            "type": "text",
+            "default": "'open'",
+            "check": "status IN ('open','closed','cancelled')",
+            "notNull": true,
+            "comment": "Lifecycle status of the RFQ"
+          }
+        },
+        "comment": "Request for quotation headers, optionally linked to prototype projects and created by an employee affiliation",
+        "indexes": {
+          "ux_rfqs_number": {
+            "name": "ux_rfqs_number",
+            "unique": true,
+            "columns": [
+              "rfq_number"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_rfqs": {
+            "type": "PRIMARY KEY",
+            "name": "pk_rfqs",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_rfqs_project": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfqs_project",
+            "columnNames": [
+              "project_id"
+            ],
+            "targetTableName": "prototype_projects",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "SET_NULL"
+          },
+          "fk_rfqs_created_by": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfqs_created_by",
+            "columnNames": [
+              "created_by_affiliation_id"
+            ],
+            "targetTableName": "employee_affiliations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "rfq_recipients": {
+        "name": "rfq_recipients",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique mapping id between RFQ and recipient supplier"
+          },
+          "rfq_id": {
+            "name": "rfq_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to rfqs"
+          },
+          "supplier_id": {
+            "name": "supplier_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to suppliers.business_partner_id who receive the RFQ"
+          },
+          "invited_at": {
+            "name": "invited_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Timestamp when supplier was invited to the RFQ"
+          }
+        },
+        "comment": "List of suppliers invited to respond to an RFQ; used to validate quotations come only from recipients",
+        "indexes": {
+          "ux_rfq_recipient_unique": {
+            "name": "ux_rfq_recipient_unique",
+            "unique": true,
+            "columns": [
+              "rfq_id",
+              "supplier_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_rfq_recipients": {
+            "type": "PRIMARY KEY",
+            "name": "pk_rfq_recipients",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_rfq_recipients_rfq": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfq_recipients_rfq",
+            "columnNames": [
+              "rfq_id"
+            ],
+            "targetTableName": "rfqs",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_rfq_recipients_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfq_recipients_supplier",
+            "columnNames": [
+              "supplier_id"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "rfq_details": {
+        "name": "rfq_details",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "RFQ detail line identifier"
+          },
+          "rfq_id": {
+            "name": "rfq_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to rfqs"
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": "rfq_detail_number > 0",
+            "notNull": true,
+            "comment": "Sequence number unique within RFQ"
+          },
+          "item_id": {
+            "name": "item_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Requested item"
+          },
+          "required_quantity": {
+            "name": "required_quantity",
+            "type": "integer",
+            "default": null,
+            "check": "required_quantity > 0",
+            "notNull": true,
+            "comment": "Quantity required for procurement; must be positive"
+          },
+          "desired_delivery_date": {
+            "name": "desired_delivery_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Desired delivery date for the item"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional notes about the RFQ line"
+          }
+        },
+        "comment": "Line items requested in an RFQ with required quantities and unique sequence numbers per RFQ",
+        "indexes": {
+          "ux_rfq_detail_number": {
+            "name": "ux_rfq_detail_number",
+            "unique": true,
+            "columns": [
+              "rfq_id",
+              "rfq_detail_number"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_rfq_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_rfq_details",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_rfq_details_rfq": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfq_details_rfq",
+            "columnNames": [
+              "rfq_id"
+            ],
+            "targetTableName": "rfqs",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_rfq_details_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfq_details_item",
+            "columnNames": [
+              "item_id"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "quotations": {
+        "name": "quotations",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Quotation header unique id"
+          },
+          "rfq_id": {
+            "name": "rfq_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to RFQ being quoted"
+          },
+          "supplier_id": {
+            "name": "supplier_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to supplier providing the quotation"
+          },
+          "quotation_number": {
+            "name": "quotation_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Business quotation number"
+          },
+          "quotation_date": {
+            "name": "quotation_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date of the quotation"
+          },
+          "valid_until": {
+            "name": "valid_until",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Validity end date for the quotation"
+          },
+          "created_by_affiliation_id": {
+            "name": "created_by_affiliation_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee affiliation who recorded the quotation"
+          }
+        },
+        "comment": "Supplier quotations submitted in response to RFQs; one quotation per (rfq,supplier)",
+        "indexes": {
+          "ux_quotation_unique": {
+            "name": "ux_quotation_unique",
+            "unique": true,
+            "columns": [
+              "rfq_id",
+              "supplier_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_quotations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_quotations",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_quotations_rfq": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotations_rfq",
+            "columnNames": [
+              "rfq_id"
+            ],
+            "targetTableName": "rfqs",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_quotations_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotations_supplier",
+            "columnNames": [
+              "supplier_id"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_quotations_created_by": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotations_created_by",
+            "columnNames": [
+              "created_by_affiliation_id"
+            ],
+            "targetTableName": "employee_affiliations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "quotation_details": {
+        "name": "quotation_details",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Quotation detail line id referencing an RFQ detail"
+          },
+          "quotation_id": {
+            "name": "quotation_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to quotations header"
+          },
+          "rfq_detail_id": {
+            "name": "rfq_detail_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to rfq_details being quoted"
+          },
+          "proposed_item_id": {
+            "name": "proposed_item_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional alternative item proposed by supplier"
+          },
+          "proposed_reason": {
+            "name": "proposed_reason",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Reason for proposing an alternative item"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional notes"
+          }
+        },
+        "comment": "Line-level supplier proposal referencing RFQ detail and optionally proposing alternatives",
+        "indexes": {
+          "ux_quotation_detail_unique": {
+            "name": "ux_quotation_detail_unique",
+            "unique": true,
+            "columns": [
+              "quotation_id",
+              "rfq_detail_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_quotation_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_quotation_details",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_quotation_details_quotation": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotation_details_quotation",
+            "columnNames": [
+              "quotation_id"
+            ],
+            "targetTableName": "quotations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_quotation_details_rfq_detail": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotation_details_rfq_detail",
+            "columnNames": [
+              "rfq_detail_id"
+            ],
+            "targetTableName": "rfq_details",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_quotation_details_proposed_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotation_details_proposed_item",
+            "columnNames": [
+              "proposed_item_id"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "quotation_conditions": {
+        "name": "quotation_conditions",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Condition option for a quotation detail, e.g., price, lot size, deliverable date"
+          },
+          "quotation_detail_id": {
+            "name": "quotation_detail_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to quotation_details"
+          },
+          "unit_price": {
+            "name": "unit_price",
+            "type": "numeric(14,4)",
+            "default": null,
+            "check": "unit_price > 0",
+            "notNull": true,
+            "comment": "Unit price per item, must be positive"
+          },
+          "lot_size": {
+            "name": "lot_size",
+            "type": "integer",
+            "default": "1",
+            "check": "lot_size > 0",
+            "notNull": true,
+            "comment": "Lot size for ordering; must be positive integer"
+          },
+          "deliverable_date": {
+            "name": "deliverable_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Proposed deliverable date for this condition"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Additional condition notes"
+          }
+        },
+        "comment": "Multiple procurement conditions per quotation detail representing price and logistical options",
+        "indexes": {
+          "ux_condition_one_per_selection": {
+            "name": "ux_condition_one_per_selection",
+            "unique": true,
+            "columns": [
+              "quotation_detail_id",
+              "unit_price",
+              "lot_size",
+              "deliverable_date"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_quotation_conditions": {
+            "type": "PRIMARY KEY",
+            "name": "pk_quotation_conditions",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_quotation_conditions_detail": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotation_conditions_detail",
+            "columnNames": [
+              "quotation_detail_id"
+            ],
+            "targetTableName": "quotation_details",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "purchase_orders": {
+        "name": "purchase_orders",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Purchase order header id"
+          },
+          "po_number": {
+            "name": "po_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Business PO number"
+          },
+          "supplier_id": {
+            "name": "supplier_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to supplier who is seller on the PO"
+          },
+          "order_date": {
+            "name": "order_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date PO was created"
+          },
+          "created_by_affiliation_id": {
+            "name": "created_by_affiliation_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee affiliation who created the PO"
+          },
+          "status": {
+            "name": "status",
+            "type": "text",
+            "default": "'open'",
+            "check": "status IN ('open','confirmed','received','closed','cancelled')",
+            "notNull": true,
+            "comment": "Lifecycle status of the PO"
+          }
+        },
+        "comment": "Purchase order headers issued to suppliers selecting quotation conditions",
+        "indexes": {
+          "ux_po_number": {
+            "name": "ux_po_number",
+            "unique": true,
+            "columns": [
+              "po_number"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_purchase_orders": {
+            "type": "PRIMARY KEY",
+            "name": "pk_purchase_orders",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_po_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_po_supplier",
+            "columnNames": [
+              "supplier_id"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_po_created_by": {
+            "type": "FOREIGN KEY",
+            "name": "fk_po_created_by",
+            "columnNames": [
+              "created_by_affiliation_id"
+            ],
+            "targetTableName": "employee_affiliations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "po_details": {
+        "name": "po_details",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "PO detail line id referencing chosen quotation condition"
+          },
+          "po_id": {
+            "name": "po_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to purchase_orders header"
+          },
+          "quotation_condition_id": {
+            "name": "quotation_condition_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Selected quotation condition; one-to-one mapping to PO detail"
+          },
+          "number_of_lots": {
+            "name": "number_of_lots",
+            "type": "integer",
+            "default": "1",
+            "check": "number_of_lots > 0",
+            "notNull": true,
+            "comment": "Number of lots ordered"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional notes"
+          },
+          "unit_price_cached": {
+            "name": "unit_price_cached",
+            "type": "numeric(14,4)",
+            "default": null,
+            "check": "unit_price_cached > 0",
+            "notNull": true,
+            "comment": "Cached unit price copied from the selected quotation condition at order time"
+          },
+          "lot_size_cached": {
+            "name": "lot_size_cached",
+            "type": "integer",
+            "default": null,
+            "check": "lot_size_cached > 0",
+            "notNull": true,
+            "comment": "Cached lot size copied from the selected quotation condition at order time"
+          }
+        },
+        "comment": "PO detail lines that reference a single quotation condition; caches unit/lot for stable computation and prevents reuse of condition across PO details",
+        "indexes": {
+          "ux_po_detail_condition_unique": {
+            "name": "ux_po_detail_condition_unique",
+            "unique": true,
+            "columns": [
+              "quotation_condition_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_po_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_po_details",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_po_details_po": {
+            "type": "FOREIGN KEY",
+            "name": "fk_po_details_po",
+            "columnNames": [
+              "po_id"
+            ],
+            "targetTableName": "purchase_orders",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_po_details_condition": {
+            "type": "FOREIGN KEY",
+            "name": "fk_po_details_condition",
+            "columnNames": [
+              "quotation_condition_id"
+            ],
+            "targetTableName": "quotation_conditions",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "receipts": {
+        "name": "receipts",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Receipt header unique id for goods received"
+          },
+          "receipt_number": {
+            "name": "receipt_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Business receipt number"
+          },
+          "supplier_id": {
+            "name": "supplier_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Supplier who delivered goods"
+          },
+          "received_at": {
+            "name": "received_at",
+            "type": "timestamptz",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Timestamp when goods were received"
+          },
+          "created_by_affiliation_id": {
+            "name": "created_by_affiliation_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee affiliation who recorded the receipt"
+          }
+        },
+        "comment": "Goods receipt headers linked to POs and suppliers",
+        "indexes": {
+          "ux_receipts_number": {
+            "name": "ux_receipts_number",
+            "unique": true,
+            "columns": [
+              "receipt_number"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_receipts": {
+            "type": "PRIMARY KEY",
+            "name": "pk_receipts",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_receipts_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_receipts_supplier",
+            "columnNames": [
+              "supplier_id"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_receipts_created_by": {
+            "type": "FOREIGN KEY",
+            "name": "fk_receipts_created_by",
+            "columnNames": [
+              "created_by_affiliation_id"
+            ],
+            "targetTableName": "employee_affiliations",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "receipt_details": {
+        "name": "receipt_details",
+        "columns": {
+          "id": {
+            "name": "id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Unique receipt detail identifier mapped to a PO detail"
+          },
+          "receipt_id": {
+            "name": "receipt_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to receipts header"
+          },
+          "po_detail_id": {
+            "name": "po_detail_id",
+            "type": "uuid",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to the PO detail being received (no split deliveries allowed)"
+          },
+          "received_quantity": {
+            "name": "received_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": "received_quantity >= 0",
+            "notNull": true,
+            "comment": "Quantity received for this PO detail"
+          },
+          "notes": {
+            "name": "notes",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Receiving notes"
+          }
+        },
+        "comment": "Receipt detail lines mapping each PO detail to a single receipt (no split deliveries allowed)",
+        "indexes": {
+          "ux_receipt_po_detail_unique": {
+            "name": "ux_receipt_po_detail_unique",
+            "unique": true,
+            "columns": [
+              "po_detail_id"
+            ],
+            "type": "btree"
+          }
+        },
+        "constraints": {
+          "pk_receipt_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_receipt_details",
+            "columnNames": [
+              "id"
+            ]
+          },
+          "fk_receipt_details_receipt": {
+            "type": "FOREIGN KEY",
+            "name": "fk_receipt_details_receipt",
+            "columnNames": [
+              "receipt_id"
+            ],
+            "targetTableName": "receipts",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_receipt_details_po_detail": {
+            "type": "FOREIGN KEY",
+            "name": "fk_receipt_details_po_detail",
+            "columnNames": [
+              "po_detail_id"
+            ],
+            "targetTableName": "po_details",
+            "targetColumnNames": [
+              "id"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      }
+    },
+    "enums": {},
+    "extensions": {}
+}

--- a/pm-testcases-before.json
+++ b/pm-testcases-before.json
@@ -1,0 +1,2192 @@
+{
+    "tables": {
+      "organizations": {
+        "name": "organizations",
+        "columns": {
+          "organization_code": {
+            "name": "organization_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique business code identifying an organization (used as natural primary key)"
+          },
+          "organization_name": {
+            "name": "organization_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Human-friendly unique organization name"
+          },
+          "parent_organization_code": {
+            "name": "parent_organization_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional parent organization_code to form organization hierarchy; null for root organizations"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Business description and purpose of the organization"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Identifier of user who created the record"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamp",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Last update timestamp for audit"
+          },
+          "updated_by": {
+            "name": "updated_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Identifier of user who last updated the record"
+          }
+        },
+        "comment": "Stores organizations and their hierarchy used for employee affiliations and internal ownership",
+        "indexes": {},
+        "constraints": {
+          "pk_organizations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_organizations",
+            "columnNames": [
+              "organization_code"
+            ]
+          },
+          "uq_organizations_name": {
+            "type": "UNIQUE",
+            "name": "uq_organizations_name",
+            "columnNames": [
+              "organization_name"
+            ]
+          },
+          "fk_organizations_parent": {
+            "type": "FOREIGN KEY",
+            "name": "fk_organizations_parent",
+            "columnNames": [
+              "parent_organization_code"
+            ],
+            "targetTableName": "organizations",
+            "targetColumnNames": [
+              "organization_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "positions": {
+        "name": "positions",
+        "columns": {
+          "position_code": {
+            "name": "position_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique code for position or role within the organization"
+          },
+          "position_name": {
+            "name": "position_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Human-friendly unique position name"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Description of responsibilities for the position"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the position"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamp",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Last update timestamp for audit"
+          },
+          "updated_by": {
+            "name": "updated_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who last updated the position"
+          }
+        },
+        "comment": "Canonical list of positions/roles used in employee affiliations",
+        "indexes": {},
+        "constraints": {
+          "pk_positions": {
+            "type": "PRIMARY KEY",
+            "name": "pk_positions",
+            "columnNames": [
+              "position_code"
+            ]
+          },
+          "uq_positions_name": {
+            "type": "UNIQUE",
+            "name": "uq_positions_name",
+            "columnNames": [
+              "position_name"
+            ]
+          }
+        }
+      },
+      "employees": {
+        "name": "employees",
+        "columns": {
+          "employee_code": {
+            "name": "employee_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique Employee business identifier"
+          },
+          "employee_name": {
+            "name": "employee_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee full name (not required to be unique)"
+          },
+          "email": {
+            "name": "email",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Contact email"
+          },
+          "phone": {
+            "name": "phone",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Contact phone number"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the employee record"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamp",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Last update timestamp for audit"
+          },
+          "updated_by": {
+            "name": "updated_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who last updated the employee record"
+          }
+        },
+        "comment": "People who participate in procurement workflows and internal organizations",
+        "indexes": {},
+        "constraints": {
+          "pk_employees": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employees",
+            "columnNames": [
+              "employee_code"
+            ]
+          }
+        }
+      },
+      "employee_affiliations": {
+        "name": "employee_affiliations",
+        "columns": {
+          "affiliation_id": {
+            "name": "affiliation_id",
+            "type": "uuid",
+            "default": "gen_random_uuid()",
+            "check": null,
+            "notNull": true,
+            "comment": "Surrogate id for the employee-organization affiliation"
+          },
+          "employee_code": {
+            "name": "employee_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Employee participating in the organization"
+          },
+          "organization_code": {
+            "name": "organization_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Organization the employee is affiliated with"
+          },
+          "position_code": {
+            "name": "position_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional position code assigned for this affiliation; at most one per affiliation"
+          },
+          "reporting_employee_code": {
+            "name": "reporting_employee_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional designated reporting employee code who must also belong to the same organization"
+          },
+          "start_date": {
+            "name": "start_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Affiliation start date"
+          },
+          "end_date": {
+            "name": "end_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Affiliation end date if applicable"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the affiliation"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamp",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Last update timestamp for audit"
+          },
+          "updated_by": {
+            "name": "updated_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who last updated the affiliation"
+          }
+        },
+        "comment": "Associates employees to organizations and optionally a position and designated reporting employee; reporting employee must belong to same organization",
+        "indexes": {},
+        "constraints": {
+          "pk_employee_affiliations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_employee_affiliations",
+            "columnNames": [
+              "affiliation_id"
+            ]
+          },
+          "uq_emp_org_unique_position": {
+            "type": "UNIQUE",
+            "name": "uq_emp_org_unique_position",
+            "columnNames": [
+              "employee_code",
+              "organization_code",
+              "position_code"
+            ]
+          },
+          "fk_aff_employee": {
+            "type": "FOREIGN KEY",
+            "name": "fk_aff_employee",
+            "columnNames": [
+              "employee_code"
+            ],
+            "targetTableName": "employees",
+            "targetColumnNames": [
+              "employee_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_aff_organization": {
+            "type": "FOREIGN KEY",
+            "name": "fk_aff_organization",
+            "columnNames": [
+              "organization_code"
+            ],
+            "targetTableName": "organizations",
+            "targetColumnNames": [
+              "organization_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_aff_position": {
+            "type": "FOREIGN KEY",
+            "name": "fk_aff_position",
+            "columnNames": [
+              "position_code"
+            ],
+            "targetTableName": "positions",
+            "targetColumnNames": [
+              "position_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "SET_NULL"
+          },
+          "fk_aff_reporting_employee": {
+            "type": "FOREIGN KEY",
+            "name": "fk_aff_reporting_employee",
+            "columnNames": [
+              "reporting_employee_code"
+            ],
+            "targetTableName": "employees",
+            "targetColumnNames": [
+              "employee_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "SET_NULL"
+          }
+        }
+      },
+      "business_partners": {
+        "name": "business_partners",
+        "columns": {
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique business partner code used as natural key"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Business partner legal or display name"
+          },
+          "address": {
+            "name": "address",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Primary address for the business partner"
+          },
+          "category": {
+            "name": "category",
+            "type": "text",
+            "default": null,
+            "check": "category IN ('CLIENT','SUPPLIER')",
+            "notNull": true,
+            "comment": "Partner category: either CLIENT or SUPPLIER"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the partner record"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamp",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who last updated the partner record"
+          },
+          "updated_by": {
+            "name": "updated_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who last updated the partner record"
+          }
+        },
+        "comment": "Master list of business partners categorized as CLIENT or SUPPLIER; category enforces subtype consistency",
+        "indexes": {},
+        "constraints": {
+          "pk_business_partners": {
+            "type": "PRIMARY KEY",
+            "name": "pk_business_partners",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          },
+          "uq_business_partner_code": {
+            "type": "UNIQUE",
+            "name": "uq_business_partner_code",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          }
+        }
+      },
+      "clients": {
+        "name": "clients",
+        "columns": {
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to business_partners for partners with category CLIENT"
+          },
+          "last_fiscal_year_order_amount": {
+            "name": "last_fiscal_year_order_amount",
+            "type": "numeric",
+            "default": "0",
+            "check": null,
+            "notNull": false,
+            "comment": "Total order amount from last fiscal year for the client"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the client subtype record"
+          }
+        },
+        "comment": "Client-specific attributes for business partners categorized as CLIENT",
+        "indexes": {},
+        "constraints": {
+          "pk_clients": {
+            "type": "PRIMARY KEY",
+            "name": "pk_clients",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          },
+          "fk_clients_bp": {
+            "type": "FOREIGN KEY",
+            "name": "fk_clients_bp",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "business_partners",
+            "targetColumnNames": [
+              "business_partner_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "suppliers": {
+        "name": "suppliers",
+        "columns": {
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "FK to business_partners for partners with category SUPPLIER"
+          },
+          "last_fiscal_year_procurement_amount": {
+            "name": "last_fiscal_year_procurement_amount",
+            "type": "numeric",
+            "default": "0",
+            "check": null,
+            "notNull": false,
+            "comment": "Total procurement amount from last fiscal year for the supplier"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the supplier subtype record"
+          }
+        },
+        "comment": "Supplier-specific attributes for business partners categorized as SUPPLIER",
+        "indexes": {},
+        "constraints": {
+          "pk_suppliers": {
+            "type": "PRIMARY KEY",
+            "name": "pk_suppliers",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          },
+          "fk_suppliers_bp": {
+            "type": "FOREIGN KEY",
+            "name": "fk_suppliers_bp",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "business_partners",
+            "targetColumnNames": [
+              "business_partner_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "manufacturers": {
+        "name": "manufacturers",
+        "columns": {
+          "manufacturer_code": {
+            "name": "manufacturer_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique manufacturer code"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Manufacturer name"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created this record"
+          }
+        },
+        "comment": "Entities that manufacture items and own brands",
+        "indexes": {},
+        "constraints": {
+          "pk_manufacturers": {
+            "type": "PRIMARY KEY",
+            "name": "pk_manufacturers",
+            "columnNames": [
+              "manufacturer_code"
+            ]
+          }
+        }
+      },
+      "brands": {
+        "name": "brands",
+        "columns": {
+          "brand_code": {
+            "name": "brand_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique brand code"
+          },
+          "brand_name": {
+            "name": "brand_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Human-friendly brand name"
+          },
+          "manufacturer_code": {
+            "name": "manufacturer_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Manufacturer that owns the brand"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the brand record"
+          }
+        },
+        "comment": "Brands associated with a single manufacturer",
+        "indexes": {},
+        "constraints": {
+          "pk_brands": {
+            "type": "PRIMARY KEY",
+            "name": "pk_brands",
+            "columnNames": [
+              "brand_code"
+            ]
+          },
+          "uq_brands_name": {
+            "type": "UNIQUE",
+            "name": "uq_brands_name",
+            "columnNames": [
+              "brand_name"
+            ]
+          },
+          "fk_brands_manufacturer": {
+            "type": "FOREIGN KEY",
+            "name": "fk_brands_manufacturer",
+            "columnNames": [
+              "manufacturer_code"
+            ],
+            "targetTableName": "manufacturers",
+            "targetColumnNames": [
+              "manufacturer_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "item_categories": {
+        "name": "item_categories",
+        "columns": {
+          "item_category_code": {
+            "name": "item_category_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique code for item category"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Human-friendly category name"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Business description of the item category"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          }
+        },
+        "comment": "Hierarchy of item categories used to classify parts and materials",
+        "indexes": {},
+        "constraints": {
+          "pk_item_categories": {
+            "type": "PRIMARY KEY",
+            "name": "pk_item_categories",
+            "columnNames": [
+              "item_category_code"
+            ]
+          },
+          "uq_item_categories_name": {
+            "type": "UNIQUE",
+            "name": "uq_item_categories_name",
+            "columnNames": [
+              "name"
+            ]
+          }
+        }
+      },
+      "items": {
+        "name": "items",
+        "columns": {
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Globally unique manufacturer part number identifying an item"
+          },
+          "brand_code": {
+            "name": "brand_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Brand associated with the item; implies the manufacturer via the brand"
+          },
+          "item_category_code": {
+            "name": "item_category_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Item category for classification"
+          },
+          "description": {
+            "name": "description",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Descriptive specification or notes for the item"
+          },
+          "unit_of_measure": {
+            "name": "unit_of_measure",
+            "type": "text",
+            "default": "\"EA\"",
+            "check": null,
+            "notNull": true,
+            "comment": "Unit of measure (e.g., EA, PCS) for quantities"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the item record"
+          }
+        },
+        "comment": "Catalog of items parts with enforced global uniqueness on manufacturer_part_number; brand associates the item to a manufacturer",
+        "indexes": {},
+        "constraints": {
+          "pk_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_items",
+            "columnNames": [
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_items_brand": {
+            "type": "FOREIGN KEY",
+            "name": "fk_items_brand",
+            "columnNames": [
+              "brand_code"
+            ],
+            "targetTableName": "brands",
+            "targetColumnNames": [
+              "brand_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_items_category": {
+            "type": "FOREIGN KEY",
+            "name": "fk_items_category",
+            "columnNames": [
+              "item_category_code"
+            ],
+            "targetTableName": "item_categories",
+            "targetColumnNames": [
+              "item_category_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "prototype_projects": {
+        "name": "prototype_projects",
+        "columns": {
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique project identifier for prototype projects"
+          },
+          "name": {
+            "name": "name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Project name"
+          },
+          "client_business_partner_code": {
+            "name": "client_business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Client business_partner_code referencing a business partner with category CLIENT"
+          },
+          "product_purpose": {
+            "name": "product_purpose",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Product purpose description shared with suppliers (client identity suppressed)"
+          },
+          "registration_date": {
+            "name": "registration_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Project registration date"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Record creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the project record"
+          }
+        },
+        "comment": "Prototype projects requested by clients; product_purpose may be shared in RFQs without exposing client identity",
+        "indexes": {},
+        "constraints": {
+          "pk_prototype_projects": {
+            "type": "PRIMARY KEY",
+            "name": "pk_prototype_projects",
+            "columnNames": [
+              "prototype_project_number"
+            ]
+          },
+          "fk_projects_client_bp": {
+            "type": "FOREIGN KEY",
+            "name": "fk_projects_client_bp",
+            "columnNames": [
+              "client_business_partner_code"
+            ],
+            "targetTableName": "clients",
+            "targetColumnNames": [
+              "business_partner_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "models": {
+        "name": "models",
+        "columns": {
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Owning prototype project number"
+          },
+          "model_name": {
+            "name": "model_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Model name unique within a project"
+          },
+          "design_drawing_number": {
+            "name": "design_drawing_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Design drawing reference number"
+          },
+          "production_quantity": {
+            "name": "production_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Units to be produced for this model"
+          },
+          "client_requested_delivery_date": {
+            "name": "client_requested_delivery_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Delivery date requested by the client for this model"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the model record"
+          }
+        },
+        "comment": "Models belonging to prototype projects; composite primary key (project, model_name) enforces uniqueness",
+        "indexes": {},
+        "constraints": {
+          "pk_models": {
+            "type": "PRIMARY KEY",
+            "name": "pk_models",
+            "columnNames": [
+              "prototype_project_number",
+              "model_name"
+            ]
+          },
+          "fk_models_project": {
+            "type": "FOREIGN KEY",
+            "name": "fk_models_project",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "prototype_projects",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "model_items": {
+        "name": "model_items",
+        "columns": {
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Project owning the model"
+          },
+          "model_name": {
+            "name": "model_name",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Model name within the project"
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Item used in this model identified by manufacturer part number"
+          },
+          "quantity_per_unit": {
+            "name": "quantity_per_unit",
+            "type": "integer",
+            "default": "1",
+            "check": null,
+            "notNull": true,
+            "comment": "Number of this item required per unit of model assembly"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the model item record"
+          }
+        },
+        "comment": "Bill of materials mapping items to models with per-unit quantities",
+        "indexes": {},
+        "constraints": {
+          "pk_model_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_model_items",
+            "columnNames": [
+              "prototype_project_number",
+              "model_name",
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_mi_model": {
+            "type": "FOREIGN KEY",
+            "name": "fk_mi_model",
+            "columnNames": [
+              "prototype_project_number",
+              "model_name"
+            ],
+            "targetTableName": "models",
+            "targetColumnNames": [
+              "prototype_project_number",
+              "model_name"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_mi_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_mi_item",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "project_items": {
+        "name": "project_items",
+        "columns": {
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Prototype project owning the aggregated item total"
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Item for which project-level totals are tracked"
+          },
+          "total_required_quantity": {
+            "name": "total_required_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Total quantity required across all models in the project (derived but stored for performance)"
+          },
+          "client_provided_quantity": {
+            "name": "client_provided_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Quantity provided by the client and therefore not procured"
+          },
+          "procurement_quantity": {
+            "name": "procurement_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Derived procurement quantity = total_required_quantity - client_provided_quantity"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "updated_at": {
+            "name": "updated_at",
+            "type": "timestamp",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Update timestamp to track recalculations"
+          },
+          "updated_by": {
+            "name": "updated_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who triggered recalculation or update"
+          }
+        },
+        "comment": "Per-project aggregated totals for each item to drive RFQs and procurement; procurement_quantity is maintained consistent with components",
+        "indexes": {},
+        "constraints": {
+          "pk_project_items": {
+            "type": "PRIMARY KEY",
+            "name": "pk_project_items",
+            "columnNames": [
+              "prototype_project_number",
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_pi_project": {
+            "type": "FOREIGN KEY",
+            "name": "fk_pi_project",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "prototype_projects",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_pi_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_pi_item",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "rfqs": {
+        "name": "rfqs",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique RFQ identifier"
+          },
+          "rfq_date": {
+            "name": "rfq_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date RFQ was created/sent"
+          },
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Associated prototype project for which RFQ is issued"
+          },
+          "supplier_business_partner_code": {
+            "name": "supplier_business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Supplier receiving the RFQ; must be a business partner of category SUPPLIER"
+          },
+          "shared_product_purpose": {
+            "name": "shared_product_purpose",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Product purpose shared with supplier; client identity must not be exposed"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the RFQ record"
+          }
+        },
+        "comment": "Request for quote issued to a specific supplier for a project; supplier must handle items' brands",
+        "indexes": {},
+        "constraints": {
+          "pk_rfqs": {
+            "type": "PRIMARY KEY",
+            "name": "pk_rfqs",
+            "columnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_rfqs_project": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfqs_project",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "prototype_projects",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_rfqs_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfqs_supplier",
+            "columnNames": [
+              "supplier_business_partner_code"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "rfq_details": {
+        "name": "rfq_details",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Parent RFQ identifier"
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Detail line number within the RFQ"
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Item requested in the RFQ detail; must be part of the project's item list"
+          },
+          "required_procurement_quantity": {
+            "name": "required_procurement_quantity",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Quantity requested to be procured for this RFQ detail"
+          },
+          "desired_delivery_date": {
+            "name": "desired_delivery_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Desired delivery date for this RFQ line"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          }
+        },
+        "comment": "Details of RFQs per supplier; item must exist in project_items and supplier must handle its brand",
+        "indexes": {},
+        "constraints": {
+          "pk_rfq_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_rfq_details",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number"
+            ]
+          },
+          "fk_rfq_details_rfq": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfq_details_rfq",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "rfqs",
+            "targetColumnNames": [
+              "rfq_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_rfq_details_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rfq_details_item",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "quotations": {
+        "name": "quotations",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "RFQ that this quotation responds to (at most one quotation per RFQ)"
+          },
+          "supplier_quotation_number": {
+            "name": "supplier_quotation_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Supplier's own quotation reference number"
+          },
+          "quotation_date": {
+            "name": "quotation_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date the quotation was issued"
+          },
+          "validity_end_date": {
+            "name": "validity_end_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Date until which the quotation terms are valid"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who recorded the quotation"
+          }
+        },
+        "comment": "Supplier quotation in response to an RFQ; limited to one quotation per RFQ",
+        "indexes": {},
+        "constraints": {
+          "pk_quotations": {
+            "type": "PRIMARY KEY",
+            "name": "pk_quotations",
+            "columnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_quotations_rfq": {
+            "type": "FOREIGN KEY",
+            "name": "fk_quotations_rfq",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "rfqs",
+            "targetColumnNames": [
+              "rfq_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "quotation_details": {
+        "name": "quotation_details",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Parent RFQ/quotation identifier"
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Reference to the RFQ detail line being quoted"
+          },
+          "quotation_detail_number": {
+            "name": "quotation_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Supplier-provided detail number (not globally unique)"
+          },
+          "proposed_manufacturer_part_number": {
+            "name": "proposed_manufacturer_part_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Item proposed by supplier; if null implies the requested item"
+          },
+          "proposal_reason": {
+            "name": "proposal_reason",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Optional reason the supplier proposes an alternative item"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          }
+        },
+        "comment": "Detailed lines within a supplier quotation; may propose alternative items and link to the RFQ detail",
+        "indexes": {},
+        "constraints": {
+          "pk_quotation_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_quotation_details",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number",
+              "quotation_detail_number"
+            ]
+          },
+          "fk_qd_quotation": {
+            "type": "FOREIGN KEY",
+            "name": "fk_qd_quotation",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "quotations",
+            "targetColumnNames": [
+              "rfq_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_qd_rfq_detail_ref": {
+            "type": "FOREIGN KEY",
+            "name": "fk_qd_rfq_detail_ref",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number"
+            ],
+            "targetTableName": "rfq_details",
+            "targetColumnNames": [
+              "rfq_number",
+              "rfq_detail_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_qd_proposed_item": {
+            "type": "FOREIGN KEY",
+            "name": "fk_qd_proposed_item",
+            "columnNames": [
+              "proposed_manufacturer_part_number"
+            ],
+            "targetTableName": "items",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "SET_NULL"
+          }
+        }
+      },
+      "quotation_conditions": {
+        "name": "quotation_conditions",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Quotation (RFQ) identifier to which this condition applies"
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "RFQ detail number that this condition relates to"
+          },
+          "quotation_detail_number": {
+            "name": "quotation_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Quotation detail that provides this procurement condition"
+          },
+          "condition_sequence": {
+            "name": "condition_sequence",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Sequence number to identify multiple conditions for the same quotation detail"
+          },
+          "unit_price": {
+            "name": "unit_price",
+            "type": "numeric",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Unit price offered under this procurement condition"
+          },
+          "lot_size": {
+            "name": "lot_size",
+            "type": "integer",
+            "default": "1",
+            "check": null,
+            "notNull": true,
+            "comment": "Number of units per lot for pricing and ordering"
+          },
+          "deliverable_date": {
+            "name": "deliverable_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Date supplier can deliver for this condition"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          }
+        },
+        "comment": "One-to-many procurement condition rows per quotation detail describing price and lot terms",
+        "indexes": {},
+        "constraints": {
+          "pk_quotation_conditions": {
+            "type": "PRIMARY KEY",
+            "name": "pk_quotation_conditions",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number",
+              "quotation_detail_number",
+              "condition_sequence"
+            ]
+          },
+          "fk_qc_quotation_detail": {
+            "type": "FOREIGN KEY",
+            "name": "fk_qc_quotation_detail",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number",
+              "quotation_detail_number"
+            ],
+            "targetTableName": "quotation_details",
+            "targetColumnNames": [
+              "rfq_number",
+              "rfq_detail_number",
+              "quotation_detail_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          }
+        }
+      },
+      "purchase_orders": {
+        "name": "purchase_orders",
+        "columns": {
+          "purchase_order_number": {
+            "name": "purchase_order_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique purchase order number grouping order details for a single supplier"
+          },
+          "supplier_business_partner_code": {
+            "name": "supplier_business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Supplier for the entire PO header"
+          },
+          "order_date": {
+            "name": "order_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date the purchase order was issued"
+          },
+          "total_amount": {
+            "name": "total_amount",
+            "type": "numeric",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Derived total amount for the PO header, sum of line amounts"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the PO"
+          }
+        },
+        "comment": "Purchase order header grouping multiple order details for one supplier across projects",
+        "indexes": {},
+        "constraints": {
+          "pk_purchase_orders": {
+            "type": "PRIMARY KEY",
+            "name": "pk_purchase_orders",
+            "columnNames": [
+              "purchase_order_number"
+            ]
+          },
+          "fk_po_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_po_supplier",
+            "columnNames": [
+              "supplier_business_partner_code"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "purchase_order_details": {
+        "name": "purchase_order_details",
+        "columns": {
+          "purchase_order_number": {
+            "name": "purchase_order_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "PO header this detail belongs to"
+          },
+          "line_number": {
+            "name": "line_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Line number within the purchase order"
+          },
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "RFQ identifier that originated the requirement"
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "RFQ detail line referenced"
+          },
+          "quotation_detail_number": {
+            "name": "quotation_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Quotation detail number selected"
+          },
+          "condition_sequence": {
+            "name": "condition_sequence",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Quotation condition sequence chosen for ordering"
+          },
+          "specified_delivery_date": {
+            "name": "specified_delivery_date",
+            "type": "date",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Delivery date specified on the PO line"
+          },
+          "number_of_lots": {
+            "name": "number_of_lots",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Number of lots ordered for this line"
+          },
+          "ordered_units": {
+            "name": "ordered_units",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Computed ordered units = number_of_lots * lot_size (from quotation_conditions)"
+          },
+          "unit_price": {
+            "name": "unit_price",
+            "type": "numeric",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Unit price copied from selected quotation condition"
+          },
+          "line_amount": {
+            "name": "line_amount",
+            "type": "numeric",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Computed line amount = ordered_units * unit_price"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who created the PO detail"
+          }
+        },
+        "comment": "PO detail lines referencing a selected quotation condition; all lines in a PO must reference the PO's supplier via the quotation selected",
+        "indexes": {},
+        "constraints": {
+          "pk_po_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_po_details",
+            "columnNames": [
+              "purchase_order_number",
+              "line_number"
+            ]
+          },
+          "fk_pod_po": {
+            "type": "FOREIGN KEY",
+            "name": "fk_pod_po",
+            "columnNames": [
+              "purchase_order_number"
+            ],
+            "targetTableName": "purchase_orders",
+            "targetColumnNames": [
+              "purchase_order_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_pod_quotation_condition": {
+            "type": "FOREIGN KEY",
+            "name": "fk_pod_quotation_condition",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number",
+              "quotation_detail_number",
+              "condition_sequence"
+            ],
+            "targetTableName": "quotation_conditions",
+            "targetColumnNames": [
+              "rfq_number",
+              "rfq_detail_number",
+              "quotation_detail_number",
+              "condition_sequence"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "fk_pod_rfq_detail": {
+            "type": "FOREIGN KEY",
+            "name": "fk_pod_rfq_detail",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number"
+            ],
+            "targetTableName": "rfq_details",
+            "targetColumnNames": [
+              "rfq_number",
+              "rfq_detail_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "receipts": {
+        "name": "receipts",
+        "columns": {
+          "receipt_number": {
+            "name": "receipt_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Unique receipt identifier representing a physical receipt event"
+          },
+          "receipt_date": {
+            "name": "receipt_date",
+            "type": "date",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Date goods were received"
+          },
+          "supplier_business_partner_code": {
+            "name": "supplier_business_partner_code",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Supplier associated with the receipt, matching the PO supplier"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who recorded the receipt"
+          }
+        },
+        "comment": "Receipt header linked to supplier and purchase order details; supplier derived from PO details",
+        "indexes": {},
+        "constraints": {
+          "pk_receipts": {
+            "type": "PRIMARY KEY",
+            "name": "pk_receipts",
+            "columnNames": [
+              "receipt_number"
+            ]
+          },
+          "fk_receipts_supplier": {
+            "type": "FOREIGN KEY",
+            "name": "fk_receipts_supplier",
+            "columnNames": [
+              "supplier_business_partner_code"
+            ],
+            "targetTableName": "suppliers",
+            "targetColumnNames": [
+              "business_partner_code"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          }
+        }
+      },
+      "receipt_details": {
+        "name": "receipt_details",
+        "columns": {
+          "receipt_number": {
+            "name": "receipt_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Receipt header identifier"
+          },
+          "receipt_detail_number": {
+            "name": "receipt_detail_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "Detail line within the receipt used for package labeling"
+          },
+          "purchase_order_number": {
+            "name": "purchase_order_number",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "PO number that the received line corresponds to"
+          },
+          "purchase_order_line_number": {
+            "name": "purchase_order_line_number",
+            "type": "integer",
+            "default": null,
+            "check": null,
+            "notNull": true,
+            "comment": "PO line number that was received (one-to-one mapping required)"
+          },
+          "received_units": {
+            "name": "received_units",
+            "type": "integer",
+            "default": "0",
+            "check": null,
+            "notNull": true,
+            "comment": "Quantity received in units; normally equals ordered_units but exceptions allowed per business rule"
+          },
+          "label": {
+            "name": "label",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "Traceability label combining receipt_number and receipt_detail_number for packages"
+          },
+          "created_at": {
+            "name": "created_at",
+            "type": "timestamp",
+            "default": "now()",
+            "check": null,
+            "notNull": true,
+            "comment": "Creation timestamp for audit"
+          },
+          "created_by": {
+            "name": "created_by",
+            "type": "text",
+            "default": null,
+            "check": null,
+            "notNull": false,
+            "comment": "User who recorded the receipt detail"
+          }
+        },
+        "comment": "Receipt details referencing exactly one purchase order detail; prevents split deliveries by enforcing one-to-one mapping",
+        "indexes": {},
+        "constraints": {
+          "pk_receipt_details": {
+            "type": "PRIMARY KEY",
+            "name": "pk_receipt_details",
+            "columnNames": [
+              "receipt_number",
+              "receipt_detail_number"
+            ]
+          },
+          "fk_rd_receipt": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rd_receipt",
+            "columnNames": [
+              "receipt_number"
+            ],
+            "targetTableName": "receipts",
+            "targetColumnNames": [
+              "receipt_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "CASCADE"
+          },
+          "fk_rd_po_detail": {
+            "type": "FOREIGN KEY",
+            "name": "fk_rd_po_detail",
+            "columnNames": [
+              "purchase_order_number",
+              "purchase_order_line_number"
+            ],
+            "targetTableName": "purchase_order_details",
+            "targetColumnNames": [
+              "purchase_order_number",
+              "line_number"
+            ],
+            "updateConstraint": "NO_ACTION",
+            "deleteConstraint": "RESTRICT"
+          },
+          "uq_po_detail_one_receipt_map": {
+            "type": "UNIQUE",
+            "name": "uq_po_detail_one_receipt_map",
+            "columnNames": [
+              "purchase_order_number",
+              "purchase_order_line_number"
+            ]
+          }
+        }
+      }
+    },
+    "enums": {},
+    "extensions": {}
+}

--- a/pm-testcases-case-001.json
+++ b/pm-testcases-case-001.json
@@ -1,0 +1,1493 @@
+{
+    "enums": {},
+    "tables": {
+      "item": {
+        "name": "item",
+        "columns": {
+          "brand_code": {
+            "name": "brand_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK brand.brand_code",
+            "default": null,
+            "notNull": true
+          },
+          "item_category_code": {
+            "name": "item_category_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK item_category.item_category_code",
+            "default": null,
+            "notNull": true
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Manufacturer part number PK",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Electronic components",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_item",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_item_cat": {
+            "name": "fk_item_cat",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "item_category_code"
+            ],
+            "targetTableName": "item_category",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "item_category_code"
+            ]
+          },
+          "fk_item_brand": {
+            "name": "fk_item_brand",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "brand_code"
+            ],
+            "targetTableName": "brand",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "brand_code"
+            ]
+          }
+        }
+      },
+      "brand": {
+        "name": "brand",
+        "columns": {
+          "brand_code": {
+            "name": "brand_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "brand_name": {
+            "name": "brand_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Name",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Component brands",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_brand",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "brand_code"
+            ]
+          },
+          "unique_brand_name": {
+            "name": "unique_brand_name",
+            "type": "UNIQUE",
+            "columnNames": [
+              "brand_name"
+            ]
+          }
+        }
+      },
+      "model": {
+        "name": "model",
+        "columns": {
+          "model_name": {
+            "name": "model_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Model identifier",
+            "default": null,
+            "notNull": true
+          },
+          "production_quantity": {
+            "name": "production_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Quantity",
+            "default": null,
+            "notNull": true
+          },
+          "design_drawing_number": {
+            "name": "design_drawing_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Design drawing",
+            "default": null,
+            "notNull": true
+          },
+          "client_req_delivery_date": {
+            "name": "client_req_delivery_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Requested date",
+            "default": null,
+            "notNull": true
+          },
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK prototype_project.prototype_project_number",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Models in prototype projects",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_model",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "prototype_project_number",
+              "model_name"
+            ]
+          },
+          "fk_model_prototype_project": {
+            "name": "fk_model_prototype_project",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "prototype_project",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ]
+          }
+        }
+      },
+      "client": {
+        "name": "client",
+        "columns": {
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK/FK business_partner.business_partner_code",
+            "default": null,
+            "notNull": true
+          },
+          "order_amount_last_year": {
+            "name": "order_amount_last_year",
+            "type": "DECIMAL",
+            "check": null,
+            "comment": "Total orders",
+            "default": 0,
+            "notNull": true
+          }
+        },
+        "comment": "Client-specific",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_client",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          },
+          "fk_client_business_partner": {
+            "name": "fk_client_business_partner",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "business_partner",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "business_partner_code"
+            ]
+          }
+        }
+      },
+      "receipt": {
+        "name": "receipt",
+        "columns": {
+          "receipt_date": {
+            "name": "receipt_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Date received",
+            "default": null,
+            "notNull": true
+          },
+          "receipt_number": {
+            "name": "receipt_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Receipts from suppliers",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_receipt",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "receipt_number"
+            ]
+          }
+        }
+      },
+      "employee": {
+        "name": "employee",
+        "columns": {
+          "employee_code": {
+            "name": "employee_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "employee_name": {
+            "name": "employee_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Employee name",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Employees",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_employee",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "employee_code"
+            ]
+          }
+        }
+      },
+      "position": {
+        "name": "position",
+        "columns": {
+          "position_code": {
+            "name": "position_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "position_name": {
+            "name": "position_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Unique",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Job positions",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_position",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "position_code"
+            ]
+          },
+          "unique_position_name": {
+            "name": "unique_position_name",
+            "type": "UNIQUE",
+            "columnNames": [
+              "position_name"
+            ]
+          }
+        }
+      },
+      "supplier": {
+        "name": "supplier",
+        "columns": {
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK/FK business_partner.business_partner_code",
+            "default": null,
+            "notNull": true
+          },
+          "procurement_amount_last_year": {
+            "name": "procurement_amount_last_year",
+            "type": "DECIMAL",
+            "check": null,
+            "comment": "Total procured",
+            "default": 0,
+            "notNull": true
+          }
+        },
+        "comment": "Supplier-specific",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_supplier",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          },
+          "fk_supplier_business_partner": {
+            "name": "fk_supplier_business_partner",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "business_partner",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "business_partner_code"
+            ]
+          }
+        }
+      },
+      "quotation": {
+        "name": "quotation",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK rfq.rfq_number",
+            "default": null,
+            "notNull": true
+          },
+          "quotation_date": {
+            "name": "quotation_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Date received",
+            "default": null,
+            "notNull": true
+          },
+          "quotation_number": {
+            "name": "quotation_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Supplier's ref",
+            "default": null,
+            "notNull": true
+          },
+          "quotation_validity_period": {
+            "name": "quotation_validity_period",
+            "type": "INT",
+            "check": null,
+            "comment": "Days valid",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Supplier's quotation responses",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_quotation",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_q_rfq": {
+            "name": "fk_q_rfq",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "request_for_quotation",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "rfq_number"
+            ]
+          }
+        }
+      },
+      "model_item": {
+        "name": "model_item",
+        "columns": {
+          "model_name": {
+            "name": "model_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK model.model_name",
+            "default": null,
+            "notNull": true
+          },
+          "req_quantity_per_unit": {
+            "name": "req_quantity_per_unit",
+            "type": "INT",
+            "check": null,
+            "comment": "Per unit",
+            "default": null,
+            "notNull": true
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK item.manufacturer_part_number",
+            "default": null,
+            "notNull": true
+          },
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK model.prototype_project_number",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Items per model",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_model_item",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "prototype_project_number",
+              "model_name",
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_mi_item": {
+            "name": "fk_mi_item",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "item",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_mi_model": {
+            "name": "fk_mi_model",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "model",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ]
+          },
+          "fk_mi_model2": {
+            "name": "fk_mi_model2",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "model_name"
+            ],
+            "targetTableName": "model",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "model_name"
+            ]
+          }
+        }
+      },
+      "rfq_detail": {
+        "name": "rfq_detail",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK rfq.rfq_number",
+            "default": null,
+            "notNull": true
+          },
+          "req_quantity": {
+            "name": "req_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Quantity needed",
+            "default": null,
+            "notNull": true
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "Sequence",
+            "default": null,
+            "notNull": true
+          },
+          "desired_delivery_date": {
+            "name": "desired_delivery_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Date",
+            "default": null,
+            "notNull": true
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Item FK",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Items in each RFQ",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_rfq_detail",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "rfq_number",
+              "rfq_detail_number"
+            ]
+          },
+          "fk_rd_rfq": {
+            "name": "fk_rd_rfq",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "request_for_quotation",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_rd_item": {
+            "name": "fk_rd_item",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "item",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ]
+          }
+        }
+      },
+      "organization": {
+        "name": "organization",
+        "columns": {
+          "organization_code": {
+            "name": "organization_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "organization_name": {
+            "name": "organization_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Unique",
+            "default": null,
+            "notNull": true
+          },
+          "parent_organization_code": {
+            "name": "parent_organization_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK to organization.organization_code",
+            "default": null,
+            "notNull": false
+          }
+        },
+        "comment": "Hierarchical organizations",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_organization",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "organization_code"
+            ]
+          },
+          "fk_parent_org": {
+            "name": "fk_organization_parent",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "parent_organization_code"
+            ],
+            "targetTableName": "organization",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "organization_code"
+            ]
+          },
+          "unique_organization_name": {
+            "name": "unique_organization_name",
+            "type": "UNIQUE",
+            "columnNames": [
+              "organization_name"
+            ]
+          }
+        }
+      },
+      "handled_brand": {
+        "name": "handled_brand",
+        "columns": {
+          "brand_code": {
+            "name": "brand_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK brand.brand_code",
+            "default": null,
+            "notNull": true
+          },
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK supplier.business_partner_code",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Which brands suppliers handle",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_handled_brand",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "business_partner_code",
+              "brand_code"
+            ]
+          },
+          "fk_hb_brand": {
+            "name": "fk_hb_brand",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "brand_code"
+            ],
+            "targetTableName": "brand",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "brand_code"
+            ]
+          },
+          "fk_hb_supplier": {
+            "name": "fk_hb_supplier",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "supplier",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "business_partner_code"
+            ]
+          }
+        }
+      },
+      "item_category": {
+        "name": "item_category",
+        "columns": {
+          "item_category_code": {
+            "name": "item_category_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "item_category_name": {
+            "name": "item_category_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Name",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "item categories",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_item_cat",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "item_category_code"
+            ]
+          }
+        }
+      },
+      "purchase_order": {
+        "name": "purchase_order",
+        "columns": {
+          "total_amount": {
+            "name": "total_amount",
+            "type": "DECIMAL",
+            "check": null,
+            "comment": "Sum of details",
+            "default": 0,
+            "notNull": true
+          },
+          "purchase_order_date": {
+            "name": "purchase_order_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Issue date",
+            "default": null,
+            "notNull": true
+          },
+          "purchase_order_number": {
+            "name": "purchase_order_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Purchase orders",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_purchase_order",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "purchase_order_number"
+            ]
+          }
+        }
+      },
+      "receipt_detail": {
+        "name": "receipt_detail",
+        "columns": {
+          "receipt_number": {
+            "name": "receipt_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK receipt.receipt_number",
+            "default": null,
+            "notNull": true
+          },
+          "purchase_order_number": {
+            "name": "purchase_order_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK to PO",
+            "default": null,
+            "notNull": true
+          },
+          "receipt_detail_number": {
+            "name": "receipt_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "Seq within receipt",
+            "default": null,
+            "notNull": true
+          },
+          "delivered_lot_quantity": {
+            "name": "delivered_lot_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Lots delivered",
+            "default": null,
+            "notNull": true
+          },
+          "purchase_order_detail_number": {
+            "name": "purchase_order_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "FK to PO detail",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Details of items received, partial allowed",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_receipt_detail",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "receipt_number",
+              "receipt_detail_number"
+            ]
+          },
+          "fk_rd_pod": {
+            "name": "fk_rd_pod",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "purchase_order_detail_number"
+            ],
+            "targetTableName": "purchase_order_detail",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "purchase_order_detail_number"
+            ]
+          },
+          "fk_rd_receipt": {
+            "name": "fk_rd_rcpt",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "receipt_number"
+            ],
+            "targetTableName": "receipt",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "receipt_number"
+            ]
+          },
+          "fk_rd_purchase_order": {
+            "name": "fk_rd_purchase_order",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "purchase_order_number"
+            ],
+            "targetTableName": "purchase_order",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "purchase_order_number"
+            ]
+          }
+        }
+      },
+      "business_partner": {
+        "name": "business_partner",
+        "columns": {
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "business_partner_name": {
+            "name": "business_partner_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Name",
+            "default": null,
+            "notNull": true
+          },
+          "business_partner_address": {
+            "name": "business_partner_address",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Address",
+            "default": null,
+            "notNull": true
+          },
+          "business_partner_category": {
+            "name": "business_partner_category",
+            "type": "VARCHAR",
+            "check": "IN ('CLIENT','SUPPLIER')",
+            "comment": "CLIENT or SUPPLIER",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Clients and suppliers",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_business_partner",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "business_partner_code"
+            ]
+          }
+        }
+      },
+      "quotation_detail": {
+        "name": "quotation_detail",
+        "columns": {
+          "lot_size": {
+            "name": "lot_size",
+            "type": "INT",
+            "check": null,
+            "comment": "Units per lot",
+            "default": null,
+            "notNull": true
+          },
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK quotation.rfq_number",
+            "default": null,
+            "notNull": true
+          },
+          "unit_price": {
+            "name": "unit_price",
+            "type": "DECIMAL",
+            "check": null,
+            "comment": "Price per unit",
+            "default": null,
+            "notNull": true
+          },
+          "proposal_reason": {
+            "name": "proposal_reason",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "If alternate proposed",
+            "default": null,
+            "notNull": false
+          },
+          "deliverable_date": {
+            "name": "deliverable_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Date",
+            "default": null,
+            "notNull": true
+          },
+          "rfq_detail_number": {
+            "name": "rfq_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "FK rfq_detail.rfq_detail_number",
+            "default": null,
+            "notNull": true
+          },
+          "quotation_detail_number": {
+            "name": "quotation_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "Supplier seq no",
+            "default": null,
+            "notNull": true
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Proposed item",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Line items in quotations",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_quote_detail",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "rfq_number",
+              "quotation_detail_number"
+            ]
+          },
+          "fk_qd_item": {
+            "name": "fk_qd_item",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "item",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_qd_quote": {
+            "name": "fk_qd_quote",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "quotation",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_qd_rfq_detail": {
+            "name": "fk_qd_rd",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "rfq_detail_number"
+            ],
+            "targetTableName": "rfq_detail",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "rfq_detail_number"
+            ]
+          }
+        }
+      },
+      "prototype_project": {
+        "name": "prototype_project",
+        "columns": {
+          "product_purpose": {
+            "name": "product_purpose",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Shared to suppliers",
+            "default": null,
+            "notNull": true
+          },
+          "registration_date": {
+            "name": "registration_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Registration date",
+            "default": null,
+            "notNull": true
+          },
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Client FK",
+            "default": null,
+            "notNull": true
+          },
+          "prototype_project_name": {
+            "name": "prototype_project_name",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Project name",
+            "default": null,
+            "notNull": true
+          },
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Prototype projects",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_prototype_project",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "prototype_project_number"
+            ]
+          },
+          "fk_prototype_project_client": {
+            "name": "fk_prototype_project_client",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "client",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "business_partner_code"
+            ]
+          }
+        }
+      },
+      "employee_affiliation": {
+        "name": "employee_affiliation",
+        "columns": {
+          "employee_code": {
+            "name": "employee_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK employee.employee_code",
+            "default": null,
+            "notNull": true
+          },
+          "position_code": {
+            "name": "position_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Optional FK position.position_code",
+            "default": null,
+            "notNull": false
+          },
+          "organization_code": {
+            "name": "organization_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK organization.organization_code",
+            "default": null,
+            "notNull": true
+          },
+          "reporting_employee_code": {
+            "name": "reporting_employee_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Optional FK to employee.employee_code",
+            "default": null,
+            "notNull": false
+          }
+        },
+        "comment": "Link employees with organizations, positions, and reporting relationships",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_emp_aff",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "employee_code",
+              "organization_code"
+            ]
+          },
+          "fk_emp_aff_emp": {
+            "name": "fk_ea_emp",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "employee_code"
+            ],
+            "targetTableName": "employee",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "employee_code"
+            ]
+          },
+          "fk_emp_aff_org": {
+            "name": "fk_ea_org",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "organization_code"
+            ],
+            "targetTableName": "organization",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "organization_code"
+            ]
+          },
+          "fk_emp_aff_pos": {
+            "name": "fk_ea_pos",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "position_code"
+            ],
+            "targetTableName": "position",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "position_code"
+            ]
+          },
+          "fk_emp_aff_report": {
+            "name": "fk_ea_report",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "reporting_employee_code"
+            ],
+            "targetTableName": "employee",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "employee_code"
+            ]
+          }
+        }
+      },
+      "purchase_order_detail": {
+        "name": "purchase_order_detail",
+        "columns": {
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "From which RFQ",
+            "default": null,
+            "notNull": true
+          },
+          "order_lot_quantity": {
+            "name": "order_lot_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Lots ordered",
+            "default": null,
+            "notNull": true
+          },
+          "purchase_order_number": {
+            "name": "purchase_order_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK purchase_order.purchase_order_number",
+            "default": null,
+            "notNull": true
+          },
+          "quotation_detail_number": {
+            "name": "quotation_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "Selected detail",
+            "default": null,
+            "notNull": true
+          },
+          "specified_delivery_date": {
+            "name": "specified_delivery_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "Planned delivery",
+            "default": null,
+            "notNull": true
+          },
+          "purchase_order_detail_number": {
+            "name": "purchase_order_detail_number",
+            "type": "INT",
+            "check": null,
+            "comment": "Seq within PO",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Line items in POs, supports partial deliveries",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_purchase_order_detail",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "purchase_order_number",
+              "purchase_order_detail_number"
+            ]
+          },
+          "fk_pod_quote": {
+            "name": "fk_pod_q",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "rfq_number"
+            ],
+            "targetTableName": "quotation",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_pod_quote3": {
+            "name": "fk_pod_q3",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "quotation_detail_number"
+            ],
+            "targetTableName": "quotation_detail",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "quotation_detail_number"
+            ]
+          },
+          "fk_pod_purchase_order": {
+            "name": "fk_pod_purchase_order",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "purchase_order_number"
+            ],
+            "targetTableName": "purchase_order",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "purchase_order_number"
+            ]
+          }
+        }
+      },
+      "request_for_quotation": {
+        "name": "request_for_quotation",
+        "columns": {
+          "rfq_date": {
+            "name": "rfq_date",
+            "type": "DATE",
+            "check": null,
+            "comment": "RFQ date",
+            "default": null,
+            "notNull": true
+          },
+          "rfq_number": {
+            "name": "rfq_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "PK",
+            "default": null,
+            "notNull": true
+          },
+          "business_partner_code": {
+            "name": "business_partner_code",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK business_partner_code",
+            "default": null,
+            "notNull": true
+          },
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "Project FK",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Requests for quotation",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_rfq",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "rfq_number"
+            ]
+          },
+          "fk_business_partner_code": {
+            "name": "fk_business_partner_code",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "business_partner_code"
+            ],
+            "targetTableName": "business_partner",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "business_partner_code"
+            ]
+          },
+          "fk_rfq_prototype_project": {
+            "name": "fk_rfq_prototype_project",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "prototype_project",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ]
+          }
+        }
+      },
+      "prototype_project_item": {
+        "name": "prototype_project_item",
+        "columns": {
+          "total_req_quantity": {
+            "name": "total_req_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Total needed",
+            "default": null,
+            "notNull": true
+          },
+          "client_provided_quantity": {
+            "name": "client_provided_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Provided by client",
+            "default": 0,
+            "notNull": true
+          },
+          "manufacturer_part_number": {
+            "name": "manufacturer_part_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK item.manufacturer_part_number",
+            "default": null,
+            "notNull": true
+          },
+          "prototype_project_number": {
+            "name": "prototype_project_number",
+            "type": "VARCHAR",
+            "check": null,
+            "comment": "FK prototype_project.prototype_project_number",
+            "default": null,
+            "notNull": true
+          },
+          "req_procurement_quantity": {
+            "name": "req_procurement_quantity",
+            "type": "INT",
+            "check": null,
+            "comment": "Computed",
+            "default": null,
+            "notNull": true
+          }
+        },
+        "comment": "Overall project item needs",
+        "indexes": {},
+        "constraints": {
+          "pk": {
+            "name": "pk_prototype_project_item",
+            "type": "PRIMARY KEY",
+            "columnNames": [
+              "prototype_project_number",
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_ppi_item": {
+            "name": "fk_ppi_item",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "manufacturer_part_number"
+            ],
+            "targetTableName": "item",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "manufacturer_part_number"
+            ]
+          },
+          "fk_ppi_prototype_project": {
+            "name": "fk_ppi_prototype_project",
+            "type": "FOREIGN KEY",
+            "columnNames": [
+              "prototype_project_number"
+            ],
+            "targetTableName": "prototype_project",
+            "deleteConstraint": "NO_ACTION",
+            "updateConstraint": "NO_ACTION",
+            "targetColumnNames": [
+              "prototype_project_number"
+            ]
+          }
+        }
+      }
+    },
+    "extensions": {}
+}


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?

Add a new `/erd/demo/[...slug]` route that displays pre-parsed schema JSON from GitHub URLs. 

Unlike `/erd/p` which parses raw schema files (SQL, Prisma, etc.), `/erd/demo` expects JSON that already matches the `Schema` type and validates it using valibot's `schemaSchema`.

## Summary

- Add `/erd/demo/[...slug]` page component
- Fetch JSON from GitHub URLs (converts blob URLs to raw URLs automatically)
- Validate JSON against `schemaSchema` using valibot
- Error handling for network failures, JSON parsing errors, and schema validation failures
- Reuse `ERDViewer` component from `/erd/p` route

## Test plan

- [ ] Visit `/erd/demo/[github-url-to-schema-json]` and verify ERD is displayed
- [ ] Test with invalid JSON and verify error handling
- [ ] Test with invalid schema format and verify validation error
- [ ] Test with network failures and verify error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an ERD Demo page that loads JSON schemas from shared URLs and renders them in an ERD viewer.
  - Improved validation and clear error messaging for network, parsing, and schema issues.
  - Enhanced share previews with dynamic titles and images.
  - Remembers sidebar visibility and panel sizes via cookies.

- Tests
  - Added comprehensive schema datasets to support rich demo scenarios and end-to-end test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->