### PR TITLE
Replace hardcoded userName with actual user data in chat messages

### DIFF
--- a/frontend/apps/app/components/PublicSessionDetailPage/PublicSessionDetailPage.tsx
+++ b/frontend/apps/app/components/PublicSessionDetailPage/PublicSessionDetailPage.tsx
@@ -135,6 +135,7 @@ export const PublicSessionDetailPage = async ({
           isDeepModelingEnabled={false}
           initialIsPublic={true}
           initialArtifact={initialArtifact}
+          userName="Guest"
         />
       </ViewModeProvider>
     </PublicLayout>

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPage.tsx
@@ -38,6 +38,7 @@ async function loadSessionData(designSessionId: string): Promise<
       initialSchema: Schema
       initialArtifact: Artifact | null
       workflowError: string | null
+      userName: string
     },
     Error
   >
@@ -58,6 +59,21 @@ async function loadSessionData(designSessionId: string): Promise<
   }
   const baseMessages = await getMessages(config)
   const messages = serializeMessages(baseMessages)
+
+  const { data: userData } = await supabase.auth.getUser()
+  const userId = userData?.user?.id
+
+  const userName = await (async () => {
+    if (!userId) return 'User'
+
+    const { data: userInfo } = await supabase
+      .from('users')
+      .select('name')
+      .eq('id', userId)
+      .single()
+
+    return userInfo?.name || 'User'
+  })()
 
   // Fetch checkpoint error from LangGraph memory
   const checkpointErrors = await getCheckpointErrors(
@@ -96,6 +112,7 @@ async function loadSessionData(designSessionId: string): Promise<
     initialSchema,
     initialArtifact,
     workflowError,
+    userName,
   })
 }
 
@@ -115,6 +132,7 @@ export const SessionDetailPage: FC<Props> = async ({
     initialSchema,
     workflowError,
     initialArtifact,
+    userName,
   } = result.value
 
   const versions = await getVersions(buildingSchema.id)
@@ -143,6 +161,7 @@ export const SessionDetailPage: FC<Props> = async ({
         isDeepModelingEnabled={isDeepModelingEnabled}
         initialIsPublic={initialIsPublic}
         initialWorkflowError={workflowError}
+        userName={userName}
       />
     </ViewModeProvider>
   )

--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -30,6 +30,7 @@ type Props = {
   initialIsPublic: boolean
   initialWorkflowError?: string | null
   initialArtifact: Artifact | null
+  userName: string
 }
 
 // Determine the initial active tab based on available data
@@ -68,6 +69,7 @@ export const SessionDetailPageClient: FC<Props> = ({
   initialIsPublic,
   initialWorkflowError,
   initialArtifact,
+  userName,
 }) => {
   const [activeTab, setActiveTab] = useState<OutputTabValue | undefined>(
     determineInitialTab(initialArtifact, initialVersions),
@@ -117,6 +119,7 @@ export const SessionDetailPageClient: FC<Props> = ({
   const { isStreaming, messages, start, error } = useStream({
     initialMessages: chatMessages,
     designSessionId,
+    userName,
   })
 
   // Combine streaming error with workflow errors

--- a/frontend/apps/app/components/SessionDetailPage/hooks/useStream/useStream.ts
+++ b/frontend/apps/app/components/SessionDetailPage/hooks/useStream/useStream.ts
@@ -59,8 +59,13 @@ const extractStreamErrorMessage = (rawData: unknown): string => {
 type Props = {
   designSessionId: string
   initialMessages: BaseMessage[]
+  userName: string
 }
-export const useStream = ({ designSessionId, initialMessages }: Props) => {
+export const useStream = ({
+  designSessionId,
+  initialMessages,
+  userName,
+}: Props) => {
   const messageManagerRef = useRef(new MessageTupleManager())
   const storedMessage = useSessionStorageOnce(designSessionId)
   const processedInitialMessages = useMemo(() => {
@@ -266,7 +271,7 @@ export const useStream = ({ designSessionId, initialMessages }: Props) => {
         content: params.userInput,
         id: tempId,
         additional_kwargs: {
-          userName: 'Dummy',
+          userName: userName,
         },
       })
       setMessages((prev) => [...prev, optimisticMessage])
@@ -287,7 +292,7 @@ export const useStream = ({ designSessionId, initialMessages }: Props) => {
         isDeepModelingEnabled: params.isDeepModelingEnabled,
       })
     },
-    [replay, runStreamAttempt],
+    [replay, runStreamAttempt, userName],
   )
 
   return {


### PR DESCRIPTION
## Issue

No specific issue, improvement task

## Why is this change needed?

Currently, when users send messages in a design session, the `userName` in the optimistic HumanMessage is hardcoded as 'Dummy'. This change replaces the hardcoded value with the actual user's name fetched from Supabase.

## Changes

- **SessionDetailPage.tsx**: Fetch userName from Supabase using `auth.getUser()` and query the `users` table
- **SessionDetailPageClient.tsx**: Pass userName as a prop to useStream hook
- **useStream.ts**: Use the actual userName prop instead of hardcoded 'Dummy' in optimistic message creation
- **PublicSessionDetailPage.tsx**: Add userName prop with 'Guest' as the default value for public sessions

## Implementation Details

The userName is:
- Fetched once in the Server Component (SessionDetailPage) for efficiency
- Passed through props to maintain clear data flow: Server Component → Client Component → Hook
- Defaults to 'User' for authenticated users without a name, and 'Guest' for public sessions

This approach aligns with the existing pattern in `sessionCreationHelpers.ts` where new session creation also fetches userName from Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)