### PR TITLE
🐛 Strip internal props from react-markdown component handlers

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Artifact/Artifact.tsx
@@ -30,7 +30,7 @@ import { extractTocItems } from './utils/extractTocItems'
 type CodeProps = {
   className?: string
   children?: ReactNode
-} & HTMLAttributes<HTMLElement>
+} & HTMLAttributes<HTMLElement> & { node?: unknown; inline?: boolean }
 
 type Props = {
   doc: string
@@ -83,9 +83,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeRaw]}
               components={{
-                p(props) {
-                  const { children, ...rest } = props
-
+                p({ node: _node, children, ...rest }) {
                   const text = extractText(children)
 
                   // Check if this paragraph contains execution section title
@@ -99,9 +97,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
 
                   return <p {...rest}>{children}</p>
                 },
-                li(props) {
-                  const { children, ...rest } = props
-
+                li({ node: _node, children, ...rest }) {
                   const text = extractText(children)
 
                   // Check if this is an execution log entry
@@ -134,8 +130,13 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
 
                   return <li {...rest}>{children}</li>
                 },
-                code(props: CodeProps) {
-                  const { children, className, ...rest } = props
+                code({
+                  node: _node,
+                  inline: _inline,
+                  children,
+                  className,
+                  ...rest
+                }: CodeProps) {
                   const match = /language-(\w+)/.exec(className || '')
                   const isInline = !match && !className
 
@@ -157,7 +158,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
                     </code>
                   )
                 },
-                h1: ({ children, ...props }) => {
+                h1: ({ node: _node, children, ...props }) => {
                   const text = extractText(children)
                   const id = generateHeadingId(text)
                   return (
@@ -166,7 +167,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
                     </h1>
                   )
                 },
-                h2: ({ children, ...props }) => {
+                h2: ({ node: _node, children, ...props }) => {
                   const text = extractText(children)
                   const id = generateHeadingId(text)
                   return (
@@ -175,7 +176,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
                     </h2>
                   )
                 },
-                h3: ({ children, ...props }) => {
+                h3: ({ node: _node, children, ...props }) => {
                   const text = extractText(children)
                   const id = generateHeadingId(text)
                   return (
@@ -184,7 +185,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
                     </h3>
                   )
                 },
-                h4: ({ children, ...props }) => {
+                h4: ({ node: _node, children, ...props }) => {
                   const text = extractText(children)
                   const id = generateHeadingId(text)
                   return (
@@ -193,7 +194,7 @@ export const Artifact: FC<Props> = ({ doc, error }) => {
                     </h4>
                   )
                 },
-                h5: ({ children, ...props }) => {
+                h5: ({ node: _node, children, ...props }) => {
                   const text = extractText(children)
                   const id = generateHeadingId(text)
                   return (


### PR DESCRIPTION
## Issue

- resolve: N/A (Internal code quality improvement)

## Why is this change needed?

This change fixes React warnings about unknown props being passed to DOM elements. The `react-markdown` library passes internal props (`node`, `inline`) to custom component handlers, and these props were being spread directly to HTML elements, causing React to warn about unrecognized attributes.

## Changes

- Added explicit destructuring of `node` and `inline` props in all component handlers (p, li, code, h1-h5)
- Updated `CodeProps` type definition to include internal props
- Used underscore prefix convention (`_node`, `_inline`) to indicate intentionally unused parameters

## Technical Details

The issue occurred because of how rest parameter spreading works:
- Before: `{ children, ...rest }` - includes unwanted internal props in `rest`
- After: `{ node: _node, children, ...rest }` - explicitly excludes `node` from `rest`

This ensures only valid HTML attributes are forwarded to DOM elements while maintaining type safety.

| Before | After |
|--------|--------|
| <img width="1365" height="884" alt="スクリーンショット 2025-10-22 17 21 54" src="https://github.com/user-attachments/assets/2fa7c91b-ed99-47b5-b141-2fbbd30ea67b" /> | <img width="1366" height="936" alt="スクリーンショット 2025-10-22 17 19 08" src="https://github.com/user-attachments/assets/ff17358d-8d92-4e51-af8c-5f73dd212c03" /> | 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved markdown code block rendering to properly distinguish between inline and block code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->