### PR TITLE
feat(github): add countDependencies helper

### DIFF
--- a/frontend/internal-packages/github/src/countDependencies.ts
+++ b/frontend/internal-packages/github/src/countDependencies.ts
@@ -1,0 +1,60 @@
+import {
+  err,
+  fromThrowable,
+  fromValibotSafeParse,
+  ok,
+  type Result,
+} from '@liam-hq/neverthrow'
+import * as v from 'valibot'
+import { downloadFileContent } from './api.server'
+
+const packageJsonSchema = v.object({
+  dependencies: v.optional(v.record(v.string(), v.unknown())),
+})
+
+const parseJson = fromThrowable(
+  (text: string): unknown => JSON.parse(text),
+  (error) =>
+    new Error(
+      `Failed to parse package.json: ${error instanceof Error ? error.message : String(error)}`,
+    ),
+)
+
+const countDependenciesResult = async (
+  repositoryFullName: string,
+  ref: string,
+): Promise<Result<number, Error>> => {
+  const url = `https://raw.githubusercontent.com/${repositoryFullName}/${ref}/package.json`
+
+  const downloadResult = await downloadFileContent(url)
+  if (downloadResult.isErr()) {
+    return err(
+      new Error(
+        `Failed to download package.json from ${url}: ${downloadResult.error.message}`,
+      ),
+    )
+  }
+
+  const parsed = parseJson(downloadResult.value)
+  if (parsed.isErr()) return err(parsed.error)
+
+  const validated = fromValibotSafeParse(packageJsonSchema, parsed.value)
+  if (validated.isErr()) {
+    return err(
+      new Error(`Invalid package.json structure: ${validated.error.message}`),
+    )
+  }
+
+  return ok(Object.keys(validated.value.dependencies ?? {}).length)
+}
+
+export const countDependencies = async (
+  repositoryFullName: string,
+  ref: string,
+): Promise<{ count: number } | { error: string }> => {
+  const result = await countDependenciesResult(repositoryFullName, ref)
+  return result.match(
+    (count) => ({ count }),
+    (error) => ({ error: error.message }),
+  )
+}

--- a/frontend/internal-packages/github/src/countDependencies.ts
+++ b/frontend/internal-packages/github/src/countDependencies.ts
@@ -1,9 +1,7 @@
 import {
-  err,
   fromThrowable,
   fromValibotSafeParse,
-  ok,
-  type Result,
+  ResultAsync,
 } from '@liam-hq/neverthrow'
 import * as v from 'valibot'
 import { downloadFileContent } from './api.server'
@@ -17,44 +15,35 @@ const parseJson = fromThrowable(
   (error) =>
     new Error(
       `Failed to parse package.json: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error instanceof Error ? error : undefined },
     ),
 )
-
-const countDependenciesResult = async (
-  repositoryFullName: string,
-  ref: string,
-): Promise<Result<number, Error>> => {
-  const url = `https://raw.githubusercontent.com/${repositoryFullName}/${ref}/package.json`
-
-  const downloadResult = await downloadFileContent(url)
-  if (downloadResult.isErr()) {
-    return err(
-      new Error(
-        `Failed to download package.json from ${url}: ${downloadResult.error.message}`,
-      ),
-    )
-  }
-
-  const parsed = parseJson(downloadResult.value)
-  if (parsed.isErr()) return err(parsed.error)
-
-  const validated = fromValibotSafeParse(packageJsonSchema, parsed.value)
-  if (validated.isErr()) {
-    return err(
-      new Error(`Invalid package.json structure: ${validated.error.message}`),
-    )
-  }
-
-  return ok(Object.keys(validated.value.dependencies ?? {}).length)
-}
 
 export const countDependencies = async (
   repositoryFullName: string,
   ref: string,
 ): Promise<{ count: number } | { error: string }> => {
-  const result = await countDependenciesResult(repositoryFullName, ref)
-  return result.match(
-    (count) => ({ count }),
-    (error) => ({ error: error.message }),
-  )
+  const url = `https://raw.githubusercontent.com/${repositoryFullName}/${ref}/package.json`
+
+  return new ResultAsync(downloadFileContent(url))
+    .mapErr(
+      (e) =>
+        new Error(`Failed to download package.json from ${url}: ${e.message}`, {
+          cause: e,
+        }),
+    )
+    .andThen(parseJson)
+    .andThen((parsed) =>
+      fromValibotSafeParse(packageJsonSchema, parsed).mapErr(
+        (e) =>
+          new Error(`Invalid package.json structure: ${e.message}`, {
+            cause: e,
+          }),
+      ),
+    )
+    .map((validated) => Object.keys(validated.dependencies ?? {}).length)
+    .match(
+      (count) => ({ count }),
+      (error) => ({ error: error.message }),
+    )
 }

--- a/frontend/internal-packages/github/src/index.ts
+++ b/frontend/internal-packages/github/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api.oauth'
 export * from './api.server'
 export * from './config'
+export * from './countDependencies'
 export * from './factories'
 export * from './types'

--- a/frontend/internal-packages/github/tsconfig.json
+++ b/frontend/internal-packages/github/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "declaration": true,
     "target": "ES2022",
+    "lib": ["dom", "es2022"],
     "moduleResolution": "node"
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Issue

- resolve:

## Why is this change needed?

\`@liam-hq/github\` パッケージに、リポジトリの \`package.json\` を取得して \`dependencies\` 数を返すヘルパー \`countDependencies\` を追加します。

- \`downloadFileContent\` で raw.githubusercontent.com から \`package.json\` を取得
- \`@liam-hq/neverthrow\` の Result スタイルで内部処理（fromThrowable / fromValibotSafeParse / early return）
- valibot で \`dependencies\` フィールドの構造検証
- 公開シグネチャは仕様通り \`Promise<{ count: number } | { error: string }>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public function to retrieve the number of dependencies declared in a GitHub repository's package manifest.
* **Chores**
  * Exposed the new function via the package's public API surface and updated TypeScript library settings to ensure compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liam-hq/liam/pull/4097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->