### PR TITLE
Simplify schema drift check workflow

### DIFF
--- a/.github/workflows/check-schema-drift.yml
+++ b/.github/workflows/check-schema-drift.yml
@@ -41,24 +41,17 @@ jobs:
         run: |
           cd frontend/internal-packages/db
 
-          if supabase db diff --linked --use-migra > /tmp/schema_diff.sql 2>&1; then
-            if [ -s /tmp/schema_diff.sql ]; then
-              echo "drift_detected=true" >> $GITHUB_OUTPUT
-              echo "Schema drift detected!"
-              cat /tmp/schema_diff.sql
-            else
-              echo "drift_detected=false" >> $GITHUB_OUTPUT
-              echo "No schema drift detected."
-            fi
+          # Capture SQL diff to stdout file, stderr logs go to console
+          supabase db diff --linked --use-migra > /tmp/schema_diff.sql
+
+          if [ -s /tmp/schema_diff.sql ]; then
+            echo "drift_detected=true" >> $GITHUB_OUTPUT
+            echo "Schema drift detected!"
+            echo "=== Schema Diff ==="
+            cat /tmp/schema_diff.sql
           else
-            if [ -s /tmp/schema_diff.sql ]; then
-              echo "drift_detected=true" >> $GITHUB_OUTPUT
-              echo "Schema drift detected (with errors)!"
-              cat /tmp/schema_diff.sql
-            else
-              echo "drift_detected=false" >> $GITHUB_OUTPUT
-              echo "No schema drift detected."
-            fi
+            echo "drift_detected=false" >> $GITHUB_OUTPUT
+            echo "No schema drift detected."
           fi
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5918

## Why is this change needed?

The schema drift check workflow had unnecessary complexity in error handling:
- Stderr logs were saved to a separate file and only shown on errors
- Complex error handling logic with multiple conditional branches
- Redundant file management for error logs

## Changes

- Let stderr logs output directly to console for real-time visibility
- Only capture SQL diff (stdout) to file for drift detection
- Remove redundant error log file and complex error handling

This makes the workflow simpler, more maintainable, and easier to debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of schema drift detection in the continuous integration workflow.
  * Enhanced status reporting with clearer messaging for database schema validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->