### PR TITLE
fix(schema): handle pg_dump meta-commands and UTF-8 byte offsets in PostgreSQL parser

### DIFF
--- a/.changeset/fix-postgres-parser-pg-dump-meta-commands.md
+++ b/.changeset/fix-postgres-parser-pg-dump-meta-commands.md
@@ -1,0 +1,7 @@
+---
+"@liam-hq/schema": patch
+---
+
+- 🐛 Fix PostgreSQL parser to handle pg_dump meta-commands and UTF-8 byte offsets
+  - Sanitize `\restrict` and `\unrestrict` meta-commands from pg_dump 16.10+ by replacing with spaces to preserve byte offsets
+  - Fix UTF-8 byte offset to character index conversion for multibyte characters in chunked SQL processing

--- a/frontend/packages/schema/src/parser/sql/postgresql/parser.test.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/parser.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizePgDumpMetaCommands } from './parser.js'
+
+describe(sanitizePgDumpMetaCommands, () => {
+  it('replaces \\restrict meta commands with spaces without changing length', () => {
+    const sql = '\\restrict token\nCREATE TABLE foo (id integer);\n'
+    const sanitized = sanitizePgDumpMetaCommands(sql)
+
+    expect(sanitized.length).toBe(sql.length)
+    const lines = sanitized.split('\n')
+    const firstLine = lines[0]
+    const secondLine = lines[1]
+    expect(firstLine).toBeDefined()
+    expect(firstLine?.trim()).toBe('')
+    expect(secondLine).toBeDefined()
+    expect(secondLine?.startsWith('CREATE TABLE')).toBe(true)
+  })
+
+  it('replaces \\restrict commands with spaces while preserving carriage returns', () => {
+    const sql = '\\restrict token\r\nCREATE TABLE foo (id integer);\r\n'
+    const sanitized = sanitizePgDumpMetaCommands(sql)
+
+    expect(sanitized.length).toBe(sql.length)
+    const firstLine = sanitized.split('\n')[0]
+    expect(firstLine).toBeDefined()
+    expect(firstLine?.endsWith('\r')).toBe(true)
+    expect(firstLine?.trim()).toBe('')
+  })
+
+  it('replaces \\unrestrict meta commands', () => {
+    const sql = '\\unrestrict token\nSELECT 1;'
+    const sanitized = sanitizePgDumpMetaCommands(sql)
+
+    expect(sanitized.length).toBe(sql.length)
+    const firstLine = sanitized.split('\n')[0]
+    expect(firstLine).toBeDefined()
+    expect(firstLine?.trim()).toBe('')
+  })
+})

--- a/frontend/packages/schema/src/parser/sql/postgresql/processSqlInChunks.test.ts
+++ b/frontend/packages/schema/src/parser/sql/postgresql/processSqlInChunks.test.ts
@@ -52,6 +52,21 @@ describe(processSQLInChunks, () => {
 
       expect(callback).not.toHaveBeenCalled()
     })
+
+    it('should interpret readOffset byte positions for multibyte characters', async () => {
+      // Using Japanese hiragana characters (3 bytes each in UTF-8)
+      const input = 'あいう\nかきく\n' // eslint-disable-line no-non-english/no-non-english-characters
+      const chunkSize = 2
+      const firstLineBytes = Buffer.from('あいう\n').length // eslint-disable-line no-non-english/no-non-english-characters
+      const callback = vi.fn()
+      callback
+        .mockResolvedValueOnce([null, firstLineBytes, []])
+        .mockResolvedValue([null, null, []])
+
+      await processSQLInChunks(input, chunkSize, callback)
+
+      expect(callback).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('processSQLInChunks, partially consuming chunk lines', () => {


### PR DESCRIPTION
## Issue

- resolve: 

## Why is this change needed?

This PR fixes two issues in the PostgreSQL parser:

1. **pg_dump meta-commands handling**: pg_dump 16.10+ emits meta-commands like `\restrict` and `\unrestrict` that are not valid SQL statements for parsing. These caused parsing errors.

2. **UTF-8 byte offset handling**: The parser returns offsets measured in UTF-8 bytes, but the chunking code operates on JS string indices (UTF-16 code units). This caused misalignment when processing SQL with multibyte characters.

## What changes are made?

- Sanitize `\restrict` and `\unrestrict` meta-commands by replacing their contents with spaces while preserving byte offsets
- Implement UTF-8 byte offset to character index conversion for proper chunked SQL processing
- Add comprehensive tests for both fixes

## Test plan

- [ ] Existing tests pass
- [ ] New tests for meta-command sanitization
- [ ] New tests for multibyte character handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved PostgreSQL dump parsing by sanitizing pg_dump meta-commands (restrict/unrestrict), preventing parse errors while preserving offsets.
  - Corrected handling of multibyte UTF-8 characters in chunked SQL processing to ensure accurate byte offsets and line numbers.
  - Increased robustness when processing inputs with mixed line endings (CRLF), preserving carriage returns where expected.
  - Overall, enhances compatibility with newer pg_dump outputs and non-ASCII SQL content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->