### PR TITLE
feat(github): add countDependencies helper

### DIFF
--- a/frontend/internal-packages/github/src/countDependencies.ts
+++ b/frontend/internal-packages/github/src/countDependencies.ts
@@ -1,0 +1,44 @@
+import { getFileContent } from './api.server'
+
+export async function countDependencies(
+  repositoryFullName: string,
+  ref: string,
+  installationId: number,
+): Promise<{ count: number } | { error: string }> {
+  const { content } = await getFileContent(
+    repositoryFullName,
+    'package.json',
+    ref,
+    installationId,
+  )
+
+  if (content === null) {
+    return {
+      error: `Failed to fetch package.json from ${repositoryFullName}@${ref}`,
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { error: `Failed to parse package.json: ${message}` }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { error: 'package.json is not a valid object' }
+  }
+
+  if (!('dependencies' in parsed)) {
+    return { count: 0 }
+  }
+
+  const dependencies = parsed.dependencies
+
+  if (typeof dependencies !== 'object' || dependencies === null) {
+    return { error: 'dependencies field is not a valid object' }
+  }
+
+  return { count: Object.keys(dependencies).length }
+}

--- a/frontend/internal-packages/github/src/index.ts
+++ b/frontend/internal-packages/github/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api.oauth'
 export * from './api.server'
 export * from './config'
+export * from './countDependencies'
 export * from './factories'
 export * from './types'


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

`getFileContent` を使って指定リポジトリの `package.json` を取得し、`dependencies` フィールドのキー数を数える小さなユーティリティ `countDependencies` を追加します。

- 成功時: `{ count: number }`
- 失敗時: `{ error: string }` （取得失敗 / JSON パース失敗 / 形式不正など）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to retrieve and count dependencies from GitHub repository project files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liam-hq/liam/pull/4096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->