### PR TITLE
test: fix validatePgTapTest test case naming and implementation alignment

### DIFF
--- a/frontend/internal-packages/agent/src/qa-agent/tools/validatePgTapTest.test.ts
+++ b/frontend/internal-packages/agent/src/qa-agent/tools/validatePgTapTest.test.ts
@@ -42,17 +42,12 @@ describe('validatePgTapTest', () => {
     expect(result.isOk()).toBe(true)
   })
 
-  it('returns Err when pgTAP test has no valid assertions', () => {
-    // This test should contain pgTAP-like syntax but fail validation
-    // However, since checkAssertions looks for pgTAP functions, we need a different approach
-    // Let's test with syntax error instead
-    const sql = `
-      SELECT lives_ok($$SELECT 1$$;)
-    `
+  it('returns Err when pgTAP function has syntax error', () => {
+    const sql = 'SELECT lives_ok($$SELECT 1$$;)'
     const result = validatePgTapTest(sql)
     expect(result.isErr()).toBe(true)
     if (result.isErr()) {
-      expect(result.error).toContain('pgTAP test validation failed')
+      expect(result.error).toContain('Semicolon before closing parenthesis')
     }
   })
 


### PR DESCRIPTION
## Issue

- resolve: N/A (Code quality improvement)

## Why is this change needed?

The test case "returns Err when pgTAP test has no valid assertions" in `validatePgTapTest.test.ts` had inconsistencies between its name, comments, and actual implementation:

- **Test name**: Suggested testing for missing assertions
- **Comments**: Indicated testing syntax errors instead  
- **SQL**: Actually tested semicolon syntax errors

This misalignment made the test confusing and harder to maintain.

## Changes

- Renamed test to accurately reflect what it tests: "returns Err when pgTAP function has syntax error"
- Removed confusing comments that contradicted the test name
- Updated assertion to check for specific error message ("Semicolon before closing parenthesis")
- Simplified SQL to be more direct and readable

## Test Results

All tests pass (13/13 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved pgTAP validation test coverage by updating test scenarios to better verify error handling for syntax issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->