### PR TITLE
chore: disable auto-opening browser when starting Storybook

### DIFF
--- a/frontend/internal-packages/storybook/package.json
+++ b/frontend/internal-packages/storybook/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "mkdir -p public && mkdir -p .storybook/public && storybook build",
-    "dev": "storybook dev -p 6006"
+    "dev": "storybook dev -p 6006 --no-open"
   },
   "msw": {
     "workerDirectory": [


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

To prevent Storybook from automatically opening in the browser every time with `pnpm dev`, I added the `--no-open` flag.

## Changes

- Added --no-open flag to Storybook dev script
- Storybook remains manually accessible at http://localhost:6006
- No impact on CI/CD or E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the Storybook development workflow to prevent the browser from auto-opening when starting the dev server, reducing interruptions during local development. Launch the URL manually when needed. No impact on the built product, features, or user interface. Startup port and server behavior remain unchanged aside from this adjustment. Testing and documentation unaffected. CI pipelines unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->