### PR TITLE
feat(github): add countDependencies helper

### DIFF
--- a/frontend/internal-packages/github/src/countDependencies.ts
+++ b/frontend/internal-packages/github/src/countDependencies.ts
@@ -1,0 +1,38 @@
+import * as v from 'valibot'
+import { downloadFileContent } from './api.server'
+
+const packageJsonSchema = v.object({
+  dependencies: v.optional(v.record(v.string(), v.unknown())),
+})
+
+export async function countDependencies(
+  repositoryFullName: string,
+  ref: string,
+): Promise<{ count: number } | { error: string }> {
+  const url = `https://raw.githubusercontent.com/${repositoryFullName}/${ref}/package.json`
+
+  const downloadResult = await downloadFileContent(url)
+  if (downloadResult.isErr()) {
+    return { error: downloadResult.error.message }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(downloadResult.value)
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? `Failed to parse package.json: ${error.message}`
+          : 'Failed to parse package.json',
+    }
+  }
+
+  const validation = v.safeParse(packageJsonSchema, parsed)
+  if (!validation.success) {
+    return { error: 'Invalid package.json structure' }
+  }
+
+  const dependencies = validation.output.dependencies ?? {}
+  return { count: Object.keys(dependencies).length }
+}

--- a/frontend/internal-packages/github/src/index.ts
+++ b/frontend/internal-packages/github/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api.oauth'
 export * from './api.server'
 export * from './config'
+export * from './countDependencies'
 export * from './factories'
 export * from './types'


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

\`@liam-hq/github\` パッケージに、リポジトリの \`package.json\` の \`dependencies\` フィールドのエントリ数を数えるヘルパー関数 \`countDependencies\` を追加します。

- \`raw.githubusercontent.com\` から対象リポジトリ・ref の \`package.json\` を [\`downloadFileContent\`](frontend/internal-packages/github/src/api.server.ts) 経由で取得
- JSON パースと構造検証は \`valibot\` で行い、\`dependencies\` のキー数を返却
- 成功時は \`{ count: number }\`、失敗時は \`{ error: string }\` を返すシンプルな API

## What changes

- 新規ファイル: [frontend/internal-packages/github/src/countDependencies.ts](frontend/internal-packages/github/src/countDependencies.ts)
- [frontend/internal-packages/github/src/index.ts](frontend/internal-packages/github/src/index.ts) から re-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to count and retrieve dependency information from GitHub repositories, enabling enhanced insights into project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liam-hq/liam/pull/4095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->