### PR TITLE
💄 style(command palette): fix column option indent indicator

### DIFF
--- a/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteOptions/CommandPaletteOptions.module.css
+++ b/frontend/packages/erd-core/src/features/erd/components/ERDRenderer/CommandPalette/CommandPaletteOptions/CommandPaletteOptions.module.css
@@ -14,10 +14,10 @@
 .item.indent:before {
   content: '';
   position: absolute;
-  top: calc(var(--spacing-1) / 2);
+  top: 0;
   left: var(--spacing-4);
   width: 1px;
-  height: calc(100% - var(--spacing-1));
+  height: 100%;
   background-color: var(--overlay-10);
 }
 


### PR DESCRIPTION
## Issue

~- resolve:~

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

In the previous version, each Column option have slight gaps in its indent line on top and bottom of it. This PR will remove the gap and connect the lines to make it prettier.

preview(Table input mode is activated): https://liam-erd-sample-a5vxtbr49-liambx.vercel.app

|before|after|
|---|---|
|<img width="445" height="678" alt="Screenshot 0007-10-11 at 11 18 50" src="https://github.com/user-attachments/assets/3f2f1c95-eee1-4ff9-8e83-9d9fd4fb6229" />|<img width="445" height="678" alt="Screenshot 0007-10-11 at 11 25 48" src="https://github.com/user-attachments/assets/8d56db86-5440-41b8-b5c6-583b86fde0e8" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the indentation guide in the command palette options to align from the top and span the full height of each item. This removes small vertical gaps, delivering a cleaner and more consistent appearance for nested entries. The update improves visual alignment and readability, especially when items vary in height or spacing, without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->