### PR TITLE
✨ Show initial_schema_snapshot as Version 0 in VersionDropdown

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/SessionDetailPageClient.tsx
@@ -23,7 +23,6 @@ import { SQL_REVIEW_COMMENTS } from './mock'
 import styles from './SessionDetailPageClient.module.css'
 import type { Version } from './types'
 import { determineWorkflowAction } from './utils/determineWorkflowAction'
-import { isEmptySchema } from './utils/isEmptySchema'
 import { getWorkflowInProgress } from './utils/workflowStorage'
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -45,13 +44,11 @@ type Props = {
 const determineInitialTab = (
   versions: Version[],
   analyzedRequirements: AnalyzedRequirements | null,
-  initialDisplayedSchema: Schema,
 ): OutputTabValue | undefined => {
   const hasVersions = versions.length > 0
   const hasAnalyzedRequirements = analyzedRequirements !== null
-  const hasInitialSchema = !isEmptySchema(initialDisplayedSchema)
 
-  if (hasVersions || hasInitialSchema) return OUTPUT_TABS.ERD
+  if (hasVersions) return OUTPUT_TABS.ERD
   if (hasAnalyzedRequirements) return OUTPUT_TABS.ARTIFACT
   return undefined
 }
@@ -69,11 +66,7 @@ export const SessionDetailPageClient: FC<Props> = ({
   panelSizes,
 }) => {
   const [activeTab, setActiveTab] = useState<OutputTabValue | undefined>(
-    determineInitialTab(
-      initialVersions,
-      initialAnalyzedRequirements,
-      initialDisplayedSchema,
-    ),
+    determineInitialTab(initialVersions, initialAnalyzedRequirements),
   )
   const [isResizing, setIsResizing] = useState(false)
   const [hasReceivedAnalyzedRequirements, setHasReceivedAnalyzedRequirements] =
@@ -125,10 +118,7 @@ export const SessionDetailPageClient: FC<Props> = ({
   }, [analyzedRequirements, hasReceivedAnalyzedRequirements])
 
   const shouldShowOutputSection =
-    (selectedVersion !== null ||
-      analyzedRequirements !== null ||
-      !isEmptySchema(initialDisplayedSchema)) &&
-    activeTab
+    (selectedVersion !== null || analyzedRequirements !== null) && activeTab
 
   const handleLayoutChange = useCallback((sizes: number[]) => {
     setCookieJson(PANEL_LAYOUT_COOKIE_NAME, sizes, {

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/Header.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Header/Header.tsx
@@ -6,7 +6,6 @@ import clsx from 'clsx'
 import type { ComponentProps, FC } from 'react'
 import * as v from 'valibot'
 import type { Version } from '../../../../types'
-import { isEmptySchema } from '../../../../utils/isEmptySchema'
 import {
   ARTIFACT_TAB,
   ERD_SCHEMA_TABS_LIST,
@@ -58,9 +57,7 @@ export const Header: FC<Props> = ({
   ...propsForVersionDropdown
 }) => {
   const { versions, selectedVersion } = propsForVersionDropdown
-  const disabled =
-    (!versions || versions.length === 0 || !selectedVersion) &&
-    isEmptySchema(schema)
+  const disabled = !versions || versions.length === 0 || !selectedVersion
   const cumulativeOperations = generateCumulativeOperations(
     versions,
     selectedVersion,

--- a/frontend/apps/app/components/SessionDetailPage/services/getVersions.ts
+++ b/frontend/apps/app/components/SessionDetailPage/services/getVersions.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { isEmptySchema, schemaSchema } from '@liam-hq/schema'
+import { safeParse } from 'valibot'
 import { createClient } from '../../../libs/db/server'
 import type { Version } from '../types'
 
@@ -7,7 +9,7 @@ export async function getVersions(
   buildingSchemaId: string,
 ): Promise<Version[]> {
   const supabase = await createClient()
-  const { data } = await supabase
+  const { data: versions } = await supabase
     .from('building_schema_versions')
     .select(`
       id,
@@ -23,5 +25,28 @@ export async function getVersions(
     .eq('building_schema_id', buildingSchemaId)
     .order('number', { ascending: false })
 
-  return data ?? []
+  // Check initial_schema_snapshot and add Version 0 if needed
+  const { data: bs } = await supabase
+    .from('building_schemas')
+    .select('id, initial_schema_snapshot')
+    .eq('id', buildingSchemaId)
+    .single()
+
+  const parsedInitial = safeParse(schemaSchema, bs?.initial_schema_snapshot)
+  const hasInitialSchema =
+    parsedInitial.success && !isEmptySchema(parsedInitial.output)
+
+  if (!hasInitialSchema) {
+    return versions ?? []
+  }
+
+  const versionZero: Version = {
+    id: 'initial',
+    building_schema_id: buildingSchemaId,
+    number: 0,
+    patch: null,
+    reverse_patch: null,
+  }
+
+  return [...(versions ?? []), versionZero]
 }

--- a/frontend/apps/app/components/SessionDetailPage/utils/isEmptySchema.ts
+++ b/frontend/apps/app/components/SessionDetailPage/utils/isEmptySchema.ts
@@ -1,9 +1,0 @@
-import type { Schema } from '@liam-hq/schema'
-
-export function isEmptySchema(schema: Schema): boolean {
-  return (
-    Object.keys(schema.tables).length === 0 &&
-    Object.keys(schema.enums).length === 0 &&
-    Object.keys(schema.extensions).length === 0
-  )
-}


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5914

## Why is this change needed?

Currently, the VersionDropdown only displays versions from the `building_schema_versions` table. However, the initial schema stored in `building_schemas.initial_schema_snapshot` (the state before the agent starts generating schemas) is not included in the version history.

By making the initial schema selectable as Version 0, users can track the complete evolution of their schema from the very beginning.

## What changed?

### Core changes
1. **Moved `isEmptySchema` utility to `@liam-hq/schema` package** for reusability across the codebase
2. **Modified `getVersions` service** to include Version 0 when `initial_schema_snapshot` exists and is non-empty
3. **Removed client-side `initial_schema_snapshot` display logic** from UI components
4. **Simplified tab initialization** by removing the `initial_schema_snapshot` parameter
5. **Centralized version display logic** in the `getVersions` service

### Implementation details
- Version 0 is a virtual version (no actual DB record) with:
  - `id: 'initial'`
  - `number: 0`
  - `patch: null`, `reverse_patch: null`
- The service checks if `initial_schema_snapshot` exists and is non-empty using the `isEmptySchema` utility
- Version 0 is appended to the end of the versions array (after sorting by number descending)


## Demo

| After linking the schema file | When switching versions | When the schema file is not associated |
|--------|--------|--------|
| <video src="https://github.com/user-attachments/assets/ca5f15f8-0417-48c7-8374-12fefe2ad2bc" /> | <video src="https://github.com/user-attachments/assets/ed30b2a7-c470-4950-a1f0-119c0aff6ceb" /> | <video src="https://github.com/user-attachments/assets/95f8ffb1-652f-484f-a2ed-426af0398c78" /> | 










