### PR TITLE
🔒 Make MigrationsViewer SQL editor read-only

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/SQL/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/SQL/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
@@ -35,6 +35,7 @@ const baseExtensions: Extension[] = [
   lintGutter(),
   syntaxHighlighting(sqlHighlightStyle),
   customTheme,
+  EditorState.readOnly.of(true),
 ]
 
 type Props = {


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5186

## Why is this change needed?

The MigrationsViewer component displays Agent-generated DDL for viewing purposes only. However, users were able to edit and delete the SQL content, which was not the intended behavior. This PR adds read-only configuration to the CodeMirror editor to prevent accidental modifications to migration SQL files.

## Summary

Added `EditorState.readOnly.of(true)` to the CodeMirror base extensions in the MigrationsViewer component, making the SQL editor read-only while maintaining all other viewer functionality.

## Demo

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/a8b0b379-d702-458f-be3c-ebb88f9e49da" /> | <video src="https://github.com/user-attachments/assets/c56f566a-9ad9-425c-92b0-22faf54ac0c7" /> | 






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQL migrations viewer now displays in read-only mode, preventing unintended modifications to migration content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->