### PR TITLE
fix: preserve scroll position when switching between Output tabs

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.module.css
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.module.css
@@ -8,3 +8,7 @@
   min-height: 0;
   height: 100%;
 }
+
+.tabsContent[data-state='inactive'] {
+  display: none;
+}

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
@@ -80,17 +80,29 @@ export const Output: FC<Props> = ({
         initialIsPublic={initialIsPublic}
         {...propsForVersionDropdown}
       />
-      <TabsContent value={OUTPUT_TABS.ERD} className={styles.tabsContent}>
+      <TabsContent
+        value={OUTPUT_TABS.ERD}
+        className={styles.tabsContent}
+        forceMount
+      >
         <ERD schema={schema} prevSchema={prevSchema} />
       </TabsContent>
-      <TabsContent value={OUTPUT_TABS.SQL} className={styles.tabsContent}>
+      <TabsContent
+        value={OUTPUT_TABS.SQL}
+        className={styles.tabsContent}
+        forceMount
+      >
         <SQL
           currentSchema={schema}
           prevSchema={prevSchema}
           comments={sqlReviewComments}
         />
       </TabsContent>
-      <TabsContent value={OUTPUT_TABS.ARTIFACT} className={styles.tabsContent}>
+      <TabsContent
+        value={OUTPUT_TABS.ARTIFACT}
+        className={styles.tabsContent}
+        forceMount
+      >
         <ArtifactContainer analyzedRequirements={analyzedRequirements} />
       </TabsContent>
     </TabsRoot>


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5879

## Why is this change needed?

When users scroll down in the Artifact tab and then switch to another tab (ERD or SQL), returning to the Artifact tab resets the scroll position to the top. This forces users to re-scroll to their previous position, resulting in poor UX.

## Changes

- Add `forceMount` prop to all `TabsContent` components (ERD, SQL, ARTIFACT)
- Add CSS rule to hide inactive tabs using the `data-state` attribute
- This keeps all tabs mounted in the DOM while visually hiding inactive ones

## Technical Details

By default, Radix UI's `TabsContent` unmounts inactive tabs, destroying all internal state including scroll position. Using `forceMount` keeps tabs mounted while CSS (`display: none` on `[data-state='inactive']`) handles visibility.

## Benefits

- Scroll position is preserved across all tabs
- Smooth tab switching experience
- Minimal performance impact (only 3 tabs total)
- Uses Radix UI's recommended pattern for this use case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inactive tab content visibility to ensure proper display behavior in the output panel.

* **Improvements**
  * Optimized tab rendering performance and layout handling for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->