### PR TITLE
♻️ Refactor: Rename schemaDesignTool to createMigrationTool

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ToolCallCard.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/ToolCallCard.stories.tsx
@@ -32,7 +32,7 @@ export default meta
 type Story = StoryObj<typeof ToolCallCard>
 
 const sampleCall: ToolCall = {
-  name: 'schemaDesignTool',
+  name: 'createMigrationTool',
   args: {
     requirements: 'Design a user authentication schema',
   },
@@ -53,7 +53,7 @@ export const Success: Story = {
     // @ts-expect-error - Using partial ToolMessage for story demo
     result: {
       content: 'Schema design completed successfully',
-      name: 'schemaDesignTool',
+      name: 'createMigrationTool',
       id: 'result-1',
       status: 'success',
       tool_call_id: 'call-1',
@@ -67,7 +67,7 @@ export const ErrorState: Story = {
     // @ts-expect-error - Using partial ToolMessage for story demo
     result: {
       content: 'Schema validation failed',
-      name: 'schemaDesignTool',
+      name: 'createMigrationTool',
       id: 'result-2',
       status: 'error',
       tool_call_id: 'call-1',

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/utils/getToolDisplayInfo.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCallCard/utils/getToolDisplayInfo.ts
@@ -11,7 +11,7 @@ type ToolDisplayInfo = {
 
 export const getToolDisplayInfo = (toolName: ToolName): ToolDisplayInfo => {
   switch (toolName) {
-    case 'schemaDesignTool':
+    case 'createMigrationTool':
       return {
         displayName: 'Database Schema Design',
         description: 'Applying database schema changes',

--- a/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.stories.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Chat/components/Messages/AiMessage/ToolCalls/ToolCalls.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof ToolCalls>
 
 const schemaDesignCall: ToolCall = {
   id: 'call_1',
-  name: 'schemaDesignTool',
+  name: 'createMigrationTool',
   type: 'tool_call',
   args: {
     operations: [

--- a/frontend/internal-packages/agent/src/constants.ts
+++ b/frontend/internal-packages/agent/src/constants.ts
@@ -6,7 +6,7 @@
  * applies to transitions between nodes.
  *
  * TEMPORARY LIMITATION (set to 10):
- * Due to issues with schemaDesignTool, the DB Agent cannot resolve schema issues
+ * Due to issues with createMigrationTool, the DB Agent cannot resolve schema issues
  * on the second and subsequent attempts, causing infinite loops between:
  * leadAgent → dbAgent → qaAgent → leadAgent (when schemaIssues exist)
  *
@@ -15,7 +15,7 @@
  * - The workflow will fail after 10 loops if issues persist
  * - Provides more opportunities for the DB Agent to refine the schema
  *
- * TODO: Increase this limit after fixing schemaDesignTool to properly handle
+ * TODO: Increase this limit after fixing createMigrationTool to properly handle
  * schema modifications (e.g., unique constraint issues, JSON patch errors)
  * See: route06/liam-internal#5642
  */

--- a/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.integration.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.integration.test.ts
@@ -25,7 +25,7 @@ describe('createDbAgentGraph Integration', () => {
       userId: context.userId,
       prompt: userInput,
       next: END,
-      schemaDesignSuccessful: false,
+      createMigrationSuccessful: false,
     }
 
     // Act

--- a/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/createDbAgentGraph.test.ts
@@ -8,11 +8,11 @@ describe('createDbAgentGraph', () => {
 graph TD;
 	__start__([<p>__start__</p>]):::first
 	designSchema(designSchema)
-	invokeSchemaDesignTool(invokeSchemaDesignTool)
+	invokeCreateMigrationTool(invokeCreateMigrationTool)
 	__end__([<p>__end__</p>]):::last
 	__start__ --> designSchema;
-	invokeSchemaDesignTool --> designSchema;
-	designSchema -.-> invokeSchemaDesignTool;
+	invokeCreateMigrationTool --> designSchema;
+	designSchema -.-> invokeCreateMigrationTool;
 	designSchema -.-> __end__;
 	designSchema -.-> designSchema;
 	classDef default fill:#f2f0ff,line-height:1.2;

--- a/frontend/internal-packages/agent/src/db-agent/invokeDesignAgent.ts
+++ b/frontend/internal-packages/agent/src/db-agent/invokeDesignAgent.ts
@@ -19,7 +19,7 @@ import {
   contextPromptTemplate,
   SYSTEM_PROMPT,
 } from './prompt'
-import { schemaDesignTool } from './tools/schemaDesignTool'
+import { createMigrationTool } from './tools/createMigrationTool'
 
 const AGENT_NAME = 'db' as const
 
@@ -28,7 +28,7 @@ const model = new ChatOpenAI({
   reasoning: { effort: 'low', summary: 'detailed' },
   useResponsesApi: true,
   streaming: true,
-}).bindTools([schemaDesignTool], {
+}).bindTools([createMigrationTool], {
   strict: true,
   tool_choice: 'auto',
 })

--- a/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.integration.test.ts
@@ -36,7 +36,7 @@ describe('designSchemaNode Integration', () => {
       designSessionId: context.designSessionId,
       prompt: userInput,
       next: END,
-      schemaDesignSuccessful: false,
+      createMigrationSuccessful: false,
     }
 
     // Act

--- a/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.ts
+++ b/frontend/internal-packages/agent/src/db-agent/nodes/designSchemaNode.ts
@@ -51,6 +51,6 @@ export async function designSchemaNode(
     ...state,
     messages: [...state.messages, response],
     // Reset success flag when retrying
-    schemaDesignSuccessful: false,
+    createMigrationSuccessful: false,
   }
 }

--- a/frontend/internal-packages/agent/src/db-agent/nodes/invokeCreateMigrationToolNode.integration.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/nodes/invokeCreateMigrationToolNode.integration.test.ts
@@ -8,16 +8,16 @@ import {
 } from '../../../test-utils/workflowTestHelpers'
 import type { DbAgentState } from '../shared/dbAgentAnnotation'
 import { dbAgentAnnotation } from '../shared/dbAgentAnnotation'
-import { invokeSchemaDesignToolNode } from './invokeSchemaDesignToolNode'
+import { invokeCreateMigrationToolNode } from './invokeCreateMigrationToolNode'
 
-describe('invokeSchemaDesignToolNode Integration', () => {
+describe('invokeCreateMigrationToolNode Integration', () => {
   it('should execute schema design tool with real APIs', async () => {
     // Arrange
     const { config, context, checkpointer } = await getTestConfig()
     const graph = new StateGraph(dbAgentAnnotation)
-      .addNode('invokeSchemaDesignTool', invokeSchemaDesignToolNode)
-      .addEdge(START, 'invokeSchemaDesignTool')
-      .addEdge('invokeSchemaDesignTool', END)
+      .addNode('invokeCreateMigrationTool', invokeCreateMigrationToolNode)
+      .addEdge(START, 'invokeCreateMigrationTool')
+      .addEdge('invokeCreateMigrationTool', END)
       .compile({ checkpointer })
 
     const toolCallMessage = new AIMessage({
@@ -25,7 +25,7 @@ describe('invokeSchemaDesignToolNode Integration', () => {
       tool_calls: [
         {
           id: 'test-tool-call-id',
-          name: 'schemaDesignTool',
+          name: 'createMigrationTool',
           args: {
             operations: [
               {
@@ -79,7 +79,7 @@ describe('invokeSchemaDesignToolNode Integration', () => {
       organizationId: context.organizationId,
       prompt: 'Test schema design',
       next: END,
-      schemaDesignSuccessful: false,
+      createMigrationSuccessful: false,
     }
 
     // Act
@@ -97,9 +97,9 @@ describe('invokeSchemaDesignToolNode Integration', () => {
     // Arrange
     const { config, context, checkpointer } = await getTestConfig()
     const graph = new StateGraph(dbAgentAnnotation)
-      .addNode('invokeSchemaDesignTool', invokeSchemaDesignToolNode)
-      .addEdge(START, 'invokeSchemaDesignTool')
-      .addEdge('invokeSchemaDesignTool', END)
+      .addNode('invokeCreateMigrationTool', invokeCreateMigrationToolNode)
+      .addEdge(START, 'invokeCreateMigrationTool')
+      .addEdge('invokeCreateMigrationTool', END)
       .compile({ checkpointer })
 
     const invalidToolCallMessage = new AIMessage({
@@ -107,7 +107,7 @@ describe('invokeSchemaDesignToolNode Integration', () => {
       tool_calls: [
         {
           id: 'test-invalid-tool-call-id',
-          name: 'schemaDesignTool',
+          name: 'createMigrationTool',
           args: {
             operations: [
               {
@@ -142,7 +142,7 @@ describe('invokeSchemaDesignToolNode Integration', () => {
       organizationId: context.organizationId,
       prompt: 'Test invalid schema design',
       next: END,
-      schemaDesignSuccessful: false,
+      createMigrationSuccessful: false,
     }
 
     // Act

--- a/frontend/internal-packages/agent/src/db-agent/routing/routeAfterDesignSchema.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/routing/routeAfterDesignSchema.test.ts
@@ -14,16 +14,16 @@ const createDbAgentState = (
   designSessionId: 'test-session',
   prompt: 'test input',
   next: END,
-  schemaDesignSuccessful: false,
+  createMigrationSuccessful: false,
 })
 
 describe('routeAfterDesignSchema', () => {
-  it('should return invokeSchemaDesignTool when message has tool calls', () => {
+  it('should return invokeCreateMigrationTool when message has tool calls', () => {
     const messageWithToolCalls = new AIMessage({
       content: 'I need to update the schema',
       tool_calls: [
         {
-          name: 'schemaDesignTool',
+          name: 'createMigrationTool',
           args: { operations: [] },
           id: 'test-id',
         },
@@ -33,7 +33,7 @@ describe('routeAfterDesignSchema', () => {
     const state = createDbAgentState([messageWithToolCalls])
     const result = routeAfterDesignSchema(state)
 
-    expect(result).toBe('invokeSchemaDesignTool')
+    expect(result).toBe('invokeCreateMigrationTool')
   })
 
   it('should return END when message has no tool calls (design complete)', () => {
@@ -75,7 +75,7 @@ describe('routeAfterDesignSchema', () => {
       content: 'I need to update the schema',
       tool_calls: [
         {
-          name: 'schemaDesignTool',
+          name: 'createMigrationTool',
           args: { operations: [] },
           id: 'test-id',
         },
@@ -100,12 +100,12 @@ describe('routeAfterDesignSchema', () => {
       content: 'I need to update the schema',
       tool_calls: [
         {
-          name: 'schemaDesignTool',
+          name: 'createMigrationTool',
           args: { operations: [] },
           id: 'test-id-1',
         },
         {
-          name: 'schemaDesignTool',
+          name: 'createMigrationTool',
           args: { operations: [] },
           id: 'test-id-2',
         },
@@ -115,6 +115,6 @@ describe('routeAfterDesignSchema', () => {
     const state = createDbAgentState([messageWithMultipleToolCalls])
     const result = routeAfterDesignSchema(state)
 
-    expect(result).toBe('invokeSchemaDesignTool')
+    expect(result).toBe('invokeCreateMigrationTool')
   })
 })

--- a/frontend/internal-packages/agent/src/db-agent/routing/routeAfterDesignSchema.ts
+++ b/frontend/internal-packages/agent/src/db-agent/routing/routeAfterDesignSchema.ts
@@ -12,13 +12,13 @@ import type { DbAgentState } from '../shared/dbAgentAnnotation'
  */
 export const routeAfterDesignSchema = (
   state: DbAgentState,
-): 'invokeSchemaDesignTool' | 'designSchema' | typeof END => {
+): 'invokeCreateMigrationTool' | 'designSchema' | typeof END => {
   const { messages } = state
   const lastMessage = messages[messages.length - 1]
 
   // If last message has tool calls, execute them
   if (lastMessage && hasToolCalls(lastMessage)) {
-    return 'invokeSchemaDesignTool'
+    return 'invokeCreateMigrationTool'
   }
 
   // No tool calls - AI has decided schema design is complete

--- a/frontend/internal-packages/agent/src/db-agent/shared/dbAgentAnnotation.ts
+++ b/frontend/internal-packages/agent/src/db-agent/shared/dbAgentAnnotation.ts
@@ -13,8 +13,8 @@ export const dbAgentAnnotation = Annotation.Root({
     default: () => END,
   }),
 
-  // Flag to indicate successful schema design tool execution
-  schemaDesignSuccessful: Annotation<boolean>({
+  // Flag to indicate successful create migration tool execution
+  createMigrationSuccessful: Annotation<boolean>({
     reducer: (current, update) => update ?? current ?? false,
     default: () => false,
   }),

--- a/frontend/internal-packages/agent/src/db-agent/tools/createMigrationTool.test.ts
+++ b/frontend/internal-packages/agent/src/db-agent/tools/createMigrationTool.test.ts
@@ -9,7 +9,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repositories } from '../../repositories'
 import { InMemoryRepository } from '../../repositories/InMemoryRepository'
-import { schemaDesignTool } from './schemaDesignTool'
+import { createMigrationTool } from './createMigrationTool'
 
 type ToolCall = {
   id: string
@@ -21,7 +21,7 @@ vi.mock('@liam-hq/pglite-server', () => ({
   executeQuery: vi.fn(),
 }))
 
-describe('schemaDesignTool', () => {
+describe('createMigrationTool', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -41,7 +41,7 @@ describe('schemaDesignTool', () => {
     },
     toolCall: {
       id: 'test-tool-call-id',
-      name: 'schemaDesignTool',
+      name: 'createMigrationTool',
       args: {},
     },
   })
@@ -108,13 +108,13 @@ describe('schemaDesignTool', () => {
     }
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const result = await schemaDesignTool.invoke(input, config as never)
+    const result = await createMigrationTool.invoke(input, config as never)
 
     // Tool returns a ToolMessage with the success message
     expect(result).toMatchObject({
       content:
         'Schema successfully updated. The operations have been applied to the database schema, DDL validation successful (1/1 statements executed successfully), and new version created.',
-      name: 'schemaDesignTool',
+      name: 'createMigrationTool',
       tool_call_id: 'test-tool-call-id',
       status: 'success',
     })
@@ -161,7 +161,7 @@ describe('schemaDesignTool', () => {
       ],
     }
 
-    await expect(schemaDesignTool.invoke(input, config)).rejects.toThrow(
+    await expect(createMigrationTool.invoke(input, config)).rejects.toThrow(
       /Could not retrieve current schema for DDL validation/,
     )
   })
@@ -183,7 +183,7 @@ describe('schemaDesignTool', () => {
     }
 
     // LangChain validates schema before our tool function is called
-    await expect(schemaDesignTool.invoke(input, config)).rejects.toThrow(
+    await expect(createMigrationTool.invoke(input, config)).rejects.toThrow(
       'Received tool input did not match expected schema',
     )
   })
@@ -213,12 +213,12 @@ describe('schemaDesignTool', () => {
 
     // With actual PGlite, empty operations on empty schema should succeed
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const result2 = await schemaDesignTool.invoke(input, config as never)
+    const result2 = await createMigrationTool.invoke(input, config as never)
     // Tool returns a ToolMessage with the success message
     expect(result2).toMatchObject({
       content:
         'Schema successfully updated. The operations have been applied to the database schema, DDL validation successful (0/0 statements executed successfully), and new version created.',
-      name: 'schemaDesignTool',
+      name: 'createMigrationTool',
       tool_call_id: 'test-tool-call-id',
       status: 'success',
     })
@@ -299,7 +299,7 @@ describe('schemaDesignTool', () => {
       ],
     }
 
-    await expect(schemaDesignTool.invoke(input, config)).rejects.toThrow(
+    await expect(createMigrationTool.invoke(input, config)).rejects.toThrow(
       /DDL execution validation failed/,
     )
 
@@ -377,7 +377,7 @@ ALTER TABLE "posts" ADD CONSTRAINT "posts_user_id_fkey" FOREIGN KEY ("user_id") 
       ],
     }
 
-    await expect(schemaDesignTool.invoke(input, config)).rejects.toThrow(
+    await expect(createMigrationTool.invoke(input, config)).rejects.toThrow(
       /Failed to create schema version after DDL validation: Version creation failed due to conflict/,
     )
 

--- a/frontend/internal-packages/agent/src/db-agent/tools/createMigrationTool.ts
+++ b/frontend/internal-packages/agent/src/db-agent/tools/createMigrationTool.ts
@@ -18,13 +18,13 @@ import { toJsonSchema } from '../../utils/jsonSchema'
 import { withSentryCaptureException } from '../../utils/withSentryCaptureException'
 import { getToolConfigurable } from '../getToolConfigurable'
 
-const TOOL_NAME = 'schemaDesignTool'
+const TOOL_NAME = 'createMigrationTool'
 
-const schemaDesignToolSchema = v.object({
+const createMigrationToolSchema = v.object({
   operations: migrationOperationsSchema,
 })
 
-const toolSchema = toJsonSchema(schemaDesignToolSchema)
+const toolSchema = toJsonSchema(createMigrationToolSchema)
 
 const validateAndExecuteDDL = async (
   schema: Schema,
@@ -109,7 +109,7 @@ const sendToolMessage = async (
   return toolMessage
 }
 
-export const schemaDesignTool: StructuredTool = tool(
+export const createMigrationTool: StructuredTool = tool(
   async (input: unknown, config: RunnableConfig): Promise<string> => {
     return withSentryCaptureException(async () => {
       const { toolCallId } = getConfigData(config)
@@ -122,7 +122,7 @@ export const schemaDesignTool: StructuredTool = tool(
         return errorMessage
       }
       const { repositories, designSessionId } = toolConfigurableResult.value
-      const parsed = v.safeParse(schemaDesignToolSchema, input)
+      const parsed = v.safeParse(createMigrationToolSchema, input)
       if (!parsed.success) {
         const errorDetails = parsed.issues
           .map((issue) => `${issue.path?.join('.')}: ${issue.message}`)

--- a/frontend/internal-packages/agent/src/pm-agent/nodes/invokeSaveArtifactToolNode.ts
+++ b/frontend/internal-packages/agent/src/pm-agent/nodes/invokeSaveArtifactToolNode.ts
@@ -5,7 +5,7 @@ import { processAnalyzedRequirementsTool } from '../tools/processAnalyzedRequire
 
 /**
  * Invoke Save Artifact Tool Node - Uses ToolNode to process analyzed requirements
- * This follows the same pattern as invokeSchemaDesignToolNode
+ * This follows the same pattern as invokeCreateMigrationToolNode
  */
 export const invokeSaveArtifactToolNode = async (
   state: PmAgentState,

--- a/frontend/internal-packages/agent/src/streaming/core/toolCallTypes.ts
+++ b/frontend/internal-packages/agent/src/streaming/core/toolCallTypes.ts
@@ -4,7 +4,7 @@ const toolNames = [
   'runTestTool',
   'processAnalyzedRequirementsTool',
   'saveTestcase',
-  'schemaDesignTool',
+  'createMigrationTool',
 ] as const
 
 const baseToolCallSchema = v.object({

--- a/frontend/internal-packages/agent/src/streaming/server/formatToolCallArgs.test.ts
+++ b/frontend/internal-packages/agent/src/streaming/server/formatToolCallArgs.test.ts
@@ -129,7 +129,7 @@ describe('formatToolCallArgs - Observable Behavior', () => {
   })
 
   describe('Real-world examples', () => {
-    it('formats schemaDesignTool args', () => {
+    it('formats createMigrationTool args', () => {
       const args = {
         operations: [
           { op: 'add', path: '/extensions/pgcrypto' },

--- a/frontend/internal-packages/agent/src/types.ts
+++ b/frontend/internal-packages/agent/src/types.ts
@@ -45,4 +45,4 @@ export type ToolName =
   | 'runTestTool'
   | 'processAnalyzedRequirementsTool'
   | 'saveTestcase'
-  | 'schemaDesignTool'
+  | 'createMigrationTool'


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5959

## Why is this change needed?

Renamed the Agent tool from `schemaDesignTool` to `createMigrationTool` to better reflect its actual purpose. The tool creates migration operations for database schema changes rather than just designing schemas, so the new name provides clearer semantics.

## Changes

### Tool Renaming
- **Tool**: `schemaDesignTool` → `createMigrationTool`
- **Node**: `invokeSchemaDesignToolNode` → `invokeCreateMigrationToolNode`
- **State flag**: `schemaDesignSuccessful` → `createMigrationSuccessful`

### Updated Components
- Agent core files (tools, nodes, routing)
- Type definitions (`ToolName` union type)
- Validation schemas (`toolNames` array)
- UI components and display name mappings
- All test files and Storybook stories
- Documentation including README and Mermaid diagrams

## Impact

- **Breaking Change**: No external API changes - this is an internal refactoring
- **Migration Required**: None - all references updated in this PR
- **Testing**: All existing tests pass with updated names

## Verification

- ✅ All linter checks pass (biome, tsc, eslint)
- ✅ Type checking successful
- ✅ Unit tests pass (routing, tool execution)
- ✅ Integration test structure updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed database migration tool and associated workflow components for improved naming clarity. Updated internal state tracking and routing logic to align with new tool nomenclature. Functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->