### PR TITLE
✨ feat(schema): add SQLite support to Drizzle schema parser

### DIFF
--- a/.changeset/add-sqlite-drizzle-parser.md
+++ b/.changeset/add-sqlite-drizzle-parser.md
@@ -1,0 +1,8 @@
+---
+"@liam-hq/schema": minor
+---
+
+- ✨ Add SQLite support to the Drizzle schema parser
+  - Auto-detect `drizzle-orm/sqlite-core` imports and `sqliteTable()` calls
+  - Parse columns, foreign keys, indexes, and composite primary keys (array and object callback forms)
+  - Map SQLite types (`integer`, `text`, `real`, `blob`, `numeric`); `text` with `{ enum }` is parsed as `text` since SQLite has no native enum type

--- a/frontend/apps/docs/content/docs/parser/supported-formats/drizzle.mdx
+++ b/frontend/apps/docs/content/docs/parser/supported-formats/drizzle.mdx
@@ -32,17 +32,20 @@ This allows you to generate the ER diagram from all schema files in the specifie
 
 ## Database Type Support
 
-Drizzle support in Liam ERD automatically detects whether you're using PostgreSQL or MySQL based on your imports:
+Drizzle support in Liam ERD automatically detects whether you're using PostgreSQL, MySQL, or SQLite based on your imports:
 
 - **PostgreSQL**: Uses imports from `drizzle-orm/pg-core` (e.g., `pgTable`, `pgEnum`)
 - **MySQL**: Uses imports from `drizzle-orm/mysql-core` (e.g., `mysqlTable`, `mysqlEnum`)
+- **SQLite**: Uses imports from `drizzle-orm/sqlite-core` (e.g., `sqliteTable`)
 
 The parser supports common Drizzle features including tables, columns, relationships, indexes, and constraints. However, some advanced features like multiple database schemas may not be fully supported yet.
+
+Note: SQLite has no native enum type, so columns defined with `text('status', { enum: [...] })` are parsed as `text`.
 
 ## Under the Hood
 
 Liam CLI analyzes your TypeScript schema files using a custom parser that:
-- Automatically detects the database type (PostgreSQL or MySQL) from your imports
+- Automatically detects the database type (PostgreSQL, MySQL, or SQLite) from your imports
 - Extracts table definitions, column types, and relationships
 - Supports Drizzle-specific features like enums, indexes, and constraints
 - Handles complex type definitions and default values

--- a/frontend/apps/docs/content/docs/parser/supported-formats/sqlite.mdx
+++ b/frontend/apps/docs/content/docs/parser/supported-formats/sqlite.mdx
@@ -2,7 +2,17 @@
 title: SQLite
 ---
 
-Currently, SQLite is supported through the tbls integration. While direct SQLite support is not yet implemented, you can use tbls as a workaround to generate schema documentation for your SQLite database.
+If your SQLite schema is defined with [Drizzle ORM](https://orm.drizzle.team/), you can generate an ER diagram directly from your schema files using the `drizzle` format. For SQLite databases themselves, you can use tbls as a workaround to generate schema documentation.
+
+## Using Drizzle ORM with SQLite
+
+If your schema files use `drizzle-orm/sqlite-core` (e.g., `sqliteTable`), specify `--format drizzle` as follows:
+
+```bash
+npx @liam-hq/cli erd build --format drizzle --input src/db/schema.ts
+```
+
+For more details, see the [Drizzle documentation](/docs/parser/supported-formats/drizzle).
 
 ## Using tbls with SQLite
 
@@ -26,4 +36,4 @@ For more details about using tbls format, see the [tbls documentation](/docs/par
 
 ## Direct SQLite Support
 
-Direct SQLite support is planned but not yet implemented. If you're interested in this feature, please follow or contribute to the discussion on [GitHub](https://github.com/liam-hq/liam/discussions/364).
+Direct parsing of SQLite databases or DDL files is planned but not yet implemented. If you're interested in this feature, please follow or contribute to the discussion on [GitHub](https://github.com/liam-hq/liam/discussions/364).

--- a/frontend/packages/schema/src/parser/drizzle/__tests__/autoDetection.test.ts
+++ b/frontend/packages/schema/src/parser/drizzle/__tests__/autoDetection.test.ts
@@ -48,6 +48,29 @@ describe('Drizzle auto-detection', () => {
     )
   })
 
+  it('should detect SQLite schema and use SQLite parser', async () => {
+    const sqliteSchema = `
+      import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+
+      export const users = sqliteTable('users', {
+        id: integer('id').primaryKey({ autoIncrement: true }),
+        name: text('name').notNull(),
+      });
+    `
+
+    const { value, errors } = await processor(sqliteSchema)
+
+    expect(errors).toHaveLength(0)
+    expect(value.tables).toHaveProperty('users')
+    expect(value.tables['users']?.columns).toHaveProperty('id')
+    expect(value.tables['users']?.columns).toHaveProperty('name')
+
+    // Check that SQLite-specific features are parsed correctly
+    expect(value.tables['users']?.columns['id']?.default).toBe(
+      'autoincrement()',
+    )
+  })
+
   it('should default to PostgreSQL for ambiguous schemas', async () => {
     const ambiguousSchema = `
       // No specific imports or table functions
@@ -87,5 +110,20 @@ describe('Drizzle auto-detection', () => {
 
     // Should be detected as PostgreSQL even without imports
     expect(value).toBeDefined()
+  })
+
+  it('should detect SQLite by table function names', async () => {
+    const sqliteSchemaWithFunctions = `
+      export const users = sqliteTable('users', {
+        id: integer('id').primaryKey({ autoIncrement: true }),
+      });
+    `
+
+    const { value } = await processor(sqliteSchemaWithFunctions)
+
+    // Should be detected as SQLite even without imports
+    expect(value.tables['users']?.columns['id']?.default).toBe(
+      'autoincrement()',
+    )
   })
 })

--- a/frontend/packages/schema/src/parser/drizzle/__tests__/unified.test.ts
+++ b/frontend/packages/schema/src/parser/drizzle/__tests__/unified.test.ts
@@ -4,11 +4,12 @@ import { aColumn, anIndex, aSchema, aTable } from '../../../schema/index.js'
 import { createParserTestCases } from '../../__tests__/index.js'
 import { processor as mysqlProcessor } from '../mysql/index.js'
 import { processor as postgresProcessor } from '../postgres/index.js'
+import { processor as sqliteProcessor } from '../sqlite/index.js'
 
 /**
- * Unified test suite for MySQL and PostgreSQL Drizzle parsers
+ * Unified test suite for MySQL, PostgreSQL, and SQLite Drizzle parsers
  * This test suite reduces code duplication by running the same test cases
- * against both database parsers with parameterized configurations.
+ * against all database parsers with parameterized configurations.
  */
 
 // Database configuration for parameterized tests
@@ -30,12 +31,13 @@ const dbConfigs = {
     },
     types: {
       id: 'int',
-      idColumn: () => "int('id').primaryKey().autoincrement()",
+      idColumn: (name = 'id') => `int('${name}').primaryKey().autoincrement()`,
       varchar: 'varchar',
       text: 'text',
       integer: 'int',
       bigint: 'bigint',
       boolean: 'boolean',
+      booleanColumn: (name: string) => `boolean('${name}')`,
       timestamp: 'timestamp',
       decimal: 'decimal',
       json: 'json',
@@ -105,12 +107,13 @@ const dbConfigs = {
     },
     types: {
       id: 'serial',
-      idColumn: () => "serial('id').primaryKey()",
+      idColumn: (name = 'id') => `serial('${name}').primaryKey()`,
       varchar: 'varchar',
       text: 'text',
       integer: 'integer',
       bigint: 'bigint',
       boolean: 'boolean',
+      booleanColumn: (name: string) => `boolean('${name}')`,
       timestamp: 'timestamp',
       decimal: 'decimal',
       json: 'json',
@@ -163,6 +166,83 @@ const dbConfigs = {
         },
       }),
   },
+  sqlite: {
+    name: 'SQLite',
+    processor: sqliteProcessor,
+    imports: {
+      core: 'drizzle-orm/sqlite-core',
+      relations: 'drizzle-orm',
+    },
+    functions: {
+      table: 'sqliteTable',
+      enum: '', // SQLite has no native enum type
+      index: 'index',
+      uniqueIndex: 'uniqueIndex',
+      primaryKey: 'primaryKey',
+      check: 'check',
+    },
+    types: {
+      id: 'integer',
+      idColumn: (name = 'id') =>
+        `integer('${name}').primaryKey({ autoIncrement: true })`,
+      varchar: 'text',
+      text: 'text',
+      integer: 'integer',
+      bigint: 'blob',
+      boolean: 'integer',
+      booleanColumn: (name: string) =>
+        `integer('${name}', { mode: 'boolean' })`,
+      timestamp: 'integer',
+      decimal: 'numeric',
+      json: 'text',
+    },
+    expectedTypes: {
+      id: 'integer',
+      varchar: (length: number) => `text(${length})`,
+      text: 'text',
+      integer: 'integer',
+      bigint: 'blob',
+      boolean: 'integer',
+      timestamp: 'integer',
+      decimal: (_precision: number, _scale: number) => 'numeric',
+      json: 'text',
+      enum: 'text',
+    },
+    userTableBase: (override?: Partial<Table>) =>
+      aSchema({
+        tables: {
+          users: aTable({
+            name: 'users',
+            columns: {
+              id: aColumn({
+                name: 'id',
+                type: 'integer',
+                default: 'autoincrement()',
+                notNull: true,
+              }),
+              ...override?.columns,
+            },
+            indexes: {
+              users_pkey: anIndex({
+                name: 'users_pkey',
+                columns: ['id'],
+                unique: true,
+              }),
+              ...override?.indexes,
+            },
+            constraints: {
+              PRIMARY_id: {
+                type: 'PRIMARY KEY',
+                name: 'PRIMARY_id',
+                columnNames: ['id'],
+              },
+              ...override?.constraints,
+            },
+            comment: override?.comment ?? null,
+          }),
+        },
+      }),
+  },
 } as const
 
 describe.each(Object.entries(dbConfigs))(
@@ -173,11 +253,11 @@ describe.each(Object.entries(dbConfigs))(
     describe(`should parse ${config.name} schema correctly`, () => {
       it('basic table with columns', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }).notNull(),
+          name: ${config.types.varchar}('name', { length: 255 }).notNull(),
         });
       `
 
@@ -252,11 +332,11 @@ describe.each(Object.entries(dbConfigs))(
 
       it('default value as boolean', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, boolean } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.boolean} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          active: boolean('active').default(true).notNull(),
+          active: ${config.types.booleanColumn('active')}.default(true).notNull(),
         });
       `
 
@@ -305,11 +385,11 @@ describe.each(Object.entries(dbConfigs))(
 
       it('unique constraint', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          email: varchar('email', { length: 255 }).unique(),
+          email: ${config.types.varchar}('email', { length: 255 }).unique(),
         });
       `
 
@@ -339,18 +419,18 @@ describe.each(Object.entries(dbConfigs))(
         const foreignKeyRef = `${config.types.integer}('user_id').references(() => users.id)`
 
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, varchar } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, ${config.types.varchar} } from '${config.imports.core}';
         import { relations } from '${config.imports.relations}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
         });
 
         export const posts = ${config.functions.table}('posts', {
           id: ${config.types.idColumn()},
           userId: ${foreignKeyRef},
-          title: varchar('title', { length: 255 }),
+          title: ${config.types.varchar}('title', { length: 255 }),
         });
 
         export const usersRelations = relations(users, ({ many }) => ({
@@ -388,13 +468,13 @@ describe.each(Object.entries(dbConfigs))(
 
       it('composite index', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar, ${config.functions.index} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${config.functions.index} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          firstName: varchar('first_name', { length: 255 }),
-          lastName: varchar('last_name', { length: 255 }),
-          email: varchar('email', { length: 255 }),
+          firstName: ${config.types.varchar}('first_name', { length: 255 }),
+          lastName: ${config.types.varchar}('last_name', { length: 255 }),
+          email: ${config.types.varchar}('email', { length: 255 }),
         }, (table) => ({
           nameIdx: ${config.functions.index}('name_idx').on(table.firstName, table.lastName),
           emailIdx: ${config.functions.index}('email_idx').on(table.email),
@@ -414,11 +494,17 @@ describe.each(Object.entries(dbConfigs))(
       })
 
       it('multiple data types', async () => {
+        // Skip for SQLite since boolean, timestamp, and decimal are not SQLite types
+        // (SQLite core types are covered in sqlite/__tests__/index.test.ts)
+        if (dbType === 'sqlite') {
+          return
+        }
+
         const schema = `
         import { 
           ${config.functions.table}, 
           ${config.types.id}, 
-          varchar, 
+          ${config.types.varchar},
           text, 
           ${config.types.integer}, 
           ${config.types.bigint}, 
@@ -430,7 +516,7 @@ describe.each(Object.entries(dbConfigs))(
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }).notNull(),
+          name: ${config.types.varchar}('name', { length: 255 }).notNull(),
           bio: text('bio'),
           age: ${config.types.integer}('age'),
           salary: ${config.types.bigint}('salary', { mode: 'number' }),
@@ -494,17 +580,22 @@ describe.each(Object.entries(dbConfigs))(
       })
 
       it('enum type', async () => {
+        // Skip for SQLite since it has no native enum type
+        if (dbType === 'sqlite') {
+          return
+        }
+
         const enumFunction = config.functions.enum
         const enumType = dbType === 'mysql' ? 'enum' : 'role'
 
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar, ${enumFunction} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${enumFunction} } from '${config.imports.core}';
 
         ${dbType === 'postgres' ? `export const roleEnum = ${enumFunction}('role', ['user', 'admin']);` : ''}
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
           role: ${
             dbType === 'mysql'
               ? `${enumFunction}('role', ['user', 'admin']).default('user')`
@@ -546,13 +637,13 @@ describe.each(Object.entries(dbConfigs))(
       if (dbType === 'postgres') {
         it('postgres enum definitions (declared enum pattern)', async () => {
           const schema = `
-          import { pgTable, serial, varchar, pgEnum } from 'drizzle-orm/pg-core';
+          import { pgTable, serial, ${config.types.varchar}, pgEnum } from 'drizzle-orm/pg-core';
 
           export const roleEnum = pgEnum('role', ['user', 'admin', 'moderator']);
 
           export const users = pgTable('users', {
             id: serial('id').primaryKey(),
-            name: varchar('name', { length: 255 }),
+            name: ${config.types.varchar}('name', { length: 255 }),
             role: roleEnum('role').default('user'),
           });
         `
@@ -570,14 +661,14 @@ describe.each(Object.entries(dbConfigs))(
 
         it('postgres multiple enum definitions', async () => {
           const schema = `
-          import { pgTable, serial, varchar, pgEnum } from 'drizzle-orm/pg-core';
+          import { pgTable, serial, ${config.types.varchar}, pgEnum } from 'drizzle-orm/pg-core';
 
           export const roleEnum = pgEnum('role', ['user', 'admin']);
           export const statusEnum = pgEnum('status', ['active', 'inactive', 'pending']);
 
           export const users = pgTable('users', {
             id: serial('id').primaryKey(),
-            name: varchar('name', { length: 255 }),
+            name: ${config.types.varchar}('name', { length: 255 }),
             role: roleEnum('role').default('user'),
             status: statusEnum('status').default('active'),
           });
@@ -606,11 +697,11 @@ describe.each(Object.entries(dbConfigs))(
       if (dbType === 'mysql') {
         it('mysql enum definitions (inline enum pattern)', async () => {
           const schema = `
-          import { mysqlTable, int, varchar, mysqlEnum } from 'drizzle-orm/mysql-core';
+          import { mysqlTable, int, ${config.types.varchar}, mysqlEnum } from 'drizzle-orm/mysql-core';
 
           export const users = mysqlTable('users', {
             id: int('id').primaryKey().autoincrement(),
-            name: varchar('name', { length: 255 }),
+            name: ${config.types.varchar}('name', { length: 255 }),
             role: mysqlEnum('role', ['user', 'admin', 'moderator']).default('user'),
           });
         `
@@ -628,11 +719,11 @@ describe.each(Object.entries(dbConfigs))(
 
         it('mysql multiple enum definitions', async () => {
           const schema = `
-          import { mysqlTable, int, varchar, mysqlEnum } from 'drizzle-orm/mysql-core';
+          import { mysqlTable, int, ${config.types.varchar}, mysqlEnum } from 'drizzle-orm/mysql-core';
 
           export const users = mysqlTable('users', {
             id: int('id').primaryKey().autoincrement(),
-            name: varchar('name', { length: 255 }),
+            name: ${config.types.varchar}('name', { length: 255 }),
             role: mysqlEnum('role', ['user', 'admin']).default('user'),
             status: mysqlEnum('status', ['active', 'inactive', 'pending']).default('active'),
           });
@@ -659,21 +750,21 @@ describe.each(Object.entries(dbConfigs))(
       }
 
       it('empty enum definition (Postgres only - MySQL requires at least one value)', async () => {
-        // Skip for MySQL since empty enums are not valid
-        if (dbType === 'mysql') {
+        // Skip for MySQL since empty enums are not valid, and for SQLite since it has no enums
+        if (dbType !== 'postgres') {
           return
         }
 
         const enumFunction = config.functions.enum
 
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar, ${enumFunction} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${enumFunction} } from '${config.imports.core}';
 
         export const emptyEnum = ${enumFunction}('empty_enum', []);
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
           empty_field: emptyEnum('empty_field'),
         });
       `
@@ -691,18 +782,18 @@ describe.each(Object.entries(dbConfigs))(
 
       it('foreign key constraint (one-to-one)', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, varchar } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, ${config.types.varchar} } from '${config.imports.core}';
         import { relations } from '${config.imports.relations}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
         });
 
         export const profiles = ${config.functions.table}('profiles', {
           id: ${config.types.idColumn()},
           userId: ${config.types.integer}('user_id').references(() => users.id).unique(),
-          bio: varchar('bio', { length: 500 }),
+          bio: ${config.types.varchar}('bio', { length: 500 }),
         });
 
         export const usersRelations = relations(users, ({ one }) => ({
@@ -752,11 +843,11 @@ describe.each(Object.entries(dbConfigs))(
 
       it('foreign key constraint with cascade actions', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, varchar } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, ${config.types.varchar} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
         });
 
         export const posts = ${config.functions.table}('posts', {
@@ -765,7 +856,7 @@ describe.each(Object.entries(dbConfigs))(
             onDelete: 'cascade',
             onUpdate: 'restrict',
           }),
-          title: varchar('title', { length: 255 }),
+          title: ${config.types.varchar}('title', { length: 255 }),
         });
       `
 
@@ -786,17 +877,17 @@ describe.each(Object.entries(dbConfigs))(
 
       it('many-to-many relationship with junction table', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, varchar, ${config.functions.primaryKey} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, ${config.types.varchar}, ${config.functions.primaryKey} } from '${config.imports.core}';
         import { relations } from '${config.imports.relations}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
         });
 
         export const tags = ${config.functions.table}('tags', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 100 }).unique(),
+          name: ${config.types.varchar}('name', { length: 100 }).unique(),
         });
 
         export const userTags = ${config.functions.table}('user_tags', {
@@ -898,11 +989,11 @@ describe.each(Object.entries(dbConfigs))(
 
       it('unique index', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar, ${config.functions.uniqueIndex} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${config.functions.uniqueIndex} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          email: varchar('email', { length: 255 }),
+          email: ${config.types.varchar}('email', { length: 255 }),
         }, (table) => ({
           emailIdx: ${config.functions.uniqueIndex}('email_unique_idx').on(table.email),
         }));
@@ -921,18 +1012,18 @@ describe.each(Object.entries(dbConfigs))(
 
       it('one-to-one relation without explicit fields/references', async () => {
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, varchar } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.integer}, ${config.types.varchar} } from '${config.imports.core}';
         import { relations } from '${config.imports.relations}';
 
         export const users = ${config.functions.table}('users', {
           id: ${config.types.idColumn()},
-          name: varchar('name', { length: 255 }),
+          name: ${config.types.varchar}('name', { length: 255 }),
         });
 
         export const instructors = ${config.functions.table}('instructors', {
           id: ${config.types.idColumn()},
           userId: ${config.types.integer}('user_id').references(() => users.id).unique(),
-          specialization: varchar('specialization', { length: 255 }),
+          specialization: ${config.types.varchar}('specialization', { length: 255 }),
         });
 
         export const usersRelations = relations(users, ({ one, many }) => ({
@@ -985,23 +1076,18 @@ describe.each(Object.entries(dbConfigs))(
       })
 
       it('foreign key with different column names (JS property vs DB column)', async () => {
-        const userIdColumn =
-          dbType === 'mysql'
-            ? `${config.types.id}('user_id').primaryKey().autoincrement()`
-            : `${config.types.id}('user_id').primaryKey()`
-
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar, ${config.types.integer} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${config.types.integer} } from '${config.imports.core}';
 
         export const users = ${config.functions.table}('users', {
-          userId: ${userIdColumn}, // JS property: userId, DB column: user_id
-          email: varchar('email', { length: 255 }).notNull(),
+          userId: ${config.types.idColumn('user_id')}, // JS property: userId, DB column: user_id
+          email: ${config.types.varchar}('email', { length: 255 }).notNull(),
         });
 
         export const posts = ${config.functions.table}('posts', {
           id: ${config.types.idColumn()},
           authorId: ${config.types.integer}('author_id').references(() => users.userId), // Referencing JS property
-          title: varchar('title', { length: 255 }),
+          title: ${config.types.varchar}('title', { length: 255 }),
         });
       `
 
@@ -1023,13 +1109,13 @@ describe.each(Object.entries(dbConfigs))(
       if (dbType === 'mysql') {
         it('check constraints', async () => {
           const schema = `
-          import { ${config.functions.table}, ${config.types.id}, varchar, ${config.functions.check} } from '${config.imports.core}';
+          import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${config.functions.check} } from '${config.imports.core}';
           import { sql } from '${config.imports.relations}';
 
           export const users = ${config.functions.table}('users', {
             id: ${config.types.idColumn()},
             age: ${config.types.integer}('age'),
-            username: varchar('username', { length: 50 }).notNull(),
+            username: ${config.types.varchar}('username', { length: 50 }).notNull(),
           }, (table) => ({
             ageCheck: ${config.functions.check}('users_age_check', sql\`age >= 0 AND age <= 150\`),
             usernameCheck: ${config.functions.check}('users_username_check', sql\`CHAR_LENGTH(username) >= 3\`),
@@ -1064,10 +1150,15 @@ describe.each(Object.entries(dbConfigs))(
 
       // Add multi-schema tests for each database type
       it(`multiple ${config.name} schemas`, async () => {
+        // Skip for SQLite since it has no schema concept
+        if (dbType === 'sqlite') {
+          return
+        }
+
         const schemaFunction = dbType === 'mysql' ? 'mysqlSchema' : 'pgSchema'
 
         const schema = `
-        import { ${config.functions.table}, ${config.types.id}, varchar, ${config.types.integer}, ${schemaFunction} } from '${config.imports.core}';
+        import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, ${config.types.integer}, ${schemaFunction} } from '${config.imports.core}';
 
         // Define schemas
         export const authSchema = ${schemaFunction}('auth');
@@ -1076,14 +1167,14 @@ describe.each(Object.entries(dbConfigs))(
         // Auth schema table
         export const authUsers = authSchema.table('users', {
           id: ${config.types.idColumn()},
-          email: varchar('email', { length: 255 }).notNull(),
+          email: ${config.types.varchar}('email', { length: 255 }).notNull(),
         });
 
         // Public schema tables with foreign keys
         export const publicPosts = publicSchema.table('posts', {
           id: ${config.types.idColumn()},
           userId: ${config.types.integer}('user_id').references(() => authUsers.id),
-          title: varchar('title', { length: 255 }),
+          title: ${config.types.varchar}('title', { length: 255 }),
         });
 
         export const publicComments = publicSchema.table('comments', {
@@ -1122,13 +1213,13 @@ describe.each(Object.entries(dbConfigs))(
       if (dbType === 'mysql') {
         it('table-level unique constraints', async () => {
           const schema = `
-          import { ${config.functions.table}, ${config.types.id}, varchar, unique } from '${config.imports.core}';
+          import { ${config.functions.table}, ${config.types.id}, ${config.types.varchar}, unique } from '${config.imports.core}';
 
           export const users = ${config.functions.table}('users', {
             id: ${config.types.idColumn()},
-            firstName: varchar('first_name', { length: 255 }),
-            lastName: varchar('last_name', { length: 255 }),
-            email: varchar('email', { length: 255 }),
+            firstName: ${config.types.varchar}('first_name', { length: 255 }),
+            lastName: ${config.types.varchar}('last_name', { length: 255 }),
+            email: ${config.types.varchar}('email', { length: 255 }),
           }, (table) => ({
             fullNameUnique: unique('users_full_name_unique').on(table.firstName, table.lastName),
             emailUnique: unique('users_email_unique').on(table.email),

--- a/frontend/packages/schema/src/parser/drizzle/index.ts
+++ b/frontend/packages/schema/src/parser/drizzle/index.ts
@@ -1,13 +1,14 @@
 import type { ProcessResult } from '../types.js'
 import { processor as mysqlProcessor } from './mysql/index.js'
 import { processor as postgresProcessor } from './postgres/index.js'
+import { processor as sqliteProcessor } from './sqlite/index.js'
 
 /**
  * Detect database type from Drizzle schema content
  */
 const detectDrizzleDbType = (
   schemaContent: string,
-): 'postgres' | 'mysql' | 'unknown' => {
+): 'postgres' | 'mysql' | 'sqlite' => {
   // Check for MySQL-specific imports
   if (schemaContent.includes('drizzle-orm/mysql-core')) {
     return 'mysql'
@@ -16,6 +17,11 @@ const detectDrizzleDbType = (
   // Check for PostgreSQL-specific imports
   if (schemaContent.includes('drizzle-orm/pg-core')) {
     return 'postgres'
+  }
+
+  // Check for SQLite-specific imports
+  if (schemaContent.includes('drizzle-orm/sqlite-core')) {
+    return 'sqlite'
   }
 
   // Check for MySQL-specific table functions
@@ -31,12 +37,17 @@ const detectDrizzleDbType = (
     return 'postgres'
   }
 
+  // Check for SQLite-specific table functions
+  if (schemaContent.includes('sqliteTable')) {
+    return 'sqlite'
+  }
+
   // Default to PostgreSQL for backward compatibility
   return 'postgres'
 }
 
 /**
- * Auto-detecting Drizzle processor that supports both PostgreSQL and MySQL
+ * Auto-detecting Drizzle processor that supports PostgreSQL, MySQL, and SQLite
  */
 export const processor = async (
   schemaContent: string,
@@ -46,6 +57,8 @@ export const processor = async (
   switch (dbType) {
     case 'mysql':
       return mysqlProcessor(schemaContent)
+    case 'sqlite':
+      return sqliteProcessor(schemaContent)
     default:
       return postgresProcessor(schemaContent)
   }

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/__tests__/index.test.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/__tests__/index.test.ts
@@ -131,6 +131,34 @@ describe(processor, () => {
       })
     })
 
+    it('unnamed indexes in array callback form do not collide', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer, text, index } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+          firstName: text('first_name'),
+          email: text('email'),
+        }, (table) => [
+          index().on(table.firstName),
+          index().on(table.email),
+        ]);
+      `)
+
+      expect(value.tables['users']?.indexes['users_firstName_index']).toEqual({
+        name: 'users_firstName_index',
+        columns: ['first_name'],
+        unique: false,
+        type: '',
+      })
+      expect(value.tables['users']?.indexes['users_email_index']).toEqual({
+        name: 'users_email_index',
+        columns: ['email'],
+        unique: false,
+        type: '',
+      })
+    })
+
     it('column modes are parsed as underlying SQLite types', async () => {
       const { value } = await processor(`
         import { sqliteTable, integer, text, blob } from 'drizzle-orm/sqlite-core';

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/__tests__/index.test.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/__tests__/index.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { processor } from '../index.js'
+
+describe(processor, () => {
+  // SQLite-specific tests (tests that are unique to SQLite and not covered by unified tests)
+  describe('SQLite-specific functionality', () => {
+    it('SQLite column types (integer, text, real, blob, numeric)', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer, text, real, blob, numeric } from 'drizzle-orm/sqlite-core';
+
+        export const items = sqliteTable('items', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+          title: text('title').notNull(),
+          price: real('price'),
+          payload: blob('payload'),
+          amount: numeric('amount'),
+        });
+      `)
+
+      expect(value.tables['items']).toBeDefined()
+      expect(value.tables['items']?.columns['id']?.type).toBe('integer')
+      expect(value.tables['items']?.columns['title']?.type).toBe('text')
+      expect(value.tables['items']?.columns['price']?.type).toBe('real')
+      expect(value.tables['items']?.columns['payload']?.type).toBe('blob')
+      expect(value.tables['items']?.columns['amount']?.type).toBe('numeric')
+    })
+
+    it('integer primary key with autoIncrement', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+        });
+      `)
+
+      expect(value.tables['users']?.columns['id']?.default).toBe(
+        'autoincrement()',
+      )
+      expect(value.tables['users']?.columns['id']?.notNull).toBe(true)
+      expect(value.tables['users']?.constraints['PRIMARY_id']).toEqual({
+        type: 'PRIMARY KEY',
+        name: 'PRIMARY_id',
+        columnNames: ['id'],
+      })
+    })
+
+    it('integer primary key without autoIncrement', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey(),
+        });
+      `)
+
+      expect(value.tables['users']?.columns['id']?.default).toBe(null)
+      expect(value.tables['users']?.constraints['PRIMARY_id']).toEqual({
+        type: 'PRIMARY KEY',
+        name: 'PRIMARY_id',
+        columnNames: ['id'],
+      })
+    })
+
+    it('text with length option', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+          name: text('name', { length: 255 }).notNull(),
+        });
+      `)
+
+      expect(value.tables['users']?.columns['name']?.type).toBe('text(255)')
+    })
+
+    it('text with enum option is parsed as text (SQLite has no native enum)', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+          status: text('status', { enum: ['active', 'archived'] }).default('active'),
+        });
+      `)
+
+      expect(value.tables['users']?.columns['status']?.type).toBe('text')
+      expect(value.tables['users']?.columns['status']?.default).toBe('active')
+      expect(value.enums).toEqual({})
+    })
+
+    it('indexes and composite primary key in array callback form', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer, text, index, uniqueIndex, primaryKey } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+          firstName: text('first_name'),
+          lastName: text('last_name'),
+          email: text('email'),
+        }, (table) => [
+          index('name_idx').on(table.firstName, table.lastName),
+          uniqueIndex('email_idx').on(table.email),
+        ]);
+
+        export const userTags = sqliteTable('user_tags', {
+          userId: integer('user_id').references(() => users.id).notNull(),
+          tag: text('tag').notNull(),
+        }, (table) => [
+          primaryKey({ columns: [table.userId, table.tag] }),
+        ]);
+      `)
+
+      expect(value.tables['users']?.indexes['name_idx']).toEqual({
+        name: 'name_idx',
+        columns: ['first_name', 'last_name'],
+        unique: false,
+        type: '',
+      })
+      expect(value.tables['users']?.indexes['email_idx']).toEqual({
+        name: 'email_idx',
+        columns: ['email'],
+        unique: true,
+        type: '',
+      })
+      expect(value.tables['user_tags']?.constraints['user_tags_pkey']).toEqual({
+        type: 'PRIMARY KEY',
+        name: 'user_tags_pkey',
+        columnNames: ['user_id', 'tag'],
+      })
+    })
+
+    it('column modes are parsed as underlying SQLite types', async () => {
+      const { value } = await processor(`
+        import { sqliteTable, integer, text, blob } from 'drizzle-orm/sqlite-core';
+
+        export const users = sqliteTable('users', {
+          id: integer('id').primaryKey({ autoIncrement: true }),
+          isActive: integer('is_active', { mode: 'boolean' }).default(true),
+          createdAt: integer('created_at', { mode: 'timestamp' }),
+          settings: text('settings', { mode: 'json' }),
+          metadata: blob('metadata', { mode: 'json' }),
+        });
+      `)
+
+      expect(value.tables['users']?.columns['isActive']?.type).toBe('integer')
+      expect(value.tables['users']?.columns['isActive']?.default).toBe(true)
+      expect(value.tables['users']?.columns['createdAt']?.type).toBe('integer')
+      expect(value.tables['users']?.columns['settings']?.type).toBe('text')
+      expect(value.tables['users']?.columns['metadata']?.type).toBe('blob')
+    })
+  })
+})

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/astUtils.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/astUtils.ts
@@ -1,0 +1,177 @@
+/**
+ * AST manipulation utilities for Drizzle ORM schema parsing
+ */
+
+import type {
+  Argument,
+  CallExpression,
+  Expression,
+  ObjectExpression,
+} from '@swc/core'
+import { getPropertyValue, hasProperty, isObject } from './types.js'
+
+/**
+ * Type guard for SWC Argument wrapper
+ */
+const isArgumentWrapper = (arg: unknown): arg is { expression: Expression } => {
+  return isObject(arg) && hasProperty(arg, 'expression')
+}
+
+/**
+ * Extract expression from SWC Argument wrapper
+ */
+export const getArgumentExpression = (arg: unknown): Expression | null => {
+  if (isArgumentWrapper(arg)) {
+    return arg.expression
+  }
+  return null
+}
+
+/**
+ * Type guard for string literal expressions
+ */
+export const isStringLiteral = (
+  expr: unknown,
+): expr is { type: 'StringLiteral'; value: string } => {
+  return (
+    isObject(expr) &&
+    getPropertyValue(expr, 'type') === 'StringLiteral' &&
+    hasProperty(expr, 'value') &&
+    typeof getPropertyValue(expr, 'value') === 'string'
+  )
+}
+
+/**
+ * Type guard for object expressions
+ */
+export const isObjectExpression = (expr: unknown): expr is ObjectExpression => {
+  return isObject(expr) && getPropertyValue(expr, 'type') === 'ObjectExpression'
+}
+
+/**
+ * Type guard for array expressions
+ */
+export const isArrayExpression = (
+  expr: unknown,
+): expr is { type: 'ArrayExpression'; elements: unknown[] } => {
+  return (
+    isObject(expr) &&
+    getPropertyValue(expr, 'type') === 'ArrayExpression' &&
+    hasProperty(expr, 'elements') &&
+    Array.isArray(getPropertyValue(expr, 'elements'))
+  )
+}
+
+/**
+ * Type guard for identifier nodes
+ */
+export const isIdentifier = (
+  node: unknown,
+): node is { type: 'Identifier'; value: string } => {
+  return (
+    isObject(node) &&
+    getPropertyValue(node, 'type') === 'Identifier' &&
+    hasProperty(node, 'value') &&
+    typeof getPropertyValue(node, 'value') === 'string'
+  )
+}
+
+/**
+ * Type guard for member expressions
+ */
+export const isMemberExpression = (
+  node: unknown,
+): node is {
+  type: 'MemberExpression'
+  object: { type: string; value?: string }
+  property: { type: string; value?: string }
+} => {
+  return (
+    isObject(node) &&
+    getPropertyValue(node, 'type') === 'MemberExpression' &&
+    hasProperty(node, 'object') &&
+    hasProperty(node, 'property') &&
+    typeof getPropertyValue(node, 'object') === 'object' &&
+    typeof getPropertyValue(node, 'property') === 'object'
+  )
+}
+
+/**
+ * Check if a call expression is a sqliteTable call
+ */
+const isSqliteTableCall = (callExpr: CallExpression): boolean => {
+  return (
+    isIdentifier(callExpr.callee) && callExpr.callee.value === 'sqliteTable'
+  )
+}
+
+/**
+ * Extract the base sqliteTable call from method chaining patterns
+ * Handles patterns like: sqliteTable(...).$comment(...), etc.
+ */
+export const extractSqliteTableFromChain = (
+  callExpr: CallExpression,
+): CallExpression | null => {
+  // If it's already a direct sqliteTable call, return it
+  if (isSqliteTableCall(callExpr)) {
+    return callExpr
+  }
+
+  // If it's a method call on another expression, check the object
+  if (callExpr.callee.type === 'MemberExpression') {
+    const baseCall = callExpr.callee.object
+    if (baseCall.type === 'CallExpression') {
+      // Recursively check if the base call is or contains a sqliteTable call
+      return extractSqliteTableFromChain(baseCall)
+    }
+  }
+
+  return null
+}
+
+/**
+ * Extract string value from a string literal
+ */
+export const getStringValue = (node: Expression): string | null => {
+  if (node.type === 'StringLiteral') {
+    return node.value
+  }
+  return null
+}
+
+/**
+ * Extract identifier name
+ */
+export const getIdentifierName = (node: Expression): string | null => {
+  if (isIdentifier(node)) {
+    return node.value
+  }
+  return null
+}
+
+/**
+ * Parse method call chain from a call expression
+ */
+export const parseMethodChain = (
+  expr: Expression,
+): Array<{ name: string; args: Argument[] }> => {
+  const methods: Array<{ name: string; args: Argument[] }> = []
+  let current = expr
+
+  while (current.type === 'CallExpression') {
+    if (
+      current.callee.type === 'MemberExpression' &&
+      current.callee.property.type === 'Identifier'
+    ) {
+      methods.unshift({
+        name: current.callee.property.value,
+        args: current.arguments,
+      })
+      current = current.callee.object
+    } else {
+      break
+    }
+  }
+
+  return methods
+}

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/columnParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/columnParser.ts
@@ -1,0 +1,171 @@
+/**
+ * Column definition parsing for Drizzle ORM schema parsing
+ */
+
+import type { Argument, Expression, Property } from '@swc/core'
+import {
+  getArgumentExpression,
+  getIdentifierName,
+  getStringValue,
+  isObjectExpression,
+  isStringLiteral,
+  parseMethodChain,
+} from './astUtils.js'
+import { parseDefaultValue, parseObjectExpression } from './expressionParser.js'
+import type { DrizzleColumnDefinition } from './types.js'
+
+/**
+ * Check if primaryKey({ autoIncrement: true }) is specified
+ */
+const hasAutoIncrementOption = (args: Argument[]): boolean => {
+  if (args.length === 0) return false
+  const argExpr = getArgumentExpression(args[0])
+  if (!argExpr || !isObjectExpression(argExpr)) return false
+  const options = parseObjectExpression(argExpr)
+  return options['autoIncrement'] === true
+}
+
+/**
+ * Parse column definition from object property
+ */
+export const parseColumnFromProperty = (
+  prop: Property,
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO: Refactor to reduce complexity
+): DrizzleColumnDefinition | null => {
+  if (prop.type !== 'KeyValueProperty') return null
+
+  const columnName =
+    prop.key.type === 'Identifier' ? getIdentifierName(prop.key) : null
+  if (!columnName) return null
+
+  if (prop.value.type !== 'CallExpression') return null
+
+  // Parse the method chain to find the base type
+  const methods = parseMethodChain(prop.value)
+
+  // Find the base type from the root of the chain
+  let baseType: string | null = null
+  let current: Expression = prop.value
+
+  // Traverse to the bottom of the method chain to find the base type call
+  while (
+    current.type === 'CallExpression' &&
+    current.callee.type === 'MemberExpression'
+  ) {
+    current = current.callee.object
+  }
+
+  if (
+    current.type === 'CallExpression' &&
+    current.callee.type === 'Identifier'
+  ) {
+    baseType = current.callee.value
+  }
+
+  if (!baseType) return null
+
+  // Extract the actual column name from the first argument of the base type call
+  let actualColumnName = columnName // Default to JS property name
+  if (current.type === 'CallExpression' && current.arguments.length > 0) {
+    const firstArg = current.arguments[0]
+    const firstArgExpr = getArgumentExpression(firstArg)
+    if (firstArgExpr && isStringLiteral(firstArgExpr)) {
+      actualColumnName = firstArgExpr.value
+    }
+  }
+
+  const column: DrizzleColumnDefinition = {
+    name: actualColumnName,
+    type: baseType,
+    notNull: false,
+    primaryKey: false,
+    unique: false,
+  }
+
+  // Parse type options from second argument (like { length: 255 })
+  if (current.type === 'CallExpression' && current.arguments.length > 1) {
+    const secondArg = current.arguments[1]
+    const secondArgExpr = getArgumentExpression(secondArg)
+    if (secondArgExpr && isObjectExpression(secondArgExpr)) {
+      column.typeOptions = parseObjectExpression(secondArgExpr)
+    }
+  }
+
+  // Parse method calls in the chain (already parsed above)
+  for (const method of methods) {
+    switch (method.name) {
+      case 'primaryKey':
+        column.primaryKey = true
+        column.notNull = true
+        if (hasAutoIncrementOption(method.args)) {
+          column.default = 'autoincrement'
+        }
+        break
+      case 'notNull':
+        column.notNull = true
+        break
+      case 'unique':
+        column.unique = true
+        break
+      case 'default':
+        if (method.args.length > 0) {
+          const argExpr = getArgumentExpression(method.args[0])
+          if (argExpr) {
+            column.default = parseDefaultValue(argExpr)
+          }
+        }
+        break
+      case 'references':
+        if (method.args.length > 0) {
+          const argExpr = getArgumentExpression(method.args[0])
+          // Parse references: () => table.column
+          if (argExpr && argExpr.type === 'ArrowFunctionExpression') {
+            const body = argExpr.body
+            if (
+              body.type === 'MemberExpression' &&
+              body.object.type === 'Identifier' &&
+              body.property.type === 'Identifier'
+            ) {
+              const referencesOptions: {
+                table: string
+                column: string
+                onDelete?: string
+                onUpdate?: string
+              } = {
+                table: body.object.value,
+                column: body.property.value,
+              }
+
+              // Parse the second argument for onDelete/onUpdate options
+              if (method.args.length > 1) {
+                const optionsExpr = getArgumentExpression(method.args[1])
+                if (optionsExpr && isObjectExpression(optionsExpr)) {
+                  const options = parseObjectExpression(optionsExpr)
+                  if (typeof options['onDelete'] === 'string') {
+                    referencesOptions.onDelete = options['onDelete']
+                  }
+                  if (typeof options['onUpdate'] === 'string') {
+                    referencesOptions.onUpdate = options['onUpdate']
+                  }
+                }
+              }
+
+              column.references = referencesOptions
+            }
+          }
+        }
+        break
+      case '$comment':
+        if (method.args.length > 0) {
+          const argExpr = getArgumentExpression(method.args[0])
+          const commentValue = argExpr ? getStringValue(argExpr) : null
+          if (commentValue) {
+            column.comment = commentValue
+          }
+        }
+        break
+    }
+  }
+
+  return column
+}

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/convertToSqliteType.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/convertToSqliteType.ts
@@ -1,0 +1,70 @@
+/**
+ * Convert Drizzle column types to SQLite column types
+ * ref: https://orm.drizzle.team/docs/column-types/sqlite
+ */
+export const convertDrizzleTypeToSqliteType = (
+  drizzleType: string,
+  options?: Record<string, unknown>,
+): string => {
+  switch (drizzleType) {
+    // text options other than length (e.g., { enum: [...] }, { mode: 'json' })
+    // do not change the underlying SQLite type
+    case 'text':
+      if (options?.['length']) {
+        return `text(${options['length']})`
+      }
+      return 'text'
+
+    // Default case: return type name as-is (integer, real, blob, numeric)
+    default:
+      return drizzleType
+  }
+}
+
+/**
+ * Convert default values from Drizzle to SQLite format
+ */
+export const convertDefaultValue = (
+  value: unknown,
+): string | number | boolean | null => {
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  if (value === 'autoincrement') {
+    return 'autoincrement()'
+  }
+
+  // Handle primitive values
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value
+  }
+
+  return null
+}
+
+/**
+ * Convert constraint reference options from Drizzle to SQLite format
+ */
+export const convertReferenceOption = (
+  option: string,
+): 'CASCADE' | 'RESTRICT' | 'SET_NULL' | 'SET_DEFAULT' | 'NO_ACTION' => {
+  switch (option.toLowerCase()) {
+    case 'cascade':
+      return 'CASCADE'
+    case 'restrict':
+      return 'RESTRICT'
+    case 'setnull':
+    case 'set null':
+      return 'SET_NULL'
+    case 'setdefault':
+    case 'set default':
+      return 'SET_DEFAULT'
+    default:
+      return 'NO_ACTION'
+  }
+}

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/converter.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/converter.ts
@@ -1,0 +1,207 @@
+/**
+ * Data conversion logic for Drizzle ORM schema parsing
+ */
+
+import type {
+  Column,
+  Columns,
+  Constraints,
+  ForeignKeyConstraint,
+  Index,
+  Table,
+} from '../../../schema/index.js'
+import {
+  convertDefaultValue,
+  convertDrizzleTypeToSqliteType,
+  convertReferenceOption,
+} from './convertToSqliteType.js'
+import type { DrizzleTableDefinition } from './types.js'
+
+/**
+ * Convert Drizzle table definition to internal Table format
+ */
+const convertToTable = (
+  tableDef: DrizzleTableDefinition,
+  variableToTableMapping: Record<string, string> = {},
+): Table => {
+  const columns: Columns = {}
+  const constraints: Constraints = {}
+  const indexes: Record<string, Index> = {}
+
+  // Convert columns
+  for (const [columnName, columnDef] of Object.entries(tableDef.columns)) {
+    const column: Column = {
+      name: columnDef.name,
+      type: convertDrizzleTypeToSqliteType(
+        columnDef.type,
+        columnDef.typeOptions,
+      ),
+      default: convertDefaultValue(columnDef.default),
+      notNull: columnDef.notNull,
+      comment: columnDef.comment || null,
+      check: null,
+    }
+    columns[columnName] = column
+
+    // Add primary key constraint
+    if (columnDef.primaryKey) {
+      const constraintName = `PRIMARY_${columnDef.name}`
+      constraints[constraintName] = {
+        type: 'PRIMARY KEY',
+        name: constraintName,
+        columnNames: [columnDef.name],
+      }
+
+      // Add primary key index
+      const indexName = `${tableDef.name}_pkey`
+      indexes[indexName] = {
+        name: indexName,
+        columns: [columnDef.name],
+        unique: true,
+        type: '',
+      }
+    }
+
+    // Add unique constraint (inline unique does not create index, only constraint)
+    if (columnDef.unique && !columnDef.primaryKey) {
+      const constraintName = `UNIQUE_${columnDef.name}`
+      constraints[constraintName] = {
+        type: 'UNIQUE',
+        name: constraintName,
+        columnNames: [columnDef.name],
+      }
+    }
+
+    // Add foreign key constraint
+    if (columnDef.references) {
+      // Resolve variable name to actual table name
+      const targetTableName =
+        variableToTableMapping[columnDef.references.table] ||
+        columnDef.references.table
+
+      const constraintName = `${tableDef.name}_${columnDef.name}_${columnDef.references.table}_${columnDef.references.column}_fk`
+      const constraint: ForeignKeyConstraint = {
+        type: 'FOREIGN KEY',
+        name: constraintName,
+        columnNames: [columnDef.name], // Use actual column name, not JS property name
+        targetTableName: targetTableName,
+        targetColumnNames: [columnDef.references.column],
+        updateConstraint: columnDef.references.onUpdate
+          ? convertReferenceOption(columnDef.references.onUpdate)
+          : 'NO_ACTION',
+        deleteConstraint: columnDef.references.onDelete
+          ? convertReferenceOption(columnDef.references.onDelete)
+          : 'NO_ACTION',
+      }
+      constraints[constraintName] = constraint
+    }
+  }
+
+  // Handle composite primary key
+  if (tableDef.compositePrimaryKey) {
+    // Map JS property names to actual column names
+    const actualColumnNames = tableDef.compositePrimaryKey.columns
+      .map((jsPropertyName) => {
+        const columnDef = tableDef.columns[jsPropertyName]
+        return columnDef ? columnDef.name : jsPropertyName
+      })
+      .filter((name) => name && name.length > 0)
+
+    // Create composite primary key constraint
+    const constraintName = `${tableDef.name}_pkey`
+    constraints[constraintName] = {
+      type: 'PRIMARY KEY',
+      name: constraintName,
+      columnNames: actualColumnNames,
+    }
+
+    // Add composite primary key index
+    indexes[constraintName] = {
+      name: constraintName,
+      columns: actualColumnNames,
+      unique: true,
+      type: '',
+    }
+  }
+
+  // Convert indexes
+  for (const [_, indexDef] of Object.entries(tableDef.indexes)) {
+    // Map JS property names to actual column names
+    const actualColumnNames = indexDef.columns.map((jsPropertyName) => {
+      const columnDef = tableDef.columns[jsPropertyName]
+      return columnDef ? columnDef.name : jsPropertyName
+    })
+
+    // Use the actual index name from the definition
+    const actualIndexName = indexDef.name
+    indexes[actualIndexName] = {
+      name: actualIndexName,
+      columns: actualColumnNames,
+      unique: indexDef.unique,
+      type: indexDef.type || '',
+    }
+  }
+
+  return {
+    name: tableDef.name,
+    columns,
+    constraints,
+    indexes,
+    comment: tableDef.comment || null,
+  }
+}
+
+/**
+ * Fix foreign key constraint targetColumnName from JS property names to actual DB column names
+ */
+const fixForeignKeyTargetColumnNames = (
+  tables: Record<string, Table>,
+  drizzleTables: Record<string, DrizzleTableDefinition>,
+): void => {
+  for (const table of Object.values(tables)) {
+    for (const constraint of Object.values(table.constraints)) {
+      if (constraint.type === 'FOREIGN KEY') {
+        // Check in drizzleTables for column mapping
+        const drizzleTargetTable = drizzleTables[constraint.targetTableName]
+        if (drizzleTargetTable) {
+          // Map each target column from JS property name to actual DB column name
+          constraint.targetColumnNames = constraint.targetColumnNames.map(
+            (jsPropertyName) => {
+              const targetColumnDef = drizzleTargetTable.columns[jsPropertyName]
+              return targetColumnDef ? targetColumnDef.name : jsPropertyName
+            },
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Convert parsed Drizzle tables to internal format with error handling
+ */
+export const convertDrizzleTablesToInternal = (
+  drizzleTables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string> = {},
+): { tables: Record<string, Table>; errors: Error[] } => {
+  const tables: Record<string, Table> = {}
+  const errors: Error[] = []
+
+  // Convert Drizzle tables to internal format
+  for (const [tableName, tableDef] of Object.entries(drizzleTables)) {
+    try {
+      tables[tableName] = convertToTable(tableDef, variableToTableMapping)
+    } catch (error) {
+      errors.push(
+        new Error(
+          `Error parsing table ${tableName}: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      )
+    }
+  }
+
+  // Fix foreign key constraint targetColumnName from JS property names to actual DB column names
+  fixForeignKeyTargetColumnNames(tables, drizzleTables)
+
+  return { tables, errors }
+}

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/expressionParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/expressionParser.ts
@@ -1,0 +1,120 @@
+/**
+ * Expression parsing utilities for Drizzle ORM schema parsing
+ */
+
+import type { Expression, ObjectExpression } from '@swc/core'
+import {
+  getArgumentExpression,
+  getIdentifierName,
+  getStringValue,
+  isArrayExpression,
+  isIdentifier,
+  isMemberExpression,
+} from './astUtils.js'
+import { getPropertyValue, hasProperty, isObject } from './types.js'
+
+/**
+ * Parse default value from expression
+ */
+export const parseDefaultValue = (expr: Expression): unknown => {
+  switch (expr.type) {
+    case 'StringLiteral':
+      return expr.value
+    case 'NumericLiteral':
+      return expr.value
+    case 'BooleanLiteral':
+      return expr.value
+    case 'NullLiteral':
+      return null
+    case 'Identifier':
+      return expr.value
+    case 'CallExpression':
+      if (expr.callee.type === 'Identifier') {
+        return expr.callee.value
+      }
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Parse object expression to plain object
+ */
+export const parseObjectExpression = (
+  obj: ObjectExpression,
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {}
+
+  for (const prop of obj.properties) {
+    if (prop.type === 'KeyValueProperty') {
+      const key =
+        prop.key.type === 'Identifier'
+          ? getIdentifierName(prop.key)
+          : prop.key.type === 'StringLiteral'
+            ? getStringValue(prop.key)
+            : null
+      if (key) {
+        result[key] = parsePropertyValue(prop.value)
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Type guard for expression-like objects
+ */
+const isExpressionLike = (value: unknown): value is Expression => {
+  return (
+    isObject(value) &&
+    hasProperty(value, 'type') &&
+    typeof getPropertyValue(value, 'type') === 'string'
+  )
+}
+
+/**
+ * Safe parser for unknown values as expressions
+ */
+const parseUnknownValue = (value: unknown): unknown => {
+  if (isExpressionLike(value)) {
+    return parseDefaultValue(value)
+  }
+  return value
+}
+
+/**
+ * Parse property value (including arrays)
+ */
+const parsePropertyValue = (expr: unknown): unknown => {
+  if (isArrayExpression(expr)) {
+    const result: unknown[] = []
+    for (const element of expr.elements) {
+      const elementExpr = getArgumentExpression(element)
+      if (
+        elementExpr &&
+        elementExpr.type === 'MemberExpression' &&
+        elementExpr.object.type === 'Identifier' &&
+        elementExpr.property.type === 'Identifier'
+      ) {
+        // For table.columnName references, use the property name
+        result.push(elementExpr.property.value)
+      } else if (
+        isMemberExpression(element) &&
+        isIdentifier(element.object) &&
+        isIdentifier(element.property)
+      ) {
+        // Direct MemberExpression (not wrapped in { expression })
+        result.push(element.property.value)
+      } else {
+        const parsed = elementExpr
+          ? parseDefaultValue(elementExpr)
+          : parseUnknownValue(element)
+        result.push(parsed)
+      }
+    }
+    return result
+  }
+  return parseUnknownValue(expr)
+}

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/index.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/index.ts
@@ -1,0 +1,1 @@
+export { processor } from './mainParser.js'

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/mainParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/mainParser.ts
@@ -1,0 +1,164 @@
+/**
+ * Main orchestrator for Drizzle ORM schema parsing
+ */
+
+import type { CallExpression, Module, VariableDeclarator } from '@swc/core'
+import { parseSync } from '@swc/core'
+import type { Processor, ProcessResult } from '../../types.js'
+import { extractSqliteTableFromChain } from './astUtils.js'
+import { convertDrizzleTablesToInternal } from './converter.js'
+import {
+  parseSqliteTableCall,
+  parseSqliteTableWithComment,
+} from './tableParser.js'
+import type { DrizzleTableDefinition } from './types.js'
+
+/**
+ * Parse Drizzle TypeScript schema to extract table definitions using SWC AST
+ */
+const parseDrizzleSchema = (
+  sourceCode: string,
+): {
+  tables: Record<string, DrizzleTableDefinition>
+  variableToTableMapping: Record<string, string>
+} => {
+  // Parse TypeScript code into AST
+  const ast = parseSync(sourceCode, {
+    syntax: 'typescript',
+    target: 'es2022',
+  })
+
+  const tables: Record<string, DrizzleTableDefinition> = {}
+  const variableToTableMapping: Record<string, string> = {}
+
+  // Traverse the AST to find sqliteTable calls
+  visitModule(ast, tables, variableToTableMapping)
+
+  return { tables, variableToTableMapping }
+}
+
+/**
+ * Visit and traverse the module AST
+ */
+const visitModule = (
+  module: Module,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  for (const item of module.body) {
+    if (item.type === 'VariableDeclaration') {
+      for (const declarator of item.declarations) {
+        visitVariableDeclarator(declarator, tables, variableToTableMapping)
+      }
+    } else if (
+      item.type === 'ExportDeclaration' &&
+      item.declaration?.type === 'VariableDeclaration'
+    ) {
+      for (const declarator of item.declaration.declarations) {
+        visitVariableDeclarator(declarator, tables, variableToTableMapping)
+      }
+    }
+  }
+}
+
+/**
+ * Check if the call expression is a comment call
+ */
+const isCommentCall = (callExpr: CallExpression): boolean => {
+  return (
+    callExpr.type === 'CallExpression' &&
+    callExpr.callee.type === 'MemberExpression' &&
+    callExpr.callee.property.type === 'Identifier' &&
+    callExpr.callee.property.value === '$comment'
+  )
+}
+
+/**
+ * Handle comment calls
+ */
+const handleCommentCall = (
+  declarator: VariableDeclarator,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  if (declarator.init?.type !== 'CallExpression') return
+
+  const table = parseSqliteTableWithComment(declarator.init)
+  if (table && declarator.id.type === 'Identifier') {
+    tables[table.name] = table
+    variableToTableMapping[declarator.id.value] = table.name
+  }
+}
+
+/**
+ * Handle sqliteTable calls (direct or method chained)
+ */
+const handleSqliteTableCall = (
+  declarator: VariableDeclarator,
+  callExpr: CallExpression,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  const baseSqliteTableCall = extractSqliteTableFromChain(callExpr)
+  if (baseSqliteTableCall) {
+    const table = parseSqliteTableCall(baseSqliteTableCall)
+    if (table && declarator.id.type === 'Identifier') {
+      tables[table.name] = table
+      variableToTableMapping[declarator.id.value] = table.name
+    }
+  }
+}
+
+/**
+ * Visit variable declarator to find sqliteTable calls
+ */
+const visitVariableDeclarator = (
+  declarator: VariableDeclarator,
+  tables: Record<string, DrizzleTableDefinition>,
+  variableToTableMapping: Record<string, string>,
+) => {
+  if (!declarator.init || declarator.init.type !== 'CallExpression') {
+    return
+  }
+
+  const callExpr = declarator.init
+
+  if (isCommentCall(callExpr)) {
+    handleCommentCall(declarator, tables, variableToTableMapping)
+  } else {
+    handleSqliteTableCall(declarator, callExpr, tables, variableToTableMapping)
+  }
+}
+
+/**
+ * Main processor function for Drizzle schemas
+ */
+const parseDrizzleSchemaString = (
+  schemaString: string,
+): Promise<ProcessResult> => {
+  try {
+    const { tables: drizzleTables, variableToTableMapping } =
+      parseDrizzleSchema(schemaString)
+    const { tables, errors } = convertDrizzleTablesToInternal(
+      drizzleTables,
+      variableToTableMapping,
+    )
+
+    // SQLite has no native enum type, so enums are always empty
+    return Promise.resolve({
+      value: { tables, enums: {}, extensions: {} },
+      errors,
+    })
+  } catch (error) {
+    return Promise.resolve({
+      value: { tables: {}, enums: {}, extensions: {} },
+      errors: [
+        new Error(
+          `Error parsing Drizzle schema: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      ],
+    })
+  }
+}
+
+export const processor: Processor = parseDrizzleSchemaString

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/tableParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/tableParser.ts
@@ -1,0 +1,316 @@
+/**
+ * Table structure parsing for Drizzle ORM schema parsing
+ */
+
+import type {
+  ArrayExpression,
+  CallExpression,
+  Expression,
+  ObjectExpression,
+} from '@swc/core'
+import {
+  extractSqliteTableFromChain,
+  getArgumentExpression,
+  getIdentifierName,
+  getStringValue,
+  isObjectExpression,
+  isStringLiteral,
+} from './astUtils.js'
+import { parseColumnFromProperty } from './columnParser.js'
+import { parseObjectExpression } from './expressionParser.js'
+import type {
+  CompositePrimaryKeyDefinition,
+  DrizzleIndexDefinition,
+  DrizzleTableDefinition,
+} from './types.js'
+import { isCompositePrimaryKey, isDrizzleIndex } from './types.js'
+
+/**
+ * Parse sqliteTable call with comment method chain
+ */
+export const parseSqliteTableWithComment = (
+  commentCallExpr: CallExpression,
+): DrizzleTableDefinition | null => {
+  // Extract the comment from the call arguments
+  let comment: string | null = null
+  if (commentCallExpr.arguments.length > 0) {
+    const commentArg = commentCallExpr.arguments[0]
+    const commentExpr = getArgumentExpression(commentArg)
+    if (commentExpr && isStringLiteral(commentExpr)) {
+      comment = commentExpr.value
+    }
+  }
+
+  // Get the sqliteTable call from the chain
+  if (commentCallExpr.callee.type === 'MemberExpression') {
+    const chainCall = commentCallExpr.callee.object
+    if (chainCall.type === 'CallExpression') {
+      // Use extractSqliteTableFromChain to handle complex method chaining
+      const sqliteTableCall = extractSqliteTableFromChain(chainCall)
+      if (sqliteTableCall) {
+        const table = parseSqliteTableCall(sqliteTableCall)
+        if (table && comment) {
+          table.comment = comment
+        }
+        return table
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Parse sqliteTable call expression
+ */
+export const parseSqliteTableCall = (
+  callExpr: CallExpression,
+): DrizzleTableDefinition | null => {
+  if (callExpr.arguments.length < 2) return null
+
+  const tableNameArg = callExpr.arguments[0]
+  const columnsArg = callExpr.arguments[1]
+
+  if (!tableNameArg || !columnsArg) return null
+
+  // Extract expression from SWC argument structure
+  const tableNameExpr = getArgumentExpression(tableNameArg)
+  const columnsExpr = getArgumentExpression(columnsArg)
+
+  const tableName = tableNameExpr ? getStringValue(tableNameExpr) : null
+  if (!tableName || !columnsExpr || !isObjectExpression(columnsExpr))
+    return null
+
+  const table: DrizzleTableDefinition = {
+    name: tableName,
+    columns: {},
+    indexes: {},
+  }
+
+  parseTableColumns(columnsExpr, table)
+
+  // Parse indexes and composite primary key from third argument if present
+  if (callExpr.arguments.length > 2) {
+    const thirdArgExpr = getArgumentExpression(callExpr.arguments[2])
+    if (thirdArgExpr) {
+      parseTableExtras(thirdArgExpr, table)
+    }
+  }
+
+  return table
+}
+
+/**
+ * Parse columns from the object expression
+ */
+const parseTableColumns = (
+  columnsExpr: ObjectExpression,
+  table: DrizzleTableDefinition,
+): void => {
+  for (const prop of columnsExpr.properties) {
+    if (prop.type !== 'KeyValueProperty') continue
+
+    const column = parseColumnFromProperty(prop)
+    if (!column) continue
+
+    // Use the JS property name as the key
+    const jsPropertyName =
+      prop.key.type === 'Identifier' ? getIdentifierName(prop.key) : null
+    if (jsPropertyName) {
+      table.columns[jsPropertyName] = column
+    }
+  }
+}
+
+/**
+ * Register a parsed index or composite primary key on the table
+ */
+const addIndexDefinition = (
+  table: DrizzleTableDefinition,
+  indexDef: DrizzleIndexDefinition | CompositePrimaryKeyDefinition | null,
+): void => {
+  if (isCompositePrimaryKey(indexDef)) {
+    table.compositePrimaryKey = indexDef
+  } else if (isDrizzleIndex(indexDef)) {
+    table.indexes[indexDef.name] = indexDef
+  }
+}
+
+/**
+ * Parse indexes and composite primary keys from the third argument callback.
+ * Supports both the array form (table) => [index(...)] and the legacy
+ * object form (table) => ({ nameIdx: index(...) })
+ */
+const parseTableExtras = (
+  expr: Expression,
+  table: DrizzleTableDefinition,
+): void => {
+  if (expr.type !== 'ArrowFunctionExpression') return
+
+  let returnExpr = expr.body
+
+  // Handle parenthesized expressions like (table) => ({ ... })
+  if (returnExpr.type === 'ParenthesisExpression') {
+    returnExpr = returnExpr.expression
+  }
+
+  if (returnExpr.type === 'ArrayExpression') {
+    parseArrayExtras(returnExpr, table)
+  } else if (returnExpr.type === 'ObjectExpression') {
+    parseObjectExtras(returnExpr, table)
+  }
+}
+
+/**
+ * Parse extras in array form: [index(...), primaryKey(...)]
+ */
+const parseArrayExtras = (
+  arrayExpr: ArrayExpression,
+  table: DrizzleTableDefinition,
+): void => {
+  for (const element of arrayExpr.elements) {
+    const elementExpr = getArgumentExpression(element)
+    if (elementExpr && elementExpr.type === 'CallExpression') {
+      addIndexDefinition(table, parseIndexDefinition(elementExpr, ''))
+    }
+  }
+}
+
+/**
+ * Parse extras in object form: { nameIdx: index(...), pk: primaryKey(...) }
+ */
+const parseObjectExtras = (
+  objectExpr: ObjectExpression,
+  table: DrizzleTableDefinition,
+): void => {
+  for (const prop of objectExpr.properties) {
+    if (prop.type !== 'KeyValueProperty') continue
+
+    const indexName =
+      prop.key.type === 'Identifier' ? getIdentifierName(prop.key) : null
+    if (indexName && prop.value.type === 'CallExpression') {
+      addIndexDefinition(table, parseIndexDefinition(prop.value, indexName))
+    }
+  }
+}
+
+/**
+ * Parse primaryKey({ columns: [...] }) definition
+ */
+const parseCompositePrimaryKey = (
+  callExpr: CallExpression,
+): CompositePrimaryKeyDefinition | null => {
+  if (callExpr.arguments.length === 0) return null
+
+  const configExpr = getArgumentExpression(callExpr.arguments[0])
+  if (!configExpr || !isObjectExpression(configExpr)) return null
+
+  const config = parseObjectExpression(configExpr)
+  if (!config['columns'] || !Array.isArray(config['columns'])) return null
+
+  return {
+    type: 'primaryKey',
+    columns: config['columns'].filter(
+      (col): col is string => typeof col === 'string',
+    ),
+  }
+}
+
+/**
+ * Parse the base index() or uniqueIndex() call to extract name and uniqueness
+ */
+const parseIndexBase = (
+  expr: Expression,
+  fallbackName: string,
+): { name: string; unique: boolean } => {
+  if (expr.type !== 'CallExpression' || expr.callee.type !== 'Identifier') {
+    return { name: fallbackName, unique: false }
+  }
+
+  const baseMethod = expr.callee.value
+  if (baseMethod !== 'index' && baseMethod !== 'uniqueIndex') {
+    return { name: fallbackName, unique: false }
+  }
+
+  let name = fallbackName
+  if (expr.arguments.length > 0) {
+    const nameExpr = getArgumentExpression(expr.arguments[0])
+    if (nameExpr && isStringLiteral(nameExpr)) {
+      name = nameExpr.value
+    }
+  }
+
+  return { name, unique: baseMethod === 'uniqueIndex' }
+}
+
+/**
+ * Collect column references from .on(...) calls in the method chain
+ */
+const collectOnColumns = (
+  methodCalls: Array<{ method: string; expr: CallExpression }>,
+): string[] => {
+  const columns: string[] = []
+
+  for (const { method, expr } of methodCalls) {
+    if (method !== 'on') continue
+
+    for (const arg of expr.arguments) {
+      const argExpr = getArgumentExpression(arg)
+      if (
+        argExpr &&
+        argExpr.type === 'MemberExpression' &&
+        argExpr.object.type === 'Identifier' &&
+        argExpr.property.type === 'Identifier'
+      ) {
+        columns.push(argExpr.property.value)
+      }
+    }
+  }
+
+  return columns
+}
+
+/**
+ * Parse index or primary key definition
+ */
+const parseIndexDefinition = (
+  callExpr: CallExpression,
+  name: string,
+): DrizzleIndexDefinition | CompositePrimaryKeyDefinition | null => {
+  // Handle primaryKey({ columns: [...] })
+  if (
+    callExpr.callee.type === 'Identifier' &&
+    callExpr.callee.value === 'primaryKey'
+  ) {
+    return parseCompositePrimaryKey(callExpr)
+  }
+
+  // Handle index('name').on(...) or uniqueIndex('name').on(...)
+  // Traverse the method chain to find index() and on() calls
+  const methodCalls: Array<{ method: string; expr: CallExpression }> = []
+  let currentExpr: Expression = callExpr
+
+  while (
+    currentExpr.type === 'CallExpression' &&
+    currentExpr.callee.type === 'MemberExpression' &&
+    currentExpr.callee.property.type === 'Identifier'
+  ) {
+    methodCalls.unshift({
+      method: currentExpr.callee.property.value,
+      expr: currentExpr,
+    })
+    currentExpr = currentExpr.callee.object
+  }
+
+  const { name: indexName, unique } = parseIndexBase(currentExpr, name)
+  const columns = collectOnColumns(methodCalls)
+
+  if (columns.length === 0) return null
+
+  return {
+    name: indexName,
+    columns,
+    unique,
+    type: '',
+  }
+}

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/tableParser.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/tableParser.ts
@@ -132,7 +132,11 @@ const addIndexDefinition = (
   if (isCompositePrimaryKey(indexDef)) {
     table.compositePrimaryKey = indexDef
   } else if (isDrizzleIndex(indexDef)) {
-    table.indexes[indexDef.name] = indexDef
+    // index() can omit the name in the array form; synthesize a deterministic
+    // one so unnamed indexes don't collide on the same empty key
+    const name =
+      indexDef.name || `${table.name}_${indexDef.columns.join('_')}_index`
+    table.indexes[name] = { ...indexDef, name }
   }
 }
 

--- a/frontend/packages/schema/src/parser/drizzle/sqlite/types.ts
+++ b/frontend/packages/schema/src/parser/drizzle/sqlite/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Type definitions for Drizzle ORM schema parsing
+ */
+
+export type DrizzleTableDefinition = {
+  name: string
+  columns: Record<string, DrizzleColumnDefinition>
+  indexes: Record<string, DrizzleIndexDefinition>
+  compositePrimaryKey?: CompositePrimaryKeyDefinition
+  comment?: string | undefined
+}
+
+export type DrizzleColumnDefinition = {
+  name: string
+  type: string
+  typeOptions?: Record<string, unknown>
+  notNull: boolean
+  primaryKey: boolean
+  unique: boolean
+  default?: unknown
+  comment?: string | undefined
+  references?:
+    | {
+        table: string
+        column: string
+        onDelete?: string | undefined
+        onUpdate?: string | undefined
+      }
+    | undefined
+}
+
+export type DrizzleIndexDefinition = {
+  name: string
+  columns: string[]
+  unique: boolean
+  type?: string
+}
+
+export type CompositePrimaryKeyDefinition = {
+  type: 'primaryKey'
+  columns: string[]
+}
+
+/**
+ * Type guard to check if a value is an object
+ */
+export const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Safe property checker without type casting
+ */
+export const hasProperty = <K extends string>(
+  obj: unknown,
+  key: K,
+): obj is Record<K, unknown> => {
+  return typeof obj === 'object' && obj !== null && key in obj
+}
+
+/**
+ * Safe property getter without type casting
+ */
+export const getPropertyValue = (obj: unknown, key: string): unknown => {
+  if (hasProperty(obj, key)) {
+    return obj[key]
+  }
+  return undefined
+}
+
+/**
+ * Type guard for CompositePrimaryKeyDefinition
+ */
+export const isCompositePrimaryKey = (
+  value: unknown,
+): value is CompositePrimaryKeyDefinition => {
+  return (
+    isObject(value) &&
+    getPropertyValue(value, 'type') === 'primaryKey' &&
+    hasProperty(value, 'columns') &&
+    Array.isArray(getPropertyValue(value, 'columns'))
+  )
+}
+
+/**
+ * Type guard for DrizzleIndexDefinition
+ */
+export const isDrizzleIndex = (
+  value: unknown,
+): value is DrizzleIndexDefinition => {
+  return (
+    isObject(value) &&
+    hasProperty(value, 'name') &&
+    hasProperty(value, 'columns') &&
+    hasProperty(value, 'unique')
+  )
+}


### PR DESCRIPTION
## Issue

- resolve: https://github.com/liam-hq/liam/issues/4068

## Why is this change needed?

The Drizzle parser currently supports PostgreSQL (`drizzle-orm/pg-core`) and MySQL (`drizzle-orm/mysql-core`), but not SQLite (`drizzle-orm/sqlite-core`). Running `liam erd build --input './src/schema/*.ts' --format drizzle` on a SQLite project falls through to the PostgreSQL parser and fails, so SQLite + Drizzle users (e.g. Cloudflare D1) currently need a tbls conversion workaround.

This PR adds a SQLite parser module following the existing `mysql/` and `postgres/` structure under `frontend/packages/schema/src/parser/drizzle/`.

### What's included

- Auto-detection for `drizzle-orm/sqlite-core` imports and `sqliteTable` calls (existing MySQL/PostgreSQL detection priority is unchanged; the fallback remains PostgreSQL)
- `sqliteTable()` parsing: columns, foreign keys (with `onDelete`/`onUpdate`), indexes, composite primary keys, and `$comment()` chaining
  - Supports both the array callback form `(table) => [index(...)]` (drizzle-orm 0.31+) and the legacy object form `(table) => ({ idx: index(...) })`
- SQLite type mapping: `integer` / `text` / `real` / `blob` / `numeric`; `text` with `{ length }` → `text(N)`; `.primaryKey({ autoIncrement: true })` → `autoincrement()` default
- SQLite has no native enum type, so `text('status', { enum: [...] })` is parsed as `text`
- Tests: SQLite added to the unified Drizzle test suite, auto-detection tests, and SQLite-specific tests
- Docs: `drizzle.mdx` and `sqlite.mdx` updated

### Out of scope (follow-ups)

As proposed in the issue: views, generated columns, and mode-specific type conversions (`{ mode: 'boolean' | 'timestamp' | 'json' }` columns are parsed as their underlying SQLite types).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQLite support to the Drizzle schema parser with automatic database type detection
  * SQLite schemas can now be parsed to generate ER diagrams with full support for columns, primary keys, foreign keys, indexes, and composite constraints

* **Documentation**
  * Updated Drizzle parser documentation to include SQLite support and workflows
  * Added clarification on SQLite enum handling in schema definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->