### PR TITLE
chore: bump route06/actions from v2.7.0 to v2.7.5

### DIFF
--- a/.github/workflows/add_assignee_to_pr.yml
+++ b/.github/workflows/add_assignee_to_pr.yml
@@ -8,4 +8,4 @@ jobs:
   add-assignee-to-pr:
     permissions:
       pull-requests: write
-    uses: route06/actions/.github/workflows/add_assignee_to_pr.yml@3bcea5bf834ff2e0e6c912c1167fcc1fe05e49c2 # v2.7.0
+    uses: route06/actions/.github/workflows/add_assignee_to_pr.yml@cf674a8d68a24bd75ac63171dc8e976e53024bbf # v2.7.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   codeql:
-    uses: route06/actions/.github/workflows/codeql.yml@3bcea5bf834ff2e0e6c912c1167fcc1fe05e49c2 # v2.7.0
+    uses: route06/actions/.github/workflows/codeql.yml@cf674a8d68a24bd75ac63171dc8e976e53024bbf # v2.7.5

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   dependency_review:
-    uses: route06/actions/.github/workflows/dependency_review.yml@3bcea5bf834ff2e0e6c912c1167fcc1fe05e49c2 # v2.7.0
+    uses: route06/actions/.github/workflows/dependency_review.yml@cf674a8d68a24bd75ac63171dc8e976e53024bbf # v2.7.5

--- a/.github/workflows/discussion-comment-to-slack.yml
+++ b/.github/workflows/discussion-comment-to-slack.yml
@@ -7,6 +7,6 @@ jobs:
     if: github.event.discussion && github.event.comment
     permissions:
       contents: read
-    uses: route06/actions/.github/workflows/gh_discussion_comment_to_slack.yml@3bcea5bf834ff2e0e6c912c1167fcc1fe05e49c2 # v2.7.0
+    uses: route06/actions/.github/workflows/gh_discussion_comment_to_slack.yml@cf674a8d68a24bd75ac63171dc8e976e53024bbf # v2.7.5
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_GHD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- Bump `route06/actions` reusable workflows from v2.7.0 (`3bcea5b`) to v2.7.5 (`cf674a8`)
- This picks up upstream changes that pin action references to full SHAs (e.g. `actions/checkout`, `actions/github-script`, `actions/dependency-review-action`)
- See upstream PR: https://github.com/route06/actions/pull/145

### Updated workflows
- `add_assignee_to_pr.yml`
- `codeql.yml`
- `dependency_review.yml`
- `discussion-comment-to-slack.yml`

## Test plan

- [ ] Verify CI workflows pass on this PR
- [ ] Confirm CodeQL, dependency review, and assignee workflows trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/liam-hq/liam/pull/4105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use newer versions of reusable action dependencies. This includes updates to the add assignee, CodeQL, dependency review, and discussion comment workflows to ensure the latest compatible versions are being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->