### PR TITLE
fix: handle interleave constraints as foreign key to visualize relations for Cloud Spanner

### DIFF
--- a/frontend/packages/schema/src/parser/tbls/index.test.ts
+++ b/frontend/packages/schema/src/parser/tbls/index.test.ts
@@ -618,6 +618,54 @@ describe(processor, () => {
         expect(value.tables['posts']?.constraints).toEqual(expected)
       })
 
+      it('INTERLEAVE constraint', async () => {
+        const { value } = await processor(
+          JSON.stringify({
+            name: 'testdb',
+            tables: [
+              {
+                name: 'singers',
+                type: 'TABLE',
+                columns: [{ name: 'singer_id', type: 'int', nullable: false }],
+              },
+              {
+                name: 'albums',
+                type: 'TABLE',
+                columns: [
+                  { name: 'singer_id', type: 'int', nullable: false },
+                  { name: 'album_id', type: 'int', nullable: false },
+                ],
+                constraints: [
+                  {
+                    type: 'INTERLEAVE',
+                    name: 'albums_interleave',
+                    def: 'INTERLEAVE IN PARENT singers ON DELETE CASCADE',
+                    table: 'albums',
+                    referenced_table: 'singers',
+                    columns: ['singer_id', 'album_id'],
+                    referenced_columns: ['singer_id'],
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+
+        const expected = {
+          albums_interleave: {
+            type: 'FOREIGN KEY',
+            name: 'albums_interleave',
+            columnNames: ['singer_id', 'album_id'],
+            targetTableName: 'singers',
+            targetColumnNames: ['singer_id'],
+            updateConstraint: 'NO_ACTION',
+            deleteConstraint: 'CASCADE',
+          },
+        }
+
+        expect(value.tables['albums']?.constraints).toEqual(expected)
+      })
+
       it('UNIQUE constraint', async () => {
         const { value } = await processor(
           JSON.stringify({

--- a/frontend/packages/schema/src/parser/tbls/parser.ts
+++ b/frontend/packages/schema/src/parser/tbls/parser.ts
@@ -212,6 +212,59 @@ function processCheckConstraint(constraint: {
 }
 
 /**
+ * Process an INTERLEAVE constraint as a FOREIGN KEY fallback.
+ *
+ * tbls can represent Cloud Spanner parent-child relationships as
+ * INTERLEAVE constraints, but Liam's internal schema model does not
+ * support INTERLEAVE as a first-class constraint type.
+ *
+ * To keep the fix scoped to the tbls parser and reuse the existing
+ * relationship generation pipeline, INTERLEAVE is normalized into a
+ * FOREIGN KEY-shaped constraint here.
+ *
+ * If we fully support Spanner INTERLEAVE in Liam, we should reconsider this approach
+ * and potentially add INTERLEAVE as a first-class constraint type in the schema model.
+ *
+ * @see https://github.com/liam-hq/liam/issues/2411#issuecomment-3082740297
+ */
+function processInterleaveConstraint(constraint: {
+  type: string
+  name: string
+  columns?: string[]
+  def: string
+  referenced_table?: string
+  referenced_columns?: string[]
+}): [string, Constraints[string]] | null {
+  if (
+    constraint.type === 'INTERLEAVE' &&
+    constraint.columns &&
+    constraint.columns.length > 0 &&
+    constraint.referenced_columns &&
+    constraint.referenced_columns.length > 0 &&
+    constraint.referenced_table
+  ) {
+    const { updateConstraint, deleteConstraint } = extractForeignKeyActions(
+      constraint.def,
+    )
+
+    return [
+      constraint.name,
+      {
+        type: 'FOREIGN KEY',
+        name: constraint.name,
+        columnNames: constraint.columns,
+        targetTableName: constraint.referenced_table,
+        targetColumnNames: constraint.referenced_columns,
+        updateConstraint,
+        deleteConstraint,
+      },
+    ]
+  }
+
+  return null
+}
+
+/**
  * Process constraints for a table
  */
 function processConstraints(
@@ -244,6 +297,8 @@ function processConstraints(
       result = processUniqueConstraint(constraint)
     } else if (constraint.type === 'CHECK') {
       result = processCheckConstraint(constraint)
+    } else if (constraint.type === 'INTERLEAVE') {
+      result = processInterleaveConstraint(constraint)
     }
 
     // Add constraint to the collection if valid


### PR DESCRIPTION
## Issue

- resolve: #2411

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->

I created https://github.com/liam-hq/liam/pull/2548 to fix this issue, but this change affects common schema not only tbls but prisma..etc.
I strongly agree with solution no.3 (https://github.com/liam-hq/liam/issues/2411#issuecomment-3082740297) while we don't fully support cloud spanner in the perspective of maintaining liam.

This PR implements solution no.3 by handling tbls interleave constraint as foreign key.

## Evidence

I put [schema.json](https://github.com/KaoruMuta/spanner-playground/blob/d637654ad45d6f0d3453e5af42726f26a790c760/docs/schema.json) by tbls which reflects cloud spanner schema information and check the behavior after rendering.

<img width="1269" height="830" alt="image" src="https://github.com/user-attachments/assets/722fb8cd-15c3-48d9-aecd-636d9e5cac6c" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/liam-hq/liam/pull/4076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema parser now recognizes and processes INTERLEAVE constraints as foreign key relationships, with proper handling of delete and update actions.

* **Tests**
  * Added test coverage for INTERLEAVE constraint parsing to verify correct conversion to foreign key format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->