### PR TITLE
♻️ Remove diff display logic from MigrationsViewer

### DIFF
--- a/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/Output.tsx
@@ -92,11 +92,7 @@ export const Output: FC<Props> = ({
         className={styles.tabsContent}
         forceMount
       >
-        <Migrations
-          currentSchema={schema}
-          baselineSchema={baselineSchema}
-          comments={sqlReviewComments}
-        />
+        <Migrations currentSchema={schema} comments={sqlReviewComments} />
       </TabsContent>
       <TabsContent
         value={OUTPUT_TABS.ARTIFACT}

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/Migrations.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/Migrations.tsx
@@ -10,18 +10,12 @@ import { MigrationsViewer } from './MigrationsViewer'
 
 type Props = {
   currentSchema: Schema
-  baselineSchema: Schema
   comments?: ReviewComment[]
 }
 
-export const Migrations: FC<Props> = ({
-  currentSchema,
-  baselineSchema,
-  comments = [],
-}) => {
-  const { cumulativeDdl, prevCumulativeDdl } = useDdl({
+export const Migrations: FC<Props> = ({ currentSchema, comments = [] }) => {
+  const { cumulativeDdl } = useDdl({
     currentSchema,
-    baselineSchema,
   })
 
   return (
@@ -34,9 +28,7 @@ export const Migrations: FC<Props> = ({
       </div>
       <div className={styles.body}>
         <MigrationsViewer
-          showDiff
           doc={cumulativeDdl}
-          prevDoc={prevCumulativeDdl}
           comments={comments}
           showComments={false}
         />

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/MigrationsViewer/MigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/MigrationsViewer/MigrationsViewer.tsx
@@ -5,8 +5,6 @@ import { useMigrationsViewer } from './useMigrationsViewer'
 
 type Props = {
   doc: string
-  prevDoc?: string
-  showDiff?: boolean
   comments: ReviewComment[]
   showComments: boolean
   onQuickFix?: (comment: string) => void
@@ -14,16 +12,12 @@ type Props = {
 
 export const MigrationsViewer: FC<Props> = ({
   doc,
-  prevDoc,
-  showDiff,
   comments,
   showComments,
   onQuickFix,
 }) => {
   const { ref } = useMigrationsViewer({
     doc,
-    prevDoc,
-    showDiff,
     comments,
     showComments,
     onQuickFix,

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/MigrationsViewer/useMigrationsViewer/useMigrationsViewer.tsx
@@ -3,7 +3,6 @@
 import { sql } from '@codemirror/lang-sql'
 import { foldGutter, syntaxHighlighting } from '@codemirror/language'
 import { lintGutter } from '@codemirror/lint'
-import { unifiedMergeView } from '@codemirror/merge'
 import { EditorState, type Extension } from '@codemirror/state'
 import { drawSelection, lineNumbers } from '@codemirror/view'
 import { EditorView } from 'codemirror'
@@ -40,8 +39,6 @@ const baseExtensions: Extension[] = [
 
 type Props = {
   doc: string
-  prevDoc?: string
-  showDiff?: boolean
   comments?: ReviewComment[]
   showComments?: boolean
   onQuickFix?: (comment: string) => void
@@ -49,8 +46,6 @@ type Props = {
 
 export const useMigrationsViewer = ({
   doc,
-  prevDoc,
-  showDiff = false,
   comments = [],
   showComments = false,
   onQuickFix,
@@ -69,26 +64,11 @@ export const useMigrationsViewer = ({
     (
       showComments: boolean,
       onQuickFix?: (comment: string) => void,
-      showDiff?: boolean,
-      prevDoc?: string,
     ): Extension[] => {
       const extensions = [...baseExtensions]
 
       if (showComments && onQuickFix) {
         extensions.push(commentStateField(onQuickFix))
-      }
-
-      if (showDiff) {
-        extensions.push(
-          ...unifiedMergeView({
-            original: prevDoc || '',
-            highlightChanges: true,
-            gutter: true,
-            mergeControls: false,
-            syntaxHighlightDeletions: true,
-            allowInlineDiffs: true,
-          }),
-        )
       }
 
       return extensions
@@ -132,12 +112,7 @@ export const useMigrationsViewer = ({
   useEffect(() => {
     if (!container) return
 
-    const extensions = buildExtensions(
-      showComments,
-      onQuickFix,
-      showDiff,
-      prevDoc,
-    )
+    const extensions = buildExtensions(showComments, onQuickFix)
     const viewCurrent = createEditorView(doc, extensions, container)
     setView(viewCurrent)
 
@@ -149,8 +124,6 @@ export const useMigrationsViewer = ({
     }
   }, [
     doc,
-    prevDoc,
-    showDiff,
     container,
     showComments,
     comments,

--- a/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/hooks/useDdl.ts
+++ b/frontend/apps/app/components/SessionDetailPage/components/Output/components/Migrations/hooks/useDdl.ts
@@ -4,29 +4,20 @@ import { schemaToDdl } from '../utils/schemaToDdl'
 
 type Props = {
   currentSchema: Schema | null
-  baselineSchema: Schema | null
 }
 
 type Result = {
   cumulativeDdl: string
-  prevCumulativeDdl: string
 }
 
-export const useDdl = ({ currentSchema, baselineSchema }: Props): Result => {
+export const useDdl = ({ currentSchema }: Props): Result => {
   const cumulativeDdl = useMemo(() => {
     if (!currentSchema) return ''
     const result = schemaToDdl(currentSchema)
     return result.ddl
   }, [currentSchema])
 
-  const prevCumulativeDdl = useMemo(() => {
-    if (!baselineSchema) return ''
-    const result = schemaToDdl(baselineSchema)
-    return result.ddl
-  }, [baselineSchema])
-
   return {
     cumulativeDdl,
-    prevCumulativeDdl,
   }
 }

--- a/frontend/apps/app/package.json
+++ b/frontend/apps/app/package.json
@@ -6,7 +6,6 @@
     "@codemirror/lang-sql": "6.10.0",
     "@codemirror/language": "6.11.3",
     "@codemirror/lint": "6.9.0",
-    "@codemirror/merge": "6.11.0",
     "@codemirror/state": "6.5.2",
     "@codemirror/view": "6.38.5",
     "@electric-sql/pglite": "0.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,9 +76,6 @@ importers:
       '@codemirror/lint':
         specifier: 6.9.0
         version: 6.9.0
-      '@codemirror/merge':
-        specifier: 6.11.0
-        version: 6.11.0
       '@codemirror/state':
         specifier: 6.5.2
         version: 6.5.2
@@ -1886,9 +1883,6 @@ packages:
 
   '@codemirror/lint@6.9.0':
     resolution: {integrity: sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==}
-
-  '@codemirror/merge@6.11.0':
-    resolution: {integrity: sha512-Wu5Camx8u0jKA4yV3IxcWGMIoXUxuptsbWW9kTje8d/NInnnALeyQaxcVssJznp9FRnu4As3qsBhacERyB9p6w==}
 
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
@@ -12613,14 +12607,6 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.5
       crelt: 1.0.6
-
-  '@codemirror/merge@6.11.0':
-    dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/highlight': 1.2.1
-      style-mod: 4.1.3
 
   '@codemirror/search@6.5.11':
     dependencies:


### PR DESCRIPTION
## Issue

- resolve: https://github.com/route06/liam-internal/issues/5961

## Why is this change needed?

This PR removes the unused diff display functionality from MigrationsViewer component to simplify the codebase and reduce complexity.

The showDiff and prevCumulativeDdl features were not being actively used, and removing them provides the following benefits:
- Reduces bundle size by removing @codemirror/merge dependency usage
- Simplifies component props and data flow
- Improves maintainability by removing unused code paths
- Reduces component coupling by eliminating baselineSchema prop drilling through multiple component layers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed schema diff comparison from the migrations viewer; side-by-side diffs and previous-doc diffing are no longer available.

* **Refactor**
  * Simplified migrations flow to rely only on the current schema and show cumulative migration DDL with comments.

* **Chores**
  * Removed diff-related tooling from the app bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->