### PR TITLE
💄 Fix text overflow in RepositoryItem component

### DIFF
--- a/frontend/apps/app/components/ProjectNewPage/components/InstallationSelector/components/RepositoryList/RepositoryItem/RepositoryItem.module.css
+++ b/frontend/apps/app/components/ProjectNewPage/components/InstallationSelector/components/RepositoryList/RepositoryItem/RepositoryItem.module.css
@@ -1,5 +1,6 @@
 .wrapper {
   display: flex;
+  gap: var(--spacing-4);
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-3);
@@ -13,9 +14,11 @@
   display: flex;
   gap: var(--spacing-2);
   align-items: center;
+  min-width: 0;
 }
 
 .bookMarkIcon {
+  flex-shrink: 0;
   width: 1rem;
   height: 1rem;
   color: var(--overlay-50);
@@ -25,21 +28,28 @@
   display: flex;
   gap: var(--spacing-1half);
   align-items: center;
+  min-width: 0;
 }
 
 .name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: var(--font-size-4);
   line-height: 1;
   color: var(--global-foreground);
+  white-space: nowrap;
 }
 
 .lockIcon {
+  flex-shrink: 0;
   width: 0.625rem;
   height: 0.625rem;
   color: var(--overlay-50);
 }
 
 .createdAt {
+  flex-shrink: 0;
   font-size: var(--font-size-2);
   line-height: 1;
   color: var(--overlay-50);

--- a/frontend/apps/app/components/ProjectNewPage/components/InstallationSelector/components/RepositoryList/RepositoryItem/RepositoryItem.stories.tsx
+++ b/frontend/apps/app/components/ProjectNewPage/components/InstallationSelector/components/RepositoryList/RepositoryItem/RepositoryItem.stories.tsx
@@ -48,6 +48,7 @@ export const LongName: Story = {
   args: {
     item: aRepository({
       name: 'very-long-organization-name/very-long-repository-name',
+      private: true,
     }),
   },
 }


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/pull/3947#discussion_r2479862648

## Why is this change needed?

When repository names are too long, they caused layout overflow issues in the RepositoryItem component. The text and icons would overflow beyond the container boundaries, breaking the intended layout.

## Changes

### Text Truncation
- Added `text-overflow: ellipsis` with `overflow: hidden` and `white-space: nowrap` to `.name` class
- Long repository names now display with ellipsis (...) when they exceed available space

### Flexbox Layout Fixes
- Added `min-width: 0` to `.content` and `.info` containers to enable proper text truncation in nested flex layouts
- Added `flex-shrink: 0` to fixed-size elements (`.bookMarkIcon`, `.lockIcon`, `.createdAt`) to prevent them from being compressed

### Layout Improvement
- Updated `.wrapper` gap from `var(--spacing-3)` to `var(--spacing-4)` for better visual spacing

### Testing

| Before | After |
|--------|--------|
| <img width="854" height="208" alt="image" src="https://github.com/user-attachments/assets/fba2f313-7d86-43ab-aac4-2429113c4850" /> | <img width="407" height="73" alt="スクリーンショット 2025-10-31 11 38 55" src="https://github.com/user-attachments/assets/79880d3d-7658-4022-ba8b-3051bf7f97b5" /> | 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout spacing and gaps in the repository item display.
  * Improved text truncation and overflow handling for long repository names.

* **Tests**
  * Updated test scenarios to include private repository display cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->