### PR TITLE
✨(schema-bench): Migrate to SupabaseRepositories for database persistence

### DIFF
--- a/frontend/internal-packages/schema-bench/README.md
+++ b/frontend/internal-packages/schema-bench/README.md
@@ -170,10 +170,21 @@ benchmark-workspace/
 
 ## Environment Setup
 
-For OpenAI executor, set your API key:
+### Required Environment Variables
+
+For **LiamDB executor**, you need Supabase connection details:
+```bash
+export NEXT_PUBLIC_SUPABASE_URL="your-supabase-url"
+export SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+export OPENAI_API_KEY="your-api-key"  # Also required by LiamDB for AI operations
+```
+
+For **OpenAI executor**, you only need:
 ```bash
 export OPENAI_API_KEY="your-api-key"
 ```
+
+These variables should be set in a `.env` file at the repository root.
 
 ## Example Workflow
 

--- a/frontend/internal-packages/schema-bench/package.json
+++ b/frontend/internal-packages/schema-bench/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@huggingface/transformers": "3.3.3",
     "@liam-hq/agent": "workspace:*",
+    "@liam-hq/db": "workspace:*",
     "@liam-hq/neverthrow": "workspace:*",
     "@liam-hq/schema": "workspace:*",
     "dotenv": "16.5.0",

--- a/frontend/internal-packages/schema-bench/src/executors/liamDb/setupRepositories.ts
+++ b/frontend/internal-packages/schema-bench/src/executors/liamDb/setupRepositories.ts
@@ -1,0 +1,214 @@
+import { createSupabaseRepositories } from '@liam-hq/agent'
+import {
+  createClient,
+  type SupabaseClientType,
+  toResultAsync,
+} from '@liam-hq/db'
+import { err, ok, type Result, type ResultAsync } from 'neverthrow'
+
+type Repositories = ReturnType<typeof createSupabaseRepositories>
+
+type SetupResult = {
+  repositories: Repositories
+  organizationId: string
+  buildingSchemaId: string
+  designSessionId: string
+  userId: string
+}
+
+let cachedSetup: SetupResult | null = null
+
+/**
+ * Create Supabase client
+ */
+const createDatabaseConnection = (): Result<SupabaseClientType, Error> => {
+  const supabaseUrl = process.env['NEXT_PUBLIC_SUPABASE_URL']
+  const supabaseKey = process.env['SUPABASE_SERVICE_ROLE_KEY']
+
+  if (!supabaseUrl || !supabaseKey) {
+    return err(
+      new Error(
+        'Missing required environment variables: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY',
+      ),
+    )
+  }
+
+  const supabaseClient = createClient(supabaseUrl, supabaseKey)
+  return ok(supabaseClient)
+}
+
+/**
+ * Get the first organization from database
+ */
+const getFirstOrganization = (
+  supabaseClient: SupabaseClientType,
+): ResultAsync<{ id: string }, Error> => {
+  return toResultAsync(
+    supabaseClient.from('organizations').select('id').limit(1).single(),
+  )
+}
+
+/**
+ * Get the first user from database
+ */
+const getUser = (
+  supabaseClient: SupabaseClientType,
+): ResultAsync<{ id: string }, Error> => {
+  return toResultAsync(
+    supabaseClient.from('users').select('id').limit(1).single(),
+  )
+}
+
+const getDesignSession = (
+  supabaseClient: SupabaseClientType,
+  organizationId: string,
+): ResultAsync<{ id: string }, Error> => {
+  return toResultAsync(
+    supabaseClient
+      .from('design_sessions')
+      .select('id')
+      .eq('organization_id', organizationId)
+      .limit(1)
+      .single(),
+  )
+}
+
+const createDesignSession = (
+  supabaseClient: SupabaseClientType,
+  organizationId: string,
+  userId: string,
+): ResultAsync<{ id: string }, Error> => {
+  return toResultAsync(
+    supabaseClient
+      .from('design_sessions')
+      .insert({
+        name: 'Schema Benchmark Session',
+        project_id: null,
+        organization_id: organizationId,
+        created_by_user_id: userId,
+        parent_design_session_id: null,
+      })
+      .select('id')
+      .single(),
+  )
+}
+
+/**
+ * Get or create a design session for benchmarking
+ */
+const getOrCreateDesignSession = (
+  supabaseClient: SupabaseClientType,
+  organizationId: string,
+  userId: string,
+): ResultAsync<{ id: string }, Error> => {
+  return getDesignSession(supabaseClient, organizationId).orElse(() =>
+    createDesignSession(supabaseClient, organizationId, userId),
+  )
+}
+
+const getBuildingSchema = (
+  supabaseClient: SupabaseClientType,
+  designSessionId: string,
+): ResultAsync<{ id: string }, Error> => {
+  return toResultAsync(
+    supabaseClient
+      .from('building_schemas')
+      .select('id')
+      .eq('design_session_id', designSessionId)
+      .limit(1)
+      .single(),
+  )
+}
+
+const createBuildingSchema = (
+  supabaseClient: SupabaseClientType,
+  designSessionId: string,
+  organizationId: string,
+): ResultAsync<{ id: string }, Error> => {
+  const initialSchema = { tables: {}, enums: {}, extensions: {} }
+  return toResultAsync(
+    supabaseClient
+      .from('building_schemas')
+      .insert({
+        design_session_id: designSessionId,
+        organization_id: organizationId,
+        schema: structuredClone(initialSchema),
+        initial_schema_snapshot: structuredClone(initialSchema),
+        schema_file_path: null,
+        git_sha: null,
+      })
+      .select('id')
+      .single(),
+  )
+}
+
+/**
+ * Get or create a building schema for the design session
+ */
+const getOrCreateBuildingSchema = (
+  supabaseClient: SupabaseClientType,
+  designSessionId: string,
+  organizationId: string,
+): ResultAsync<{ id: string }, Error> => {
+  return getBuildingSchema(supabaseClient, designSessionId).orElse(() =>
+    createBuildingSchema(supabaseClient, designSessionId, organizationId),
+  )
+}
+
+/**
+ * Setup Supabase repositories for schema benchmark
+ * Uses singleton pattern to reuse connections across benchmark runs
+ */
+export const setupRepositories = async (): Promise<
+  Result<SetupResult, Error>
+> => {
+  // Return cached setup if available
+  if (cachedSetup) {
+    return ok(cachedSetup)
+  }
+
+  // Create database connection
+  const connectionResult = createDatabaseConnection()
+  if (connectionResult.isErr()) {
+    return err(connectionResult.error)
+  }
+  const supabaseClient = connectionResult.value
+
+  return await getFirstOrganization(supabaseClient)
+    .andThen((organization) =>
+      getUser(supabaseClient).andThen((user) =>
+        getOrCreateDesignSession(
+          supabaseClient,
+          organization.id,
+          user.id,
+        ).andThen((designSession) =>
+          getOrCreateBuildingSchema(
+            supabaseClient,
+            designSession.id,
+            organization.id,
+          ).map((buildingSchema) => ({
+            organization,
+            user,
+            designSession,
+            buildingSchema,
+          })),
+        ),
+      ),
+    )
+    .map(({ organization, user, designSession, buildingSchema }) => {
+      const repositories = createSupabaseRepositories(
+        supabaseClient,
+        organization.id,
+      )
+
+      cachedSetup = {
+        repositories,
+        organizationId: organization.id,
+        buildingSchemaId: buildingSchema.id,
+        designSessionId: designSession.id,
+        userId: user.id,
+      }
+
+      return cachedSetup
+    })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         version: link:../../packages/ui
       '@next/third-parties':
         specifier: 15.3.5
-        version: 15.3.5(next@15.4.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 15.3.5(next@15.4.7(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@sentry/nextjs':
         specifier: '9'
         version: 9.46.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.4.7(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(webpack@5.102.0(@swc/core@1.12.11))
@@ -254,7 +254,7 @@ importers:
         version: link:../../packages/ui
       '@next/third-parties':
         specifier: 15.3.5
-        version: 15.3.5(next@15.4.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 15.3.5(next@15.4.7(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@rive-app/react-canvas':
         specifier: 4.23.3
         version: 4.23.3(react@19.1.1)
@@ -675,6 +675,9 @@ importers:
       '@liam-hq/agent':
         specifier: workspace:*
         version: link:../agent
+      '@liam-hq/db':
+        specifier: workspace:*
+        version: link:../db
       '@liam-hq/neverthrow':
         specifier: workspace:*
         version: link:../neverthrow
@@ -13340,7 +13343,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.4.7':
     optional: true
 
-  '@next/third-parties@15.3.5(next@15.4.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+  '@next/third-parties@15.3.5(next@15.4.7(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
     dependencies:
       next: 15.4.7(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
@@ -18796,7 +18799,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.12.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.12.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -21462,7 +21465,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.12.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.12.2):
     dependencies:
       axios: 1.12.2(debug@4.4.3)
 


### PR DESCRIPTION
## Issue

- resolve: #3738

## Why is this change needed?

This change replaces the InMemoryRepository with SupabaseRepositories in the schema-bench package to enable:

- Real database persistence of workflow states and checkpoints
- Consistency with integration tests and production environment
- Proper checkpoint isolation using designSessionId as thread_id

The InMemoryRepository was suitable for initial development but didn't persist data across executions, making it unsuitable for benchmark testing that requires data consistency and reproducibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled LiamDB-backed workflows using a persistent database instead of in-memory data, with automatic setup of required org, user, session, and schema.
- Documentation
  - Added a “Required Environment Variables” section with clear guidance on necessary keys and .env placement.
  - Clarified OpenAI-related configuration within the new environment section.
- Chores
  - Added a new workspace dependency to support the database-backed integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->