### PR TITLE
test: Add syntax error test case for validatePgTapTest

### DIFF
--- a/frontend/internal-packages/agent/src/qa-agent/tools/validatePgTapTest.test.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/tools/validatePgTapTest.test.ts
@@ -116,4 +116,10 @@ describe('validatePgTapTest', () => {
     const result = validatePgTapTest(sql)
     expect(result).toBeUndefined()
   })
+
+  it('returns error when pgTAP function has syntax error with semicolon before closing parenthesis', () => {
+    const sql = 'SELECT lives_ok($$SELECT 1$$;)'
+    const result = validatePgTapTest(sql)
+    expect(result).toContain('Semicolon before closing parenthesis detected')
+  })
 })


### PR DESCRIPTION
## Issue

No specific issue, test improvement.

## Why is this change needed?

This change adds a test case to verify that the `validatePgTapTest` function properly detects syntax errors when a semicolon appears before a closing parenthesis in pgTAP function calls.

The new test ensures that the function's `checkSyntaxErrors` implementation correctly catches common syntax mistakes like:
```sql
SELECT lives_ok($$SELECT 1$$;)  -- semicolon before )
```

This improves test coverage and makes the expected behavior more explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to validate error detection for specific formatting issues in pgTAP function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->