### PR TITLE
docs: improve CLAUDE.md monorepo structure documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,6 @@ pnpm --filter @liam-hq/agent test
 - **frontend/internal-packages/db** - Database utilities (`@liam-hq/db`)
 - **frontend/internal-packages/mcp-server** - MCP server implementation (`@liam-hq/mcp-server`)
 
-For LangGraph development, see @docs/langgraph/README.md
 
 ### Key Technologies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,22 @@ pnpm --filter @liam-hq/agent test
 
 ### Monorepo Structure
 
+#### Applications
 - **frontend/apps/app** - Main Next.js web application (`@liam-hq/app`)
 - **frontend/apps/docs** - Documentation site (`@liam-hq/docs`)
+
+#### Public Packages
 - **frontend/packages/cli** - Command-line tool (`@liam-hq/cli`)
 - **frontend/packages/erd-core** - Core ERD visualization (`@liam-hq/erd-core`)
 - **frontend/packages/schema** - Database schema parser (`@liam-hq/schema`)
 - **frontend/packages/ui** - UI component library (`@liam-hq/ui`)
-- **frontend/packages/github** - GitHub API integration (`@liam-hq/github`)
+
+#### Internal Packages
+- **frontend/internal-packages/agent** - AI agent system using LangGraph (`@liam-hq/agent`)
+- **frontend/internal-packages/db** - Database utilities (`@liam-hq/db`)
+- **frontend/internal-packages/mcp-server** - MCP server implementation (`@liam-hq/mcp-server`)
+
+For LangGraph development, see @docs/langgraph/README.md
 
 ### Key Technologies
 


### PR DESCRIPTION
## Issue

- resolve: N/A (documentation improvement)

## Why is this change needed?

The existing CLAUDE.md file had some inconsistencies and missing information:

1. **Missing package documentation**: The `@liam-hq/agent` package was referenced in the App-specific Commands section but wasn't documented in the Monorepo Structure section
2. **Unclear package organization**: No distinction between public packages (in `frontend/packages/`) and internal packages (in `frontend/internal-packages/`)
3. **Missing LangGraph reference**: No pointer to the comprehensive LangGraph documentation in `docs/langgraph/`
4. **Incorrect package listing**: `@liam-hq/github` was listed but doesn't exist in `frontend/packages/`

## Changes Made

- Reorganized Monorepo Structure into three clear sections:
  - Applications (apps)
  - Public Packages (publishable packages)
  - Internal Packages (internal-only packages)
- Added missing `@liam-hq/agent` package documentation
- Added `@liam-hq/db` and `@liam-hq/mcp-server` internal packages
- Added reference to LangGraph documentation for agent development
- Removed non-existent `@liam-hq/github` from the list (it's actually in `internal-packages`, not `packages`)

This improves accuracy and helps developers understand the codebase structure more clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded monorepo structure into clearer subsections for applications, public packages, and internal packages.
  * Updated listed package entries and removed an outdated public package reference to the GitHub integration.
  * Reorganized content for improved clarity, navigation, and readability.
  * No code or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->