### PR TITLE
🐛(artifact): Fix schema validation error by replacing isoDateTime with isoTimestamp

### DIFF
--- a/frontend/internal-packages/artifact/src/schemas/artifact.ts
+++ b/frontend/internal-packages/artifact/src/schemas/artifact.ts
@@ -2,7 +2,7 @@ import * as v from 'valibot'
 
 // Test result schema
 const testResultSchema = v.object({
-  executedAt: v.pipe(v.string(), v.isoDateTime()),
+  executedAt: v.pipe(v.string(), v.isoTimestamp()),
   success: v.boolean(),
   message: v.string(),
 })


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

The `executedAt` field in the artifact schema was using `isoDateTime()` validator, which doesn't match the actual timestamp format being passed (e.g., "2025-10-07T02:45:58.865Z"). This caused `safeParse` to fail during the QA Agent phase when artifacts were updated.

The issue occurred because:
- Valibot's `isoDateTime()` expects date-time format without milliseconds
- The actual data includes milliseconds (e.g., `.865Z`)
- `isoTimestamp()` is the correct validator for ISO 8601 timestamps with milliseconds

This change replaces `isoDateTime()` with `isoTimestamp()` to properly validate the timestamp format.

## Demo

<img width="1524" height="986" alt="image" src="https://github.com/user-attachments/assets/2c9e672f-3657-487a-9560-15761d03b6f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized the test execution time field to use a strict ISO timestamp format. This improves consistency across test result data, reducing ambiguity in time parsing and display.
  - Downstream consumers (UI, API clients, and integrations) should expect the updated timestamp format for executed test results.
  - No other fields or behaviors were changed; validation and error handling remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->