### PR TITLE
💄 Standardize BranchCombobox height to match other UI components

### DIFF
--- a/frontend/apps/app/components/shared/BranchCombobox/BranchCombobox.module.css
+++ b/frontend/apps/app/components/shared/BranchCombobox/BranchCombobox.module.css
@@ -12,7 +12,7 @@
   border-radius: 6px;
   background: var(--background);
   cursor: pointer;
-  min-height: 36px;
+  height: 32px;
   max-width: 100%;
   transition: border-color 0.2s ease;
 }


### PR DESCRIPTION
## Issue

- resolve: N/A

## Why is this change needed?

This PR standardizes the BranchCombobox component height to match the height of other UI components like ProjectDropdown and DeepModelingToggle for visual consistency.

### Changes
- Changed from `min-height: 36px` to `height: 32px` in BranchCombobox.module.css
- This ensures uniform height across similar combobox components in the interface

| Before | After |
|--------|--------|
| <img width="803" height="290" alt="スクリーンショット 2025-10-17 17 18 09" src="https://github.com/user-attachments/assets/b295d288-f5eb-4bb4-a982-1026c5d4a349" /> | <img width="803" height="285" alt="スクリーンショット 2025-10-17 17 15 26" src="https://github.com/user-attachments/assets/ed7cecd0-648a-4e38-8bd8-6a831e0765c3" /> | 





### Rationale
The BranchCombobox previously used `min-height: 36px`, which could result in inconsistent sizing compared to other dropdown components. By using a fixed `height: 32px`, it now aligns with the design system's standard component height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified the BranchCombobox trigger element height to ensure improved vertical layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->