### PR TITLE
fix: Include pgtap extension in Next.js build output

### DIFF
--- a/frontend/apps/app/next.config.ts
+++ b/frontend/apps/app/next.config.ts
@@ -119,6 +119,9 @@ const nextConfig: NextConfig = {
   },
   outputFileTracingIncludes: {
     '/erd/p/\\[\\.\\.\\.slug\\]': ['./prism.wasm'],
+    '/api/chat/**': [
+      '../../internal-packages/pglite-server/src/extensions/pgtap/pgtap.tar.gz',
+    ],
   },
   env: {
     NEXT_PUBLIC_GIT_HASH: gitCommitHash,

--- a/frontend/internal-packages/pglite-server/src/extensions/pgtap/index.ts
+++ b/frontend/internal-packages/pglite-server/src/extensions/pgtap/index.ts
@@ -6,25 +6,46 @@ import type { Extension } from '@electric-sql/pglite'
 export const pgtap: Extension = {
   name: 'pgtap',
   setup: async () => {
-    // In Next.js server environment, check for webpack-generated file
     if (process?.cwd) {
-      // Next.js puts webpack assets in .next/server/static/extensions/
+      const cwd = process.cwd()
+
+      // 1. Webpack build path (local Next.js builds)
       const nextServerPath = join(
-        process.cwd(),
+        cwd,
         '.next',
         'server',
         'static',
         'extensions',
         'pgtap.tar.gz',
       )
+
       if (existsSync(nextServerPath)) {
         return {
           bundlePath: pathToFileURL(nextServerPath),
         }
       }
+
+      // 2. Traced source path (Vercel deployment via outputFileTracingIncludes)
+      const tracedPath = join(
+        cwd,
+        '..',
+        '..',
+        'internal-packages',
+        'pglite-server',
+        'src',
+        'extensions',
+        'pgtap',
+        'pgtap.tar.gz',
+      )
+
+      if (existsSync(tracedPath)) {
+        return {
+          bundlePath: pathToFileURL(tracedPath),
+        }
+      }
     }
 
-    // Fallback to original relative path for non-Next.js environments (tests, etc.)
+    // 3. Source relative path (development and test environments)
     return {
       bundlePath: new URL('./pgtap.tar.gz', import.meta.url),
     }


### PR DESCRIPTION
## Issue

- resolve: (Please add the issue number if there is one)

## Why is this change needed?

This change adds the pgtap.tar.gz extension file to Next.js outputFileTracingIncludes configuration for /api/chat routes. This ensures that the PGlite pgtap extension is properly included in production builds and available at runtime.

Without this configuration, the extension file may not be included in the production build output, causing errors when trying to load the pgtap extension in the deployed application.

pgTAP working on: https://liam-app-git-fixpgtapextensionerror-liambx.vercel.app/design_sessions/1362772e-af8f-4453-bd20-66ec5b901462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to better track and include API-related resources during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->