### PR TITLE
⚡ Optimize SessionsNewPage with React Suspense for parallel data fetching

### DIFF
--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/Fallback.module.css
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/Fallback.module.css
@@ -1,0 +1,35 @@
+.wrapper {
+  margin-top: var(--spacing-12);
+  padding-top: var(--spacing-12);
+  border-top: 1px solid var(--global-border);
+  width: 100%;
+  max-width: 600px;
+}
+
+.title {
+  font-size: var(--font-size-8);
+  font-weight: 600;
+  margin-bottom: var(--spacing-6);
+  color: var(--global-foreground);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.skeletonRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+}
+
+.skeletonContent {
+  flex: 1;
+}
+
+.skeletonSpacer {
+  height: var(--spacing-2);
+}

--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/Fallback.stories.tsx
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/Fallback.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Fallback } from './Fallback'
+
+const meta = {
+  component: Fallback,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {},
+  tags: ['autodocs'],
+} satisfies Meta<typeof Fallback>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/Fallback.tsx
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/Fallback.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from '@liam-hq/ui'
+import type { FC } from 'react'
+import styles from './Fallback.module.css'
+
+const SKELETON_KEYS = [0, 1, 2, 3]
+
+export const Fallback: FC = () => {
+  return (
+    <div className={styles.wrapper}>
+      <h2 className={styles.title}>Recent Sessions</h2>
+      <div className={styles.list}>
+        {SKELETON_KEYS.map((key) => (
+          <div key={key} className={styles.skeletonRow}>
+            <Skeleton variant="box" width="40px" height="40px" />
+            <div className={styles.skeletonContent}>
+              <Skeleton variant="box" width="60%" height="16px" />
+              <div className={styles.skeletonSpacer} />
+              <Skeleton variant="box" width="30%" height="12px" />
+            </div>
+            <Skeleton variant="box" width="20px" height="14px" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/index.ts
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/Fallback/index.ts
@@ -1,0 +1,1 @@
+export * from './Fallback'

--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/RecentSessionsSection.module.css
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/RecentSessionsSection.module.css
@@ -1,0 +1,20 @@
+.wrapper {
+  margin-top: var(--spacing-12);
+  padding-top: var(--spacing-12);
+  border-top: 1px solid var(--global-border);
+  width: 100%;
+  max-width: 600px;
+}
+
+.title {
+  font-size: var(--font-size-8);
+  font-weight: 600;
+  margin-bottom: var(--spacing-6);
+  color: var(--global-foreground);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 12px);
+}

--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/RecentSessionsSection.tsx
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/RecentSessionsSection.tsx
@@ -1,0 +1,28 @@
+import type { FC } from 'react'
+import { fetchRecentSessions } from '../../CommonLayout/GlobalNav/RecentsSection/fetchRecentSessions'
+import { SessionItem } from '../../ProjectSessionsPage/SessionItem'
+import { Fallback } from './Fallback'
+import styles from './RecentSessionsSection.module.css'
+
+type Props = {
+  organizationId: string
+}
+
+export const RecentSessionsSection: FC<Props> = async ({ organizationId }) => {
+  const recentSessions = await fetchRecentSessions(organizationId)
+
+  if (recentSessions.length === 0) return null
+
+  return (
+    <div className={styles.wrapper}>
+      <h2 className={styles.title}>Recent Sessions</h2>
+      <div className={styles.list}>
+        {recentSessions.map((session) => (
+          <SessionItem key={session.id} session={session} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export { Fallback as RecentSessionsSectionFallback }

--- a/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/index.ts
+++ b/frontend/apps/app/components/SessionsNewPage/RecentSessionsSection/index.ts
@@ -1,0 +1,1 @@
+export * from './RecentSessionsSection'

--- a/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.module.css
+++ b/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.module.css
@@ -25,24 +25,3 @@
   align-items: center;
   gap: var(--spacing-7, 28px);
 }
-
-.recentsSection {
-  margin-top: var(--spacing-12);
-  padding-top: var(--spacing-12);
-  border-top: 1px solid var(--global-border);
-  width: 100%;
-  max-width: 600px;
-}
-
-.recentsTitle {
-  font-size: var(--font-size-xl, 20px);
-  font-weight: 600;
-  margin-bottom: var(--spacing-6);
-  color: var(--global-foreground);
-}
-
-.sessionsList {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3, 12px);
-}

--- a/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.tsx
+++ b/frontend/apps/app/components/SessionsNewPage/SessionsNewPage.tsx
@@ -1,11 +1,13 @@
 import { redirect } from 'next/navigation'
-import type { FC } from 'react'
+import { type FC, Suspense } from 'react'
 import { getOrganizationId } from '../../features/organizations/services/getOrganizationId'
 import { SessionFormContainer } from '../../features/sessions/components/SessionFormContainer'
 import { urlgen } from '../../libs/routes'
 import { getProjects } from '../CommonLayout/AppBar/ProjectsDropdownMenu/services/getProjects'
-import { fetchRecentSessions } from '../CommonLayout/GlobalNav/RecentsSection/fetchRecentSessions'
-import { SessionItem } from '../ProjectSessionsPage/SessionItem'
+import {
+  RecentSessionsSection,
+  RecentSessionsSectionFallback,
+} from './RecentSessionsSection'
 import styles from './SessionsNewPage.module.css'
 
 export const SessionsNewPage: FC = async () => {
@@ -19,8 +21,6 @@ export const SessionsNewPage: FC = async () => {
   const projectsResponse = await getProjects(organizationId)
   const projects = projectsResponse.data || []
 
-  const recentSessions = await fetchRecentSessions(organizationId)
-
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
@@ -30,16 +30,9 @@ export const SessionsNewPage: FC = async () => {
         </h1>
         <SessionFormContainer projects={projects} />
 
-        {recentSessions.length > 0 && (
-          <div className={styles.recentsSection}>
-            <h2 className={styles.recentsTitle}>Recent Sessions</h2>
-            <div className={styles.sessionsList}>
-              {recentSessions.map((session) => (
-                <SessionItem key={session.id} session={session} />
-              ))}
-            </div>
-          </div>
-        )}
+        <Suspense fallback={<RecentSessionsSectionFallback />}>
+          <RecentSessionsSection organizationId={organizationId} />
+        </Suspense>
       </div>
     </div>
   )


### PR DESCRIPTION
## Issue

- related: https://github.com/route06/liam-internal/issues/5288

## Why is this change needed?

This change improves the perceived performance of SessionsNewPage by implementing React Suspense to enable parallel data fetching. Previously, the page waited for both `getProjects()` and `fetchRecentSessions()` to complete sequentially before rendering, which increased the initial page load time.

By extracting the recent sessions section into a separate async Server Component and wrapping it with a Suspense boundary, the main page content (title and session form) can render immediately while the recent sessions load independently in the background. This provides users with faster access to the primary functionality while showing a skeleton loading state for secondary content.

## Demo

https://github.com/user-attachments/assets/cfe51207-aebe-4bfe-a6e0-403f33da13dc

## Changes

- Extracted `RecentSessionsSection` into a separate async Server Component
- Added Suspense boundary around `RecentSessionsSection` in parent component
- Created `Fallback` skeleton component for loading state
- Moved related CSS styles to component-specific module

## Performance Impact

- Main page content renders immediately after `getProjects()` completes
- Recent sessions fetch no longer blocks initial render
- Users can interact with session form while recent sessions load
- Improved perceived performance through progressive rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Recent Sessions section with a visual loading (skeleton) fallback.

* **Refactor**
  * Sessions page now delegates recent-sessions rendering to the new Recent Sessions section and uses a suspense-based fallback.

* **Style**
  * New styling for the Recent Sessions area and skeleton fallback to match layout and spacing.

* **Tests**
  * Added a Storybook story demonstrating the Recent Sessions loading/fallback state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->